### PR TITLE
Release 0.7.1: fix WAL-truncate durability hole (acked write lost on crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ versioning follows [Semantic Versioning](https://semver.org/).
 For design background see [ARCHITECTURE.md](ARCHITECTURE.md);
 fine-grained per-commit history is in `git log`.
 
+## [0.7.1] — 2026-06-12
+
+### Fixed
+
+- **Durability: an acknowledged write could be lost after a crash.** The
+  checkpoint's WAL-truncate gate (`maybe_truncate`) only checked the
+  BufferManager dirty/flushing/pending counters, not the store's own deferred
+  durability (`needs_flush`). The I/O worker retires a written-through blob
+  right after the `pwrite` but before the data fsync + manifest-delta persist,
+  so the WAL could be truncated while a just-written blob's new slot mapping
+  was still only in the in-memory manifest — leaving a crashed reopen with the
+  acknowledged record in neither the WAL nor `manifest.log`. The gate now also
+  waits on `needs_flush()`, mirroring the existing `run_round` early-skip
+  guard. Surfaced by the nightly crash-soak; 0.7.0's lazy routing compaction
+  amplified the exposure by re-writing the root blob every round.
+- **Durability: a torn WAL tail is now truncated on reopen.** Previously the
+  writer reopened with `O_APPEND` over the torn bytes, turning a partial tail
+  record into a mid-log torn record that a later replay would stop at,
+  silently stranding every acknowledged record written after it. `replay_wal`
+  now truncates the WAL to the last complete record on open — standard WAL
+  recovery; the torn record was never acknowledged (the crash preceded its
+  fdatasync), so nothing durable is lost.
+
 ## [0.7.0] — 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holt"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.82"
 autobenches = false

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -479,7 +479,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/src/api/tree.rs
+++ b/src/api/tree.rs
@@ -2633,6 +2633,19 @@ where
         stats.torn_tail_at.is_none() || stats.records_seen > 0 || stats.highest_seq.is_none(),
         "a torn tail without complete records must not report a highest seq",
     );
+    // Physically drop a torn tail record before the writer reopens with
+    // O_APPEND. Otherwise the next session appends a good record *after*
+    // the torn bytes, turning them into a MID-log torn record; a later
+    // replay's torn-tail `break` stops there and silently discards every
+    // acked record written after it. The torn record was never acked (the
+    // crash hit mid-write, before its fdatasync), so truncating it to the
+    // last complete record loses nothing durable — standard WAL recovery.
+    if let Some(off) = stats.torn_tail_at {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)?
+            .set_len(off)?;
+    }
     // After commit, the blob image is durable; we still want the
     // next allocated seq to be strictly greater than anything
     // ever seen in the log.

--- a/src/checkpoint/mod.rs
+++ b/src/checkpoint/mod.rs
@@ -526,6 +526,121 @@ mod tests {
         }
     }
 
