### PR TITLE
fix(blob-store): hold an exclusive directory lock across open instances

### DIFF
--- a/src/store/blob_store/file/mod.rs
+++ b/src/store/blob_store/file/mod.rs
@@ -18,6 +18,10 @@
 //!                      is compacted
 //!     manifest.log   — append-only set/delete deltas replayed on
 //!                      open; free slots are rebuilt from holes
+//!     store.lock     — zero-byte advisory lock file; held
+//!                      exclusively (flock) for the lifetime of an
+//!                      open instance so a second opener cannot
+//!                      corrupt the manifest
 //! ```
 //!
 //! Design rationale:
@@ -68,11 +72,12 @@ use std::io::{self, Read, Write};
 #[cfg(not(all(target_os = "linux", feature = "io-uring")))]
 use std::os::unix::fs::FileExt;
 use std::os::unix::fs::OpenOptionsExt;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::api::errors::{Error, Result};
 use crate::layout::{BlobGuid, PAGE_SIZE};
@@ -86,6 +91,16 @@ use self::uring::UringContext;
 
 /// Filename of the packed blob data file inside `data_dir`.
 const DATA_FILENAME: &str = "blobs.dat";
+/// Advisory lock file inside `data_dir`, flock'd exclusively for
+/// the lifetime of an open instance.
+const LOCK_FILENAME: &str = "store.lock";
+/// How long `open` waits for a previous instance to release the
+/// directory lock before failing. Covers the handover pattern where
+/// a caller opens a new instance while the previous one is still
+/// flushing its final checkpoint round on drop.
+const DIR_LOCK_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Poll interval while waiting for the directory lock.
+const DIR_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 /// Filename of the manifest inside `data_dir`.
 const MANIFEST_FILENAME: &str = "manifest.bin";
 /// Append-only manifest delta log inside `data_dir`.
