### PR TITLE
Avoid Node256 copy in child lookup

### DIFF
--- a/src/engine/walker/readers.rs
+++ b/src/engine/walker/readers.rs
@@ -9,6 +9,7 @@
 use crate::api::errors::{Error, Result};
 use crate::layout::{Leaf, Node16, Node256, Node4, Node48, NodeType, Prefix};
 use crate::store::BlobFrameRef;
+use std::mem::size_of;
 
 use super::cast;
 
@@ -106,4 +107,14 @@ pub(super) fn read_node256(frame: BlobFrameRef<'_>, slot: u16) -> Result<Node256
         .body_of_slot(slot)
         .ok_or(Error::node_corrupt("read_node256: body"))?;
     Ok(*cast::<Node256>(body))
+}
+
+pub(super) fn read_node256_child(frame: BlobFrameRef<'_>, slot: u16, byte: u8) -> Result<u32> {
+    let body = frame
+        .body_of_slot(slot)
+        .ok_or(Error::node_corrupt("read_node256_child: body"))?;
+    if body.len() != size_of::<Node256>() {
+        return Err(Error::node_corrupt("read_node256_child: non-Node256 slot"));
+    }
+    Ok(cast::<Node256>(body).children[byte as usize])
 }

--- a/src/engine/walker/writers.rs
+++ b/src/engine/walker/writers.rs
@@ -13,7 +13,9 @@ use crate::layout::{
 };
 use crate::store::BlobFrame;
 
-use super::readers::{read_node16, read_node256, read_node4, read_node48, read_prefix};
+use super::readers::{
+    read_node16, read_node256, read_node256_child, read_node4, read_node48, read_prefix,
+};
 use super::SearchKey;
 
 pub(super) fn write_struct_to_slot<T>(frame: &mut BlobFrame<'_>, slot: u16, v: &T) -> Result<()> {
@@ -160,8 +162,7 @@ pub(super) fn inner_find_child(
             }
         }
         NodeType::Node256 => {
-            let n = read_node256(frame.as_ref(), slot)?;
-            let s = n.children[byte as usize];
+            let s = read_node256_child(frame.as_ref(), slot, byte)?;
             if s == 0 {
                 Ok(None)
             } else {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Optimizes child lookup operations within `Node256` nodes by introducing a new function, `read_node256_child`. This change prevents the unnecessary copying of the entire `Node256` struct into memory when only a specific child pointer is required, directly retrieving the child's slot ID. This reduces memory overhead and improves performance during tree traversals.
<!-- kody-pr-summary:end -->