+    /// A store whose `needs_flush()` is gated by an explicit flag, so a test
+    /// can hold "store durability still pending" true while the BufferManager
+    /// dirty/flushing/pending counters all read 0 — the exact window in which
+    /// the I/O worker has retired a written-through blob (after `pwrite`) but
+    /// not yet run the data fsync + manifest persist.
+    struct FlushGateStore {
+        inner: MemoryBlobStore,
+        flush_pending: AtomicBool,
+    }
+
+    impl FlushGateStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryBlobStore::new(),
+                flush_pending: AtomicBool::new(true),
+            }
+        }
+
+        fn release_flush(&self) {
+            self.flush_pending.store(false, AtomicOrdering::Release);
+        }
+    }
+
+    impl BlobStore for FlushGateStore {
+        fn read_blob(&self, guid: BlobGuid, dst: &mut AlignedBlobBuf) -> Result<()> {
+            self.inner.read_blob(guid, dst)
+        }
+        fn write_blob(&self, guid: BlobGuid, src: &AlignedBlobBuf) -> Result<()> {
+            self.inner.write_blob(guid, src)
+        }
+        fn write_blobs_with_data_sync(&self, writes: &[(BlobGuid, &AlignedBlobBuf)]) -> Result<()> {
+            self.inner.write_blobs_with_data_sync(writes)
+        }
+        fn delete_blob(&self, guid: BlobGuid) -> Result<()> {
+            self.inner.delete_blob(guid)
+        }
+        fn list_blobs(&self) -> Result<Vec<BlobGuid>> {
+            self.inner.list_blobs()
+        }
+        fn flush(&self) -> Result<()> {
+            // Deliberately does NOT clear `flush_pending`; the test controls
+            // when the store reports durable so the truncate gate is exercised.
+            self.inner.flush()
+        }
+        fn needs_flush(&self) -> bool {
+            self.flush_pending.load(AtomicOrdering::Acquire)
+        }
+    }
+
+    /// Regression for the nightly crash-soak durability bug: `maybe_truncate`
+    /// must NOT truncate the WAL while the store still owes a flush (data
+    /// fsync / manifest-delta persist), even though dirty/flushing/pending all
+    /// read 0. Truncating there drops the only recoverable copy of an
+    /// acknowledged write across a crash. (On the pre-fix gate this test
+    /// truncates immediately once the dirty blob is written through.)
+    #[test]
+    fn truncate_waits_for_store_flush() {
+        let store = Arc::new(FlushGateStore::new()); // needs_flush() == true
+        let bm = Arc::new(BufferManager::new(store.clone(), 8));
+
+        let dir = tempfile::tempdir().unwrap();
+        let journal = Arc::new(Journal::open_or_create(&dir.path().join("wal.log"), 0).unwrap());
+        journal.submit(vec![1, 2, 3, 4], false).unwrap(); // -> needs_checkpoint()
+        assert!(journal.needs_checkpoint());
+
+        bm.write_blob([0x55; 16], &test_blob([0x55; 16])).unwrap();
+        let _pin = bm.pin([0x55; 16]).unwrap();
+        bm.mark_dirty([0x55; 16], 1);
+
+        let ck = Checkpointer::spawn(
+            Arc::clone(&bm),
+            Some(Arc::clone(&journal)),
+            maintenance_gate(),
+            commit_gate(),
+            no_merge_cfg(),
+        )
+        .expect("spawn");
+
+        // Wait until the dirty blob is written through (dirty retired).
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if bm.dirty_count() == 0 && ck.blobs_flushed() >= 1 {
+                break;
+            }
+            assert!(Instant::now() < deadline, "checkpoint never drained dirty");
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        // dirty/flushing/pending are all 0 now, but the store still needs a
+        // flush — the WAL must stay intact across several truncate attempts.
+        thread::sleep(Duration::from_millis(60));
+        assert_eq!(
+            ck.truncates(),
+            0,
+            "WAL truncated while store flush was still pending"
+        );
+
+        // Once the store reports durable, truncate is allowed to proceed
+        // (no deadlock / unbounded WAL growth).
+        store.release_flush();
+        ck.wake();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if ck.truncates() >= 1 {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "WAL never truncated after the store flush completed"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        drop(ck);
+    }
+
     /// Tests that don't construct a real Tree skip the merge pass —
     /// `collect_blob_guids` would otherwise try to pin a
     /// non-existent root.

--- a/src/checkpoint/round.rs
+++ b/src/checkpoint/round.rs
@@ -153,9 +153,23 @@ impl Pipeline {
             return Ok(());
         }
         let _commit = shared.commit_gate.enter_checkpoint();
+        // The dirty/flushing/pending counters are BufferManager state and do
+        // NOT capture the store's own deferred durability: the I/O worker
+        // retires a dirty entry right after the data `pwrite` but BEFORE the
+        // data fsync + manifest-delta persist (`flush_inner`). So all three
+        // counters can read 0 while `store.needs_flush()` is still true —
+        // i.e. a just-written blob's new slot mapping is only in the in-memory
+        // manifest, not yet in `manifest.log`. Truncating the WAL there leaves
+        // a crashed reopen with the acked write in NEITHER the (truncated) WAL
+        // nor the (un-persisted) manifest — a lost acknowledged write. The
+        // SIGKILL crash soak hits exactly this (lazy routing keeps the root
+        // blob a perpetual compaction target, so it is re-written every round).
+        // `run_round`'s early-skip gates on the same `needs_flush()` for this
+        // recovery edge; mirror it here so truncate waits for store durability.
         if shared.bm.dirty_count() == 0
             && shared.bm.flushing_count() == 0
             && shared.bm.pending_delete_count() == 0
+            && !shared.bm.needs_flush()
         {
             journal.truncate()?;
             use std::sync::atomic::Ordering;

--- a/tests/wal_torn_tail_recovery.rs
+++ b/tests/wal_torn_tail_recovery.rs
@@ -1,0 +1,59 @@
+//! Regression: a torn WAL tail (crash mid-write) must be physically
+//! truncated on reopen. Otherwise the next session's `O_APPEND` writes a good
+//! record *after* the torn bytes, turning them into a MID-log torn record; a
+//! later replay's torn-tail `break` stops there and silently strands every
+//! acked record written after it.
+
+use holt::{Durability, Tree, TreeConfig};
+
+fn cfg(dir: &std::path::Path) -> TreeConfig {
+    let mut c = TreeConfig::new(dir);
+    c.durability = Durability::Wal { sync: true };
+    // Disable the checkpointer so the WAL is never truncated out from under
+    // us — we want the torn tail to survive into the next session.
+    c.checkpoint.enabled = false;
+    c
+}
+
+#[test]
+fn torn_tail_reopen_does_not_strand_later_appends() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Session 1: two complete, durable records.
+    {
+        let t = Tree::open(cfg(dir.path())).unwrap();
+        t.put(b"a", b"1").unwrap();
+        t.put(b"b", b"2").unwrap();
+    }
+
+    // Simulate a crash mid-write: lop the CRC off the last record so it
+    // decodes as a torn tail ("record body truncated"), leaving "a" intact.
+    let wal = cfg(dir.path()).wal_path().expect("file-backed WAL");
+    let len = std::fs::metadata(&wal).unwrap().len();
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&wal)
+        .unwrap()
+        .set_len(len - 4)
+        .unwrap();
+
+    // Session 2: reopen (the fix truncates the torn tail), then append.
+    {
+        let t = Tree::open(cfg(dir.path())).unwrap();
+        assert_eq!(t.get(b"a").unwrap().as_deref(), Some(&b"1"[..]));
+        t.put(b"c", b"3").unwrap();
+    }
+
+    // Session 3: reopen again. With the torn tail dropped in session 2, "c"
+    // sits cleanly after "a"; without it, "c" was appended behind a mid-log
+    // torn record and is lost (or the log fails to replay).
+    {
+        let t = Tree::open(cfg(dir.path())).unwrap();
+        assert_eq!(t.get(b"a").unwrap().as_deref(), Some(&b"1"[..]));
+        assert_eq!(
+            t.get(b"c").unwrap().as_deref(),
+            Some(&b"3"[..]),
+            "append after a torn-tail reopen was stranded behind a mid-log torn record",
+        );
+    }
+}