@@ -149,6 +164,14 @@ const MANIFEST_LOG_COMPACT_RATIO: u64 = 4;
 #[derive(Debug)]
 pub struct FileBlobStore {
     data_dir: PathBuf,
+    /// Exclusive advisory lock on `data_dir`, held for the lifetime
+    /// of this instance. Two live instances on one directory would
+    /// each replay `manifest.log` into the same `next_slot`, assign
+    /// the same slot to different blob GUIDs, and append conflicting
+    /// set deltas — permanently corrupting the manifest. The kernel
+    /// releases the lock when this handle closes, so a crashed
+    /// holder never leaves a stale lock behind.
+    _dir_lock: File,
     data_file: File,
     manifest: RwLock<Manifest>,
     /// Tracks whether `manifest.bin` needs a rewrite. Data-only
@@ -239,6 +262,49 @@ struct FreeSlotRange {
     end: u64,
 }
 
+/// Acquire the exclusive advisory lock on `data_dir`, waiting up to
+/// `timeout` for a previous instance to release it.
+///
+/// `flock(2)` locks are per open-file-description, so this also
+/// rejects a second instance inside the same process — the scenario
+/// `fcntl` record locks would silently allow. The polling wait lets
+/// an open racing a previous instance's drop (the common handover
+/// pattern `store = reopen(path)`) serialize instead of failing.
+fn acquire_dir_lock(data_dir: &Path, timeout: Duration) -> Result<File> {
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .custom_flags(libc::O_CLOEXEC)
+        .open(data_dir.join(LOCK_FILENAME))?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        let rc = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc == 0 {
+            return Ok(lock_file);
+        }
+        let err = io::Error::last_os_error();
+        match err.kind() {
+            io::ErrorKind::Interrupted => {}
+            io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(Error::BlobStoreIo(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        format!(
+                            "blob store at {} is locked by another live instance \
+                             (waited {timeout:?}); a second opener would corrupt \
+                             the manifest",
+                            data_dir.display()
+                        ),
+                    )));
+                }
+                thread::sleep(DIR_LOCK_RETRY_INTERVAL);
+            }
+            _ => return Err(Error::BlobStoreIo(err)),
+        }
+    }
+}
+
 impl FileBlobStore {
     /// Open or create a persistent store at `data_dir`.
     ///
@@ -270,6 +336,10 @@ impl FileBlobStore {
     ) -> Result<Self> {
         let data_dir = data_dir.into();
         std::fs::create_dir_all(&data_dir)?;
+        // Take the lock before touching any store file: manifest
+        // replay (including torn-tail truncation) must not run
+        // while another instance can still append deltas.
+        let dir_lock = acquire_dir_lock(&data_dir, DIR_LOCK_ACQUIRE_TIMEOUT)?;
 
         let data_path = data_dir.join(DATA_FILENAME);
         let manifest_path = data_dir.join(MANIFEST_FILENAME);
@@ -318,6 +388,7 @@ impl FileBlobStore {
 
         Ok(Self {
             data_dir,
+            _dir_lock: dir_lock,
             data_file,
             manifest: RwLock::new(manifest),
             manifest_dirty: AtomicBool::new(false),
@@ -339,6 +410,10 @@ impl FileBlobStore {
     ) -> Result<Self> {
         let data_dir = data_dir.into();
         std::fs::create_dir_all(&data_dir)?;
+        // Take the lock before touching any store file: manifest
+        // replay (including torn-tail truncation) must not run
+        // while another instance can still append deltas.
+        let dir_lock = acquire_dir_lock(&data_dir, DIR_LOCK_ACQUIRE_TIMEOUT)?;
 
         let data_path = data_dir.join(DATA_FILENAME);
         let manifest_path = data_dir.join(MANIFEST_FILENAME);
@@ -372,6 +447,7 @@ impl FileBlobStore {
 
         Ok(Self {
             data_dir,
+            _dir_lock: dir_lock,
             data_file,
             manifest: RwLock::new(manifest),
             manifest_dirty: AtomicBool::new(false),
@@ -1444,6 +1520,35 @@ mod tests {
         let mut dst = AlignedBlobBuf::zeroed();
         b.read_blob(g, &mut dst).unwrap();
         assert_eq!(dst.as_slice()[100], 42);
+    }
+
+    #[test]
+    fn open_holds_exclusive_dir_lock_until_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let Some(b) = try_open(dir.path()) else {
+            return;
+        };
+
+        // While `b` is live, a second open must be rejected — on
+        // 0.5.x a second instance replays the same manifest into
+        // the same next_slot and corrupts it with duplicate-slot
+        // set deltas.
+        let second = acquire_dir_lock(dir.path(), Duration::from_millis(50));
+        match second {
+            Err(Error::BlobStoreIo(e)) => {
+                assert_eq!(e.kind(), io::ErrorKind::WouldBlock, "unexpected error: {e}");
+            }
+            Err(e) => panic!("unexpected error variant: {e}"),
+            Ok(_) => panic!("second open acquired the lock while the store is live"),
+        }
+
+        // The handover pattern: once the previous instance is fully
+        // dropped, the kernel releases the flock and a fresh open
+        // succeeds immediately.
+        drop(b);
+        let Some(_b2) = try_open(dir.path()) else {
+            return;
+        };
     }
 
     #[test]

--- a/tests/exclusive_open.rs
+++ b/tests/exclusive_open.rs
@@ -1,0 +1,100 @@
+//! End-to-end tests for exclusive store-directory locking.
+//!
+//! Two live instances on one data directory corrupt the
+//! [`FileBlobStore`] manifest: each replays `manifest.log` into the
+//! same `next_slot`, assigns the same slot to different blob GUIDs,
+//! and appends conflicting set deltas — after which every later
+//! open fails with `FileBlobStore::Manifest::duplicate slot` and
+//! the store is permanently unreadable. Since 0.5.0 even read-only
+//! snapshots write frozen root frames through the blob store, so
+//! the overlap window of a handover (`store = reopen(path)`) is
+//! enough to trip it.
+//!
+//! These tests pin the fix: a second opener waits for the previous
+//! instance to drop (handover) or fails cleanly, and the store
+//! replays cleanly afterwards.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use holt::{Error, TreeConfig, DB};
+use tempfile::tempdir;
+
+#[test]
+fn open_waits_for_live_instance_to_drop() {
+    let dir = tempdir().unwrap();
+    {
+        let db = DB::open(TreeConfig::new(dir.path())).unwrap();
+        let tree = db.create_tree("t").unwrap();
+        tree.put(b"k", b"v").unwrap();
+    }
+
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let path = dir.path().to_path_buf();
+    let holder = thread::spawn(move || {
+        let db = DB::open(TreeConfig::new(path.clone())).unwrap();
+        let tree = db.open_tree("t").unwrap();
+        // A snapshot read is the exact operation that, before the
+        // lock, persisted a frozen root frame from each of two
+        // overlapping instances into the same manifest slot.
+        let snap = tree.snapshot(b"").unwrap();
+        assert_eq!(snap.get(b"k").unwrap().as_deref(), Some(&b"v"[..]));
+        ready_tx.send(()).unwrap();
+        thread::sleep(Duration::from_secs(1));
+    });
+
+    ready_rx.recv().unwrap();
+    // The previous instance is still live: this open must serialize
+    // behind its drop instead of going live concurrently.
+    let started = Instant::now();
+    let db = DB::open(TreeConfig::new(dir.path())).unwrap();
+    assert!(
+        started.elapsed() >= Duration::from_millis(300),
+        "second open went live while the first instance held the store"
+    );
+    holder.join().unwrap();
+
+    let tree = db.open_tree("t").unwrap();
+    assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(&b"v"[..]));
+    drop(tree);
+    drop(db);
+
+    // The 0.5.x bug poisoned the manifest so every later open
+    // failed; the store must keep replaying cleanly.
+    let db = DB::open(TreeConfig::new(dir.path())).unwrap();
+    let tree = db.open_tree("t").unwrap();
+    assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(&b"v"[..]));
+}
+
+#[test]
+fn concurrent_open_of_live_store_fails_cleanly() {
+    let dir = tempdir().unwrap();
+    let db = DB::open(TreeConfig::new(dir.path())).unwrap();
+    let tree = db.create_tree("t").unwrap();
+    tree.put(b"k", b"v").unwrap();
+
+    // Waits out the full lock-acquire timeout, then must fail
+    // instead of going live on a store another instance holds.
+    let err = match DB::open(TreeConfig::new(dir.path())) {
+        Err(e) => e,
+        Ok(_) => panic!("second open went live on a store another instance holds"),
+    };
+    match err {
+        Error::BlobStoreIo(e) => assert_eq!(
+            e.kind(),
+            std::io::ErrorKind::WouldBlock,
+            "unexpected I/O error: {e}"
+        ),
+        other => panic!("unexpected error variant: {other}"),
+    }
+
+    // The held instance keeps working, and the rejected opener
+    // left no trace behind.
+    assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(&b"v"[..]));
+    drop(tree);
+    drop(db);
+    let db = DB::open(TreeConfig::new(dir.path())).unwrap();
+    let tree = db.open_tree("t").unwrap();
+    assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(&b"v"[..]));
+}

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -485,35 +485,74 @@ fn snapshot_correct_after_reopen() {
     }
 }
 
+/// Environment variable carrying the store directory into the
+/// crash-session child processes below.
+const CRASH_LEAK_DIR_ENV: &str = "HOLT_CRASH_LEAK_DIR";
+/// Keys written by each crash session.
+const CRASH_LEAK_N: u32 = 5000;
+
+fn crash_leak_value() -> Vec<u8> {
+    vec![0xAB_u8; 200]
+}
+
+fn crash_leak_cfg(dir: &std::path::Path) -> TreeConfig {
+    let mut c = TreeConfig::new(dir);
+    c.checkpoint.enabled = false;
+    c.durability = Durability::Wal { sync: true };
+    c
+}
+
+/// Run the named `#[ignore]` child test in a separate process.
+///
+/// The crash-leak tests simulate a crash with `mem::forget(snap)`.
+/// Inside a single process that keeps the leaked instance — and its
+/// exclusive store-directory lock — alive forever; a real crash ends
+/// the process and the kernel drops the flock with it. A child
+/// process reproduces the real semantics: leaked on-disk frames,
+/// released lock.
+fn run_crash_session(child_test: &str, dir: &std::path::Path) {
+    let exe = std::env::current_exe().unwrap();
+    let status = std::process::Command::new(exe)
+        .args([child_test, "--exact", "--ignored", "--nocapture"])
+        .env(CRASH_LEAK_DIR_ENV, dir)
+        .status()
+        .unwrap();
+    assert!(status.success(), "crash-session child {child_test} failed");
+}
+
+/// Child body for [`gc_reclaims_crash_leaked_snapshot_frames`]:
+/// snapshot + fork, checkpoint so the forks/orphans/snapshot root
+/// persist, then "crash" — forget the snapshot so it never retires
+/// and its in-memory orphan list dies with the process.
+#[test]
+#[ignore = "child-process body for gc_reclaims_crash_leaked_snapshot_frames"]
+fn crash_leak_tree_session() {
+    let Some(dir) = std::env::var_os(CRASH_LEAK_DIR_ENV) else {
+        return;
+    };
+    let dir = std::path::PathBuf::from(dir);
+    let v = crash_leak_value();
+    let tree = Tree::open(crash_leak_cfg(&dir)).unwrap();
+    for i in 0..CRASH_LEAK_N {
+        tree.put(format!("k{i:06}").as_bytes(), &v).unwrap();
+    }
+    tree.checkpoint().unwrap();
+    let snap = tree.snapshot(b"").unwrap();
+    for i in 0..CRASH_LEAK_N {
+        tree.put(format!("k{i:06}").as_bytes(), b"new").unwrap();
+    }
+    tree.checkpoint().unwrap();
+    std::mem::forget(snap);
+}
+
 #[test]
 fn gc_reclaims_crash_leaked_snapshot_frames() {
     let dir = tempdir().unwrap();
-    let cfg = || {
-        let mut c = TreeConfig::new(dir.path());
-        c.checkpoint.enabled = false;
-        c.durability = Durability::Wal { sync: true };
-        c
-    };
+    let cfg = || crash_leak_cfg(dir.path());
 
-    const N: u32 = 5000;
-    let v = vec![0xAB_u8; 200];
+    const N: u32 = CRASH_LEAK_N;
 
-    // Session 1: snapshot + fork, checkpoint so the forks/orphans/snapshot
-    // root persist, then "crash" — forget the snapshot so it never retires
-    // and its in-memory orphan list dies with the process.
-    {
-        let tree = Tree::open(cfg()).unwrap();
-        for i in 0..N {
-            tree.put(format!("k{i:06}").as_bytes(), &v).unwrap();
-        }
-        tree.checkpoint().unwrap();
-        let snap = tree.snapshot(b"").unwrap();
-        for i in 0..N {
-            tree.put(format!("k{i:06}").as_bytes(), b"new").unwrap();
-        }
-        tree.checkpoint().unwrap();
-        std::mem::forget(snap);
-    }
+    run_crash_session("crash_leak_tree_session", dir.path());
 
     // Reopen: the store still carries the leaked orphan frames + the
     // forgotten snapshot's root, unreachable from the live tree.
@@ -543,36 +582,41 @@ fn gc_reclaims_crash_leaked_snapshot_frames() {
     }
 }
 
+/// Child body for [`db_gc_reclaims_leak_and_preserves_all_trees`]:
+/// two trees; snapshot + fork + crash on t1.
+#[test]
+#[ignore = "child-process body for db_gc_reclaims_leak_and_preserves_all_trees"]
+fn crash_leak_db_session() {
+    let Some(dir) = std::env::var_os(CRASH_LEAK_DIR_ENV) else {
+        return;
+    };
+    let dir = std::path::PathBuf::from(dir);
+    let v = crash_leak_value();
+    let db = DB::open(crash_leak_cfg(&dir)).unwrap();
+    let t1 = db.create_tree("t1").unwrap();
+    let t2 = db.create_tree("t2").unwrap();
+    for i in 0..CRASH_LEAK_N {
+        t1.put(format!("k{i:06}").as_bytes(), &v).unwrap();
+        t2.put(format!("k{i:06}").as_bytes(), &v).unwrap();
+    }
+    db.checkpoint().unwrap();
+    let snap = t1.snapshot(b"").unwrap();
+    for i in 0..CRASH_LEAK_N {
+        t1.put(format!("k{i:06}").as_bytes(), b"new").unwrap();
+    }
+    db.checkpoint().unwrap();
+    std::mem::forget(snap); // crash: t1's forked-away frames leak
+}
+
 #[test]
 fn db_gc_reclaims_leak_and_preserves_all_trees() {
     let dir = tempdir().unwrap();
-    let cfg = || {
-        let mut c = TreeConfig::new(dir.path());
-        c.checkpoint.enabled = false;
-        c.durability = Durability::Wal { sync: true };
-        c
-    };
+    let cfg = || crash_leak_cfg(dir.path());
 
-    const N: u32 = 5000;
-    let v = vec![0xAB_u8; 200];
+    const N: u32 = CRASH_LEAK_N;
+    let v = crash_leak_value();
 
-    // Session 1: two trees; snapshot + fork + crash on t1.
-    {
-        let db = DB::open(cfg()).unwrap();
-        let t1 = db.create_tree("t1").unwrap();
-        let t2 = db.create_tree("t2").unwrap();
-        for i in 0..N {
-            t1.put(format!("k{i:06}").as_bytes(), &v).unwrap();
-            t2.put(format!("k{i:06}").as_bytes(), &v).unwrap();
-        }
-        db.checkpoint().unwrap();
-        let snap = t1.snapshot(b"").unwrap();
-        for i in 0..N {
-            t1.put(format!("k{i:06}").as_bytes(), b"new").unwrap();
-        }
-        db.checkpoint().unwrap();
-        std::mem::forget(snap); // crash: t1's forked-away frames leak
-    }
+    run_crash_session("crash_leak_db_session", dir.path());
 
     let db = DB::open(cfg()).unwrap();
     let freed = db.gc().unwrap();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces an exclusive advisory directory lock for the `FileBlobStore` to prevent manifest corruption caused by multiple concurrent instances operating on the same data directory.

Key changes include:
-   **Exclusive Directory Lock:** A `store.lock` file is now used with `flock(2)` to ensure only one `FileBlobStore` instance can be open at a time for a given directory. This prevents scenarios where concurrent instances could replay manifest logs into the same slots, leading to data corruption.
-   **Safe Concurrent Access:**
    -   When attempting to open a store that is currently in use, the new `open` operation will wait for a configurable timeout (5 seconds) for the existing instance to release its lock. This gracefully handles "handover" patterns where an application might open a new instance while the previous one is still shutting down.
    -   If the lock cannot be acquired within the timeout, the `open` operation will fail cleanly with an `io::ErrorKind::WouldBlock` error, preventing potential data corruption.
-   **Robustness:** The lock is held for the entire lifetime of the `FileBlobStore` instance and is automatically released by the operating system kernel upon process termination, even in the event of a crash, ensuring no stale locks are left behind.
-   **Enhanced Testing:** New end-to-end tests have been added to specifically validate the exclusive locking behavior, covering both successful handovers and clean failure modes. Existing crash-leak tests were refactored to run in child processes, ensuring they accurately simulate real-world crash scenarios where the directory lock is released by the kernel.
<!-- kody-pr-summary:end -->