--- a/tools/soak/Cargo.lock
+++ b/tools/soak/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "holt"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",


### PR DESCRIPTION
## What

Fixes a durability bug surfaced by the nightly crash-soak: an **acknowledged write could be lost after a crash**. Releases **0.7.1**.

## Root cause

The checkpoint's WAL-truncate gate (`maybe_truncate`, `src/checkpoint/round.rs`) only checked the BufferManager `dirty/flushing/pending` counters — **not** the store's own deferred durability (`needs_flush`). The I/O worker retires a written-through blob right after the `pwrite` but **before** the data fsync + manifest-delta persist (`flush_inner`). So all three counters can read 0 while a just-written blob's new slot mapping is still only in the in-memory manifest, not yet in `manifest.log`. Truncating the WAL there leaves a crashed reopen with the acknowledged record in **neither** the (truncated) WAL **nor** the (un-persisted) manifest.

`run_round`'s early-skip path already guards on `needs_flush()` for exactly this recovery edge (with a comment explaining it); `maybe_truncate` — reached every round via `reap_ready`/`drain` — did not. 0.7.0's lazy routing compaction **amplified** the exposure by rewriting the root blob every round (which is why it surfaced now; the WAL/checkpoint code is byte-identical to 0.6.0).

## Fixes

1. **`maybe_truncate`** now also gates on `!shared.bm.needs_flush()`, mirroring `run_round`. Strictly more conservative (truncates later, never earlier); `run_round`'s flush-only-epoch logic prevents unbounded WAL growth.
2. **Torn WAL tail truncated on reopen** (`replay_wal`, `src/api/tree.rs`): otherwise the writer's `O_APPEND` lands a good record *after* the torn bytes → a mid-log torn record that a later replay stops at, stranding acked records written after it. The torn record was never acked (crash preceded its fdatasync), so nothing durable is lost.

## Validation

- The bug is extremely rare (0 repros in ~28,700 soak rounds across 24 parallel instances + CPU oversubscription), so it's validated by **deterministic regression tests**, not a flaky soak A/B:
  - `checkpoint::tests::truncate_waits_for_store_flush` — **confirmed to FAIL on the pre-fix gate**.
  - `tests/wal_torn_tail_recovery.rs` — torn-tail-then-append survives a second reopen.
- 310 lib tests + integration green, clippy clean, and the fixed build passed a real-NVMe crash + normal soak smoke (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a durability issue where WAL truncation could occur before store writes were fully persisted, potentially losing acknowledged writes after a crash
  * Fixed WAL replay to properly truncate torn tail records, preventing silent mid-log corruption during subsequent replays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->