### PR TITLE
Fix nightly soak recovery and cold-read regressions

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -45,6 +45,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +82,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -264,6 +276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +308,26 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
 ]
 
 [[package]]
@@ -346,6 +387,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs2"
@@ -478,6 +528,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "heed"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4f449bab7320c56003d37732a917e18798e2f1709d80263face2b4f9436ddb"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3f528b053a6d700b2734eabcd0fd49cb8230647aa72958467527b0b7917114"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "holt"
 version = "0.7.0"
 dependencies = [
@@ -494,8 +582,9 @@ name = "holt-bench"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "heed",
  "holt",
- "rand",
+ "rand 0.9.4",
  "rocksdb",
  "rusqlite",
  "sled",
@@ -503,10 +592,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -631,6 +823,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lmdb-master-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +946,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +1031,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -827,12 +1093,21 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -842,8 +1117,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1052,6 +1333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1393,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1136,6 +1449,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1479,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -1421,6 +1762,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1804,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -15,10 +15,11 @@ tempfile = "3"
 rocksdb = { version = "0.24", default-features = false, optional = true }
 rusqlite = { version = "0.39", features = ["bundled"], optional = true }
 sled = { version = "0.34", optional = true }
+heed = { version = "0.20", optional = true }
 
 [features]
 default = ["comparators"]
-comparators = ["dep:rocksdb", "dep:rusqlite", "dep:sled"]
+comparators = ["dep:rocksdb", "dep:rusqlite", "dep:sled", "dep:heed"]
 io-uring = ["holt/io-uring"]
 
 [[bench]]

--- a/benches/eval_cold.sh
+++ b/benches/eval_cold.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Phase B — COLD regime + corrected sync-durable writes.
+#   E1-cold : positive cold point read (read-amp + space), all 4 engines
+#   E3      : negative (absent) cold point read — per-blob bloom, all 4
+#   E2      : cold QD sweep (free device queue depth), holt only
+#   E5-sync : sync-durable overwrite/mixed, all 4 (run last; lmdb msync is slow)
+#
+# holt + rocksdb-direct read O_DIRECT (device, page-cache-independent); lmdb +
+# sqlite are page-cache engines, so the harness drops the page cache before
+# timing via `sudo -n sh -c 'echo 3 > /proc/sys/vm/drop_caches'`. That reuses a
+# sudo *timestamp*, which only works from a pty — so launch this script under a
+# pty AND detached so it survives disconnect, e.g.:
+#   SUDO_PASS=*** nohup setsid script -qfc 'bash eval_cold.sh' /tmp/cold-pty.log &
+# Matched 32 MB memory (bufpool=64 → sqlite 32 MB cache, rocksdb 32 MB cache).
+set -u
+cd /tmp/holt-cr/benches
+BIN=$(ls -t target/release/deps/stress-* | grep -v '\.d$' | head -1)
+OUT=/tmp/holt-eval
+mkdir -p "$OUT"
+ALL=holt,rocksdb,sqlite,lmdb
+echo "BIN=$BIN"
+
+# Warm the sudo timestamp once (password from env, never written to this file).
+# We run under a pty, so child processes (the harness) reuse the ticket via
+# `sudo -n`; a keepalive refresh keeps it valid for the whole run.
+if [ -n "${SUDO_PASS:-}" ]; then echo "$SUDO_PASS" | sudo -S -v 2>/dev/null; unset SUDO_PASS; fi
+( while true; do sudo -n -v 2>/dev/null || exit 0; sleep 50; done ) & KEEPALIVE=$!
+trap 'kill $KEEPALIVE 2>/dev/null' EXIT
+
+grab() { grep -E '^(holt|rocksdb|sqlite|lmdb) |read_amp |space |drop_caches:|settled|holt_shape final' "$1"; }
+
+# E1-cold @1M, routed (holt reads the ~10KB routing region, not a 512KB blob).
+echo "=== E1-COLD 1m routed (all 4) ==="
+HOLT_STRESS_N=1000000 HOLT_STRESS_POINT_OPS=50000 HOLT_STRESS_LIST_OPS=1 \
+HOLT_STRESS_BUFFER_POOL=64 HOLT_STRESS_ROCKSDB_DIRECT=1 HOLT_STRESS_DROP_CACHES=1 \
+HOLT_STRESS_COMPACT_AFTER_PRELOAD=1 HOLT_STRESS_REOPEN_AFTER_PRELOAD=1 \
+HOLT_STRESS_ENGINES=$ALL HOLT_STRESS_OPS=get \
+"$BIN" objstore > "$OUT/cold_e1_1m_routed.log" 2>&1
+grab "$OUT/cold_e1_1m_routed.log"
+
+# E3 negative (absent keys) @1M, routed — bloom-reject vs leaf-miss.
+echo "=== E3-NEG 1m routed (all 4) ==="
+HOLT_STRESS_N=1000000 HOLT_STRESS_POINT_OPS=50000 HOLT_STRESS_LIST_OPS=1 \
+HOLT_STRESS_BUFFER_POOL=64 HOLT_STRESS_ROCKSDB_DIRECT=1 HOLT_STRESS_DROP_CACHES=1 \
+HOLT_STRESS_COMPACT_AFTER_PRELOAD=1 HOLT_STRESS_REOPEN_AFTER_PRELOAD=1 \
+HOLT_STRESS_NEGATIVE=1 HOLT_STRESS_ENGINES=$ALL HOLT_STRESS_OPS=get \
+"$BIN" objstore > "$OUT/cold_e3_neg_1m_routed.log" 2>&1
+grab "$OUT/cold_e3_neg_1m_routed.log"
+
+# E1-cold @10M, UNROUTED (routed compaction is glacial at 10M) — the honest
+# at-scale case where holt reads full 512KB blobs cold.
+echo "=== E1-COLD 10m unrouted (all 4) ==="
+HOLT_STRESS_N=10000000 HOLT_STRESS_POINT_OPS=50000 HOLT_STRESS_LIST_OPS=1 \
+HOLT_STRESS_BUFFER_POOL=64 HOLT_STRESS_ROCKSDB_DIRECT=1 HOLT_STRESS_DROP_CACHES=1 \
+HOLT_STRESS_REOPEN_AFTER_PRELOAD=1 \
+HOLT_STRESS_ENGINES=$ALL HOLT_STRESS_OPS=get \
+"$BIN" objstore > "$OUT/cold_e1_10m_unrouted.log" 2>&1
+grab "$OUT/cold_e1_10m_unrouted.log"
+
+# E2 cold QD sweep, holt only @1M routed — free device queue depth via N
+# concurrent lock-free gets (holt is O_DIRECT, no drop_caches needed).
+for qd in 1 4 8 16; do
+  echo "=== E2 qd=$qd 1m routed holt ==="
+  HOLT_STRESS_N=1000000 HOLT_STRESS_POINT_OPS=200000 HOLT_STRESS_LIST_OPS=1 \
+  HOLT_STRESS_BUFFER_POOL=64 HOLT_STRESS_COMPACT_AFTER_PRELOAD=1 \
+  HOLT_STRESS_REOPEN_AFTER_PRELOAD=1 HOLT_STRESS_ENGINES=holt HOLT_STRESS_OPS=get \
+  HOLT_STRESS_GET_THREADS=$qd \
+  "$BIN" objstore > "$OUT/cold_e2_qd${qd}.log" 2>&1
+  grep -E '^holt get|read_amp |settled' "$OUT/cold_e2_qd${qd}.log"
+done
+
+# E5-sync: sync-durable overwrite + mixed, warm, all 4 (LAST — lmdb msync slow).
+echo "=== E5-SYNC 1m warm (wal_sync=true, all 4) ==="
+HOLT_STRESS_N=1000000 HOLT_STRESS_POINT_OPS=50000 HOLT_STRESS_LIST_OPS=1 \
+HOLT_STRESS_BUFFER_POOL=1200 HOLT_STRESS_ENGINES=$ALL HOLT_STRESS_OPS=put,mixed \
+HOLT_STRESS_WAL_SYNC=true \
+"$BIN" objstore > "$OUT/e5_sync_1m.log" 2>&1
+grep -E '^(holt|rocksdb|sqlite|lmdb) ' "$OUT/e5_sync_1m.log"
+
+echo ALL_COLD_DONE

--- a/benches/eval_hot.sh
+++ b/benches/eval_hot.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Phase A — HOT regime (E1 read scale, E4 list/rollup, E5 overwrite, mixed).
+# All four engines warm: holt buffer-pool sized to hold the dataset; the
+# page-cache engines (lmdb/sqlite) + buffered rocksdb ride the OS page cache.
+set -u
+cd /tmp/holt-cr/benches
+BIN=$(ls -t target/release/deps/stress-* | grep -v '\.d$' | head -1)
+OUT=/tmp/holt-eval
+mkdir -p "$OUT"
+ENG=holt,rocksdb,sqlite,lmdb
+
+run() { # n bufpool tag
+  local n=$1 bp=$2 tag=$3
+  echo "=== HOT scale=$n bufpool=$bp engines=$ENG ==="
+  HOLT_STRESS_N=$n \
+  HOLT_STRESS_POINT_OPS=500000 \
+  HOLT_STRESS_LIST_OPS=50000 \
+  HOLT_STRESS_BUFFER_POOL=$bp \
+  HOLT_STRESS_ENGINES=$ENG \
+  HOLT_STRESS_OPS=get,put,mixed,list,list_dir \
+  HOLT_STRESS_WAL_SYNC=false \
+  "$BIN" objstore > "$OUT/hot_${tag}.log" 2>&1
+  echo "--- hot_${tag} ---"
+  grep -E '^(holt|rocksdb|sqlite|lmdb) ' "$OUT/hot_${tag}.log"
+}
+
+run 100000   256  100k
+run 1000000  1200 1m
+run 10000000 8192 10m
+
+# Sync-durable write profile (E5 sync) at 1M only — bounds the run.
+echo "=== HOT-SYNC scale=1000000 bufpool=1200 (wal_sync=true) ==="
+HOLT_STRESS_N=1000000 HOLT_STRESS_POINT_OPS=200000 HOLT_STRESS_LIST_OPS=1 \
+HOLT_STRESS_BUFFER_POOL=1200 HOLT_STRESS_ENGINES=$ENG \
+HOLT_STRESS_OPS=put,mixed HOLT_STRESS_WAL_SYNC=true \
+"$BIN" objstore > "$OUT/hot_sync_1m.log" 2>&1
+grep -E '^(holt|rocksdb|sqlite|lmdb) ' "$OUT/hot_sync_1m.log"
+
+echo ALL_HOT_DONE

--- a/benches/stress.rs
+++ b/benches/stress.rs
@@ -17,8 +17,15 @@
 
 use std::env;
 use std::hint::black_box;
+use std::os::unix::fs::MetadataExt;
+#[cfg(feature = "comparators")]
+use std::ops::Bound;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "comparators")]
+use heed::types::Bytes;
+#[cfg(feature = "comparators")]
+use heed::{Database as LmdbDatabase, Env as LmdbEnv, EnvFlags, EnvOpenOptions};
 use holt::{KeyRangeEntry, RangeEntry, Tree, TreeConfig};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 #[cfg(feature = "comparators")]
@@ -152,6 +159,16 @@ struct StressConfig {
     compact_after_preload: bool,
     rocksdb_direct: bool,
     get_threads: usize,
+    drop_caches: bool,
+    negative: bool,
+    /// Persistent base dir for each engine's store (`<dir>/<engine>`) instead
+    /// of a fresh TempDir. Lets a preload run and a later read-only run share
+    /// the same on-disk store across processes (matched-memory cold reads).
+    data_dir: Option<std::path::PathBuf>,
+    /// Open the existing store and go straight to the timed phase — no
+    /// preload, checkpoint, or compaction. Pairs with `data_dir`: preload once
+    /// uncapped, then read under a tight cgroup memory cap.
+    skip_preload: bool,
     engines: Vec<String>,
     ops: Vec<String>,
 }
@@ -215,6 +232,27 @@ impl StressConfig {
             // scales with this, the cold-read parallelism is already
             // there with no engine change.
             get_threads: env_usize("HOLT_STRESS_GET_THREADS", 1).max(1),
+            // Cold regime: drop the OS page cache before the timed phase so
+            // the page-cache engines (lmdb, sqlite, buffered rocksdb) read
+            // from the device, like holt's O_DIRECT path. Needs a pre-warmed
+            // sudo timestamp (`sudo -v`); we shell out with `sudo -n` and
+            // never touch the password here.
+            drop_caches: env::var("HOLT_STRESS_DROP_CACHES")
+                .as_deref()
+                .map(|s| parse_bool_env("HOLT_STRESS_DROP_CACHES", s))
+                .unwrap_or(false),
+            // Negative-lookup mode: query keys that share a real key's full
+            // prefix but are absent (a trailing sentinel byte). Exercises the
+            // descent + per-blob bloom reject (holt) / leaf-miss (others).
+            negative: env::var("HOLT_STRESS_NEGATIVE")
+                .as_deref()
+                .map(|s| parse_bool_env("HOLT_STRESS_NEGATIVE", s))
+                .unwrap_or(false),
+            data_dir: env::var_os("HOLT_STRESS_DATA_DIR").map(std::path::PathBuf::from),
+            skip_preload: env::var("HOLT_STRESS_SKIP_PRELOAD")
+                .as_deref()
+                .map(|s| parse_bool_env("HOLT_STRESS_SKIP_PRELOAD", s))
+                .unwrap_or(false),
             engines,
             ops,
         }
@@ -254,11 +292,12 @@ fn main() {
         cfg.ops.join(","),
     );
     println!(
-        "profile=single_thread,warm_service,persistent_wal,wal_sync={},checkpoint=enabled,reopen_after_preload={},compact_after_preload={},rocksdb_direct={},get_threads={}",
-        cfg.wal_sync, cfg.reopen_after_preload, cfg.compact_after_preload, cfg.rocksdb_direct, cfg.get_threads
+        "profile=single_thread,warm_service,persistent_wal,wal_sync={},checkpoint=enabled,reopen_after_preload={},compact_after_preload={},rocksdb_direct={},get_threads={},drop_caches={},negative={},skip_preload={},data_dir={}",
+        cfg.wal_sync, cfg.reopen_after_preload, cfg.compact_after_preload, cfg.rocksdb_direct, cfg.get_threads, cfg.drop_caches, cfg.negative, cfg.skip_preload,
+        cfg.data_dir.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "tempdir".to_string())
     );
 
-    let samples = make_samples(cfg.workload, cfg.n_keys, cfg.point_ops);
+    let samples = make_samples(cfg.workload, cfg.n_keys, cfg.point_ops, cfg.negative);
     reject_missing_comparators(&cfg);
     if cfg.selected("holt") {
         run_holt(&cfg, &samples);
@@ -275,11 +314,15 @@ fn main() {
     if cfg.selected("sled") {
         run_sled(&cfg, &samples);
     }
+    #[cfg(feature = "comparators")]
+    if cfg.selected("lmdb") {
+        run_lmdb(&cfg, &samples);
+    }
 }
 
 #[cfg(not(feature = "comparators"))]
 fn reject_missing_comparators(cfg: &StressConfig) {
-    for engine in ["rocksdb", "sqlite", "sled"] {
+    for engine in ["rocksdb", "sqlite", "sled", "lmdb"] {
         if cfg.selected(engine) {
             panic!("stress comparator `{engine}` requires the `comparators` feature");
         }
@@ -289,19 +332,54 @@ fn reject_missing_comparators(cfg: &StressConfig) {
 #[cfg(feature = "comparators")]
 fn reject_missing_comparators(_cfg: &StressConfig) {}
 
+/// A store directory: either an ephemeral `TempDir` (cleaned on drop) or a
+/// caller-provided persistent path (kept across runs, for matched-memory
+/// preload-once-then-read-capped). `path()` works for both so callers are
+/// unchanged; the held `TempDir` keeps the temp path alive.
+struct StoreDir {
+    path: std::path::PathBuf,
+    #[allow(dead_code)]
+    tmp: Option<TempDir>,
+}
+
+impl StoreDir {
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+fn store_dir(cfg: &StressConfig, engine: &str) -> StoreDir {
+    match &cfg.data_dir {
+        Some(base) => {
+            let path = base.join(engine);
+            std::fs::create_dir_all(&path).expect("store data dir");
+            StoreDir { path, tmp: None }
+        }
+        None => {
+            let tmp = TempDir::new().expect("store tempdir");
+            StoreDir {
+                path: tmp.path().to_path_buf(),
+                tmp: Some(tmp),
+            }
+        }
+    }
+}
+
 fn run_holt(cfg: &StressConfig, samples: &[OpSample]) {
-    let dir = TempDir::new().expect("holt tempdir");
+    let dir = store_dir(cfg, "holt");
     let mut tree_cfg = TreeConfig::new(dir.path());
     tree_cfg.durability = holt::Durability::Wal { sync: cfg.wal_sync };
     tree_cfg.buffer_pool_size = cfg.buffer_pool_size;
     let mut tree = Tree::open(tree_cfg.clone()).expect("holt open");
-    preload_holt(&tree, cfg.workload, cfg.n_keys);
-    print_holt_shape("preload", &tree);
-    tree.checkpoint().expect("holt preload checkpoint");
-    print_holt_shape("ready", &tree);
-    if cfg.compact_after_preload {
-        compact_holt_until_settled(&tree);
-        print_holt_shape("routed", &tree);
+    if !cfg.skip_preload {
+        preload_holt(&tree, cfg.workload, cfg.n_keys);
+        print_holt_shape("preload", &tree);
+        tree.checkpoint().expect("holt preload checkpoint");
+        print_holt_shape("ready", &tree);
+        if cfg.compact_after_preload {
+            compact_holt_until_settled(&tree);
+            print_holt_shape("routed", &tree);
+        }
     }
     if cfg.reopen_after_preload {
         drop(tree);
@@ -309,13 +387,14 @@ fn run_holt(cfg: &StressConfig, samples: &[OpSample]) {
         println!("holt_shape reopened deferred_until_after_timing=1");
     }
 
+    print_space("holt", dir.path(), cfg.n_keys);
+    maybe_drop_caches(cfg, "holt");
     if cfg.selected_op("get") {
-        report(
-            "holt",
-            "get",
-            samples.len(),
-            time_get_holt_concurrent(&tree, samples, cfg.get_threads),
-        );
+        let rb0 = proc_read_bytes();
+        let elapsed = time_get_holt_concurrent(&tree, samples, cfg.get_threads);
+        let rb1 = proc_read_bytes();
+        report("holt", "get", samples.len(), elapsed);
+        print_read_amp("holt", "get", samples.len(), rb1.saturating_sub(rb0));
     }
     if cfg.selected_op("put") {
         report("holt", "put", samples.len(), time_put_holt(&tree, samples));
@@ -376,23 +455,26 @@ fn run_holt(cfg: &StressConfig, samples: &[OpSample]) {
 
 #[cfg(feature = "comparators")]
 fn run_rocksdb(cfg: &StressConfig, samples: &[OpSample]) {
-    let rocksdb_dir = TempDir::new().expect("rocksdb tempdir");
+    let rocksdb_dir = store_dir(cfg, "rocksdb");
     let mut db = make_rocksdb(&rocksdb_dir, cfg);
-    preload_rocksdb(&db, cfg.workload, cfg.n_keys);
+    if !cfg.skip_preload {
+        preload_rocksdb(&db, cfg.workload, cfg.n_keys);
+    }
     if cfg.reopen_after_preload {
         db.flush().expect("rocksdb preload flush before reopen");
         drop(db);
         db = make_rocksdb(&rocksdb_dir, cfg);
     }
-    let wo = rocksdb_write_opts();
+    let wo = rocksdb_write_opts(cfg.wal_sync);
 
+    print_space("rocksdb", rocksdb_dir.path(), cfg.n_keys);
+    maybe_drop_caches(cfg, "rocksdb");
     if cfg.selected_op("get") {
-        report(
-            "rocksdb",
-            "get",
-            samples.len(),
-            time_get_rocksdb(&db, samples),
-        );
+        let rb0 = proc_read_bytes();
+        let elapsed = time_get_rocksdb(&db, samples);
+        let rb1 = proc_read_bytes();
+        report("rocksdb", "get", samples.len(), elapsed);
+        print_read_amp("rocksdb", "get", samples.len(), rb1.saturating_sub(rb0));
     }
     if cfg.selected_op("put") {
         report(
@@ -443,23 +525,26 @@ fn run_rocksdb(cfg: &StressConfig, samples: &[OpSample]) {
 
 #[cfg(feature = "comparators")]
 fn run_sqlite(cfg: &StressConfig, samples: &[OpSample]) {
-    let sqlite_dir = TempDir::new().expect("sqlite tempdir");
-    let mut conn = make_sqlite_persistent(&sqlite_dir);
-    preload_sqlite(&conn, cfg.workload, cfg.n_keys);
+    let sqlite_dir = store_dir(cfg, "sqlite");
+    let mut conn = make_sqlite_persistent(&sqlite_dir, cfg);
+    if !cfg.skip_preload {
+        preload_sqlite(&conn, cfg.workload, cfg.n_keys);
+    }
     if cfg.reopen_after_preload {
         conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
             .expect("sqlite preload checkpoint before reopen");
         drop(conn);
-        conn = make_sqlite_persistent(&sqlite_dir);
+        conn = make_sqlite_persistent(&sqlite_dir, cfg);
     }
 
+    print_space("sqlite", sqlite_dir.path(), cfg.n_keys);
+    maybe_drop_caches(cfg, "sqlite");
     if cfg.selected_op("get") {
-        report(
-            "sqlite",
-            "get",
-            samples.len(),
-            time_get_sqlite(&conn, samples),
-        );
+        let rb0 = proc_read_bytes();
+        let elapsed = time_get_sqlite(&conn, samples);
+        let rb1 = proc_read_bytes();
+        report("sqlite", "get", samples.len(), elapsed);
+        print_read_amp("sqlite", "get", samples.len(), rb1.saturating_sub(rb0));
     }
     if cfg.selected_op("put") {
         report(
@@ -512,9 +597,11 @@ fn run_sqlite(cfg: &StressConfig, samples: &[OpSample]) {
 
 #[cfg(feature = "comparators")]
 fn run_sled(cfg: &StressConfig, samples: &[OpSample]) {
-    let sled_dir = TempDir::new().expect("sled tempdir");
+    let sled_dir = store_dir(cfg, "sled");
     let mut db = make_sled_persistent(&sled_dir);
-    preload_sled(&db, cfg.workload, cfg.n_keys);
+    if !cfg.skip_preload {
+        preload_sled(&db, cfg.workload, cfg.n_keys);
+    }
     if cfg.reopen_after_preload {
         db.flush().expect("sled preload flush before reopen");
         drop(db);
@@ -566,14 +653,92 @@ fn run_sled(cfg: &StressConfig, samples: &[OpSample]) {
     }
 }
 
-fn make_samples(workload: Workload, n_keys: usize, ops: usize) -> Vec<OpSample> {
+/// LMDB (via the `heed` safe wrapper) — the read-optimized embedded
+/// B+tree that is holt's closest niche peer. Unlike the others, LMDB has
+/// no tunable cache: it is mmap-only and rides the OS page cache. The
+/// cold regime (drop_caches before timing) is the only fair way to
+/// compare it against holt's O_DIRECT reads — see docs/paper/eval-design.md.
+#[cfg(feature = "comparators")]
+fn run_lmdb(cfg: &StressConfig, samples: &[OpSample]) {
+    let lmdb_dir = store_dir(cfg, "lmdb");
+    let mut lmdb = make_lmdb(&lmdb_dir, cfg);
+    if !cfg.skip_preload {
+        preload_lmdb(&lmdb, cfg.workload, cfg.n_keys);
+    }
+    if cfg.reopen_after_preload {
+        lmdb.env
+            .force_sync()
+            .expect("lmdb preload sync before reopen");
+        drop(lmdb);
+        lmdb = make_lmdb(&lmdb_dir, cfg);
+    }
+
+    print_space("lmdb", lmdb_dir.path(), cfg.n_keys);
+    maybe_drop_caches(cfg, "lmdb");
+    if cfg.selected_op("get") {
+        let rb0 = proc_read_bytes();
+        let elapsed = time_get_lmdb(&lmdb, samples);
+        let rb1 = proc_read_bytes();
+        report("lmdb", "get", samples.len(), elapsed);
+        print_read_amp("lmdb", "get", samples.len(), rb1.saturating_sub(rb0));
+    }
+    if cfg.selected_op("put") {
+        report("lmdb", "put", samples.len(), time_put_lmdb(&lmdb, samples));
+    }
+    if cfg.selected_op("mixed") {
+        report(
+            "lmdb",
+            "mixed",
+            samples.len(),
+            time_mixed_lmdb(&lmdb, samples),
+        );
+    }
+    if cfg.selected_op("list") {
+        report(
+            "lmdb",
+            "list",
+            cfg.list_ops,
+            time_repeated(cfg.list_ops, || {
+                black_box(lmdb_list_plain(
+                    &lmdb,
+                    cfg.workload.list_prefix(),
+                    cfg.list_take,
+                ));
+            }),
+        );
+    }
+    if cfg.selected_op("list_dir") {
+        report(
+            "lmdb",
+            "list_dir",
+            cfg.list_ops,
+            time_repeated(cfg.list_ops, || {
+                black_box(lmdb_list_dir(
+                    &lmdb,
+                    cfg.workload.dir_prefix(),
+                    cfg.workload.delimiter(),
+                    cfg.dir_take,
+                ));
+            }),
+        );
+    }
+}
+
+fn make_samples(workload: Workload, n_keys: usize, ops: usize, negative: bool) -> Vec<OpSample> {
     assert!(n_keys > 0, "HOLT_STRESS_N must be > 0");
     let mut rng = StdRng::seed_from_u64(SEED);
     let mut out = Vec::with_capacity(ops);
     for op in 0..ops {
         let idx = (rng.next_u64() as usize) % n_keys;
+        let mut key = workload.key(idx, n_keys);
+        if negative {
+            // Append a sentinel byte: the result shares the real key's full
+            // prefix (same descent + same target blob) but is absent, so the
+            // lookup misses at the leaf / per-blob bloom.
+            key.push(0x7E);
+        }
         out.push(OpSample {
-            key: workload.key(idx, n_keys),
+            key,
             value: workload.value(idx, op as u64 + 1),
         });
     }
@@ -641,7 +806,9 @@ fn compact_holt_until_settled(tree: &Tree) {
 
 #[cfg(feature = "comparators")]
 fn preload_rocksdb(db: &DB, workload: Workload, n_keys: usize) {
-    let wo = rocksdb_write_opts();
+    // Preload is always async/fast (a bulk load is not the durable-write
+    // experiment); the timed put/mixed phase uses the configured profile.
+    let wo = rocksdb_write_opts(false);
     let mut batch = WriteBatch::default();
     let mut in_batch = 0usize;
     progress("rocksdb", "preload", 0, n_keys);
@@ -696,6 +863,30 @@ fn preload_sled(db: &SledDb, workload: Workload, n_keys: usize) {
             progress("sled", "preload", i + 1, n_keys);
         }
     }
+}
+
+#[cfg(feature = "comparators")]
+fn preload_lmdb(lmdb: &Lmdb, workload: Workload, n_keys: usize) {
+    progress("lmdb", "preload", 0, n_keys);
+    let mut wtxn = lmdb.env.write_txn().expect("lmdb preload wtxn");
+    let mut in_batch = 0usize;
+    for i in 0..n_keys {
+        let key = workload.key(i, n_keys);
+        let value = workload.value(i, 0);
+        lmdb.db
+            .put(&mut wtxn, key.as_slice(), value.as_slice())
+            .expect("lmdb preload put");
+        in_batch += 1;
+        if in_batch == PRELOAD_BATCH {
+            wtxn.commit().expect("lmdb preload batch commit");
+            wtxn = lmdb.env.write_txn().expect("lmdb preload wtxn");
+            in_batch = 0;
+        }
+        if should_progress(i + 1, n_keys) {
+            progress("lmdb", "preload", i + 1, n_keys);
+        }
+    }
+    wtxn.commit().expect("lmdb preload final commit");
 }
 
 fn time_get_holt(tree: &Tree, samples: &[OpSample]) -> Duration {
@@ -778,8 +969,9 @@ fn time_get_sqlite(conn: &Connection, samples: &[OpSample]) -> Duration {
         .prepare("SELECT v FROM kv WHERE k = ?")
         .expect("sqlite get stmt");
     time_samples(samples, |sample| {
-        let v: Vec<u8> = stmt
+        let v: Option<Vec<u8>> = stmt
             .query_row(params![sample.key.as_slice()], |row| row.get(0))
+            .optional()
             .expect("sqlite get");
         black_box(v);
     })
@@ -806,8 +998,9 @@ fn time_mixed_sqlite(conn: &Connection, samples: &[OpSample]) -> Duration {
         .expect("sqlite put stmt");
     time_samples_indexed(samples, |i, sample| {
         if i & 1 == 0 {
-            let v: Vec<u8> = get_stmt
+            let v: Option<Vec<u8>> = get_stmt
                 .query_row(params![sample.key.as_slice()], |row| row.get(0))
+                .optional()
                 .expect("sqlite get");
             black_box(v);
         } else {
@@ -841,6 +1034,55 @@ fn time_mixed_sled(db: &SledDb, samples: &[OpSample]) -> Duration {
         } else {
             db.insert(black_box(&sample.key), black_box(sample.value.as_slice()))
                 .expect("sled put");
+        }
+    })
+}
+
+// One read transaction reused across the whole get loop — the idiomatic
+// LMDB read path (parallels sqlite's reused prepared statement). LMDB read
+// txns are snapshot-cheap; a per-op txn would measure txn setup, not reads.
+#[cfg(feature = "comparators")]
+fn time_get_lmdb(lmdb: &Lmdb, samples: &[OpSample]) -> Duration {
+    let rtxn = lmdb.env.read_txn().expect("lmdb get rtxn");
+    time_samples(samples, |sample| {
+        black_box(
+            lmdb.db
+                .get(&rtxn, black_box(sample.key.as_slice()))
+                .expect("lmdb get"),
+        );
+    })
+}
+
+// Per-op write txn + commit = one durable write per op (commit honors the
+// env's sync flag: NO_SYNC for async-durable, msync for sync-durable),
+// matching rocksdb `put_opt`/sqlite per-row insert.
+#[cfg(feature = "comparators")]
+fn time_put_lmdb(lmdb: &Lmdb, samples: &[OpSample]) -> Duration {
+    time_samples(samples, |sample| {
+        let mut wtxn = lmdb.env.write_txn().expect("lmdb put wtxn");
+        lmdb.db
+            .put(&mut wtxn, sample.key.as_slice(), sample.value.as_slice())
+            .expect("lmdb put");
+        wtxn.commit().expect("lmdb put commit");
+    })
+}
+
+#[cfg(feature = "comparators")]
+fn time_mixed_lmdb(lmdb: &Lmdb, samples: &[OpSample]) -> Duration {
+    time_samples_indexed(samples, |i, sample| {
+        if i & 1 == 0 {
+            let rtxn = lmdb.env.read_txn().expect("lmdb mixed rtxn");
+            black_box(
+                lmdb.db
+                    .get(&rtxn, sample.key.as_slice())
+                    .expect("lmdb get"),
+            );
+        } else {
+            let mut wtxn = lmdb.env.write_txn().expect("lmdb mixed wtxn");
+            lmdb.db
+                .put(&mut wtxn, sample.key.as_slice(), sample.value.as_slice())
+                .expect("lmdb put");
+            wtxn.commit().expect("lmdb mixed commit");
         }
     })
 }
@@ -1049,6 +1291,54 @@ fn sled_list_dir(db: &SledDb, prefix: &[u8], delim: u8, take: usize) -> usize {
 }
 
 #[cfg(feature = "comparators")]
+fn lmdb_list_plain(lmdb: &Lmdb, prefix: &[u8], take: usize) -> usize {
+    let rtxn = lmdb.env.read_txn().expect("lmdb list rtxn");
+    let mut seen = 0usize;
+    let iter = lmdb
+        .db
+        .prefix_iter(&rtxn, prefix)
+        .expect("lmdb list prefix_iter");
+    for item in iter {
+        let _ = item.expect("lmdb list item");
+        seen += 1;
+        if seen >= take {
+            break;
+        }
+    }
+    seen
+}
+
+#[cfg(feature = "comparators")]
+fn lmdb_list_dir(lmdb: &Lmdb, prefix: &[u8], delim: u8, take: usize) -> usize {
+    let rtxn = lmdb.env.read_txn().expect("lmdb list_dir rtxn");
+    let mut seen = 0usize;
+    let mut cursor = prefix.to_vec();
+    let upper = prefix_upper(prefix);
+    while cursor.as_slice() < upper.as_slice() {
+        let range = (
+            Bound::Included(cursor.as_slice()),
+            Bound::Excluded(upper.as_slice()),
+        );
+        let found = lmdb
+            .db
+            .range(&rtxn, &range)
+            .expect("lmdb list_dir range")
+            .next();
+        let Some(item) = found else {
+            break;
+        };
+        let (key, _value) = item.expect("lmdb list_dir item");
+        let next_seek = delimiter_successor(key, prefix.len(), delim);
+        seen += 1;
+        if seen >= take {
+            break;
+        }
+        cursor = next_seek.unwrap_or_else(|| key_successor(key));
+    }
+    seen
+}
+
+#[cfg(feature = "comparators")]
 fn delimiter_successor(key: &[u8], prefix_len: usize, delim: u8) -> Option<Vec<u8>> {
     let rest = &key[prefix_len..];
     let idx = rest.iter().position(|b| *b == delim)?;
@@ -1069,7 +1359,7 @@ fn key_successor(key: &[u8]) -> Vec<u8> {
 }
 
 #[cfg(feature = "comparators")]
-fn make_rocksdb(dir: &TempDir, cfg: &StressConfig) -> DB {
+fn make_rocksdb(dir: &StoreDir, cfg: &StressConfig) -> DB {
     let mut opts = Options::default();
     opts.create_if_missing(true);
     opts.set_write_buffer_size(256 * 1024 * 1024);
@@ -1094,29 +1384,41 @@ fn make_rocksdb(dir: &TempDir, cfg: &StressConfig) -> DB {
 }
 
 #[cfg(feature = "comparators")]
-fn rocksdb_write_opts() -> WriteOptions {
+fn rocksdb_write_opts(sync: bool) -> WriteOptions {
     let mut wo = WriteOptions::default();
     wo.disable_wal(false);
-    wo.set_sync(false);
+    // sync-durable profile: fsync the WAL on every write (matches holt
+    // Wal{sync:true}, sqlite synchronous=FULL, lmdb default msync).
+    wo.set_sync(sync);
     wo
 }
 
 #[cfg(feature = "comparators")]
-fn make_sqlite_persistent(dir: &TempDir) -> Connection {
+fn make_sqlite_persistent(dir: &StoreDir, cfg: &StressConfig) -> Connection {
     let conn = Connection::open(dir.path().join("sqlite.db")).expect("sqlite open");
-    conn.execute_batch(
+    // sync-durable: synchronous=FULL fsyncs on each autocommit write (matches
+    // holt Wal{sync:true} / rocksdb sync=true / lmdb default). async-durable:
+    // synchronous=OFF leaves durability to the OS, like the others' async mode.
+    let synchronous = if cfg.wal_sync { "FULL" } else { "OFF" };
+    // Matched memory: sqlite's page cache (in its own heap, NOT the OS page
+    // cache, so drop_caches cannot clear it) is capped to the same bytes as
+    // holt's buffer pool — buffer_pool_size frames × 512 KiB, expressed as
+    // negative KiB. Without this the cold regime would serve sqlite's working
+    // set from its internal cache.
+    let cache_kib = cfg.buffer_pool_size.max(1) * 512;
+    conn.execute_batch(&format!(
         "PRAGMA journal_mode = WAL;\n\
-         PRAGMA synchronous = OFF;\n\
+         PRAGMA synchronous = {synchronous};\n\
          PRAGMA temp_store = MEMORY;\n\
-         PRAGMA cache_size = -262144;\n\
+         PRAGMA cache_size = -{cache_kib};\n\
          CREATE TABLE IF NOT EXISTS kv (k BLOB PRIMARY KEY, v BLOB) WITHOUT ROWID;",
-    )
+    ))
     .expect("sqlite pragmas + schema");
     conn
 }
 
 #[cfg(feature = "comparators")]
-fn make_sled_persistent(dir: &TempDir) -> SledDb {
+fn make_sled_persistent(dir: &StoreDir) -> SledDb {
     sled::Config::new()
         .path(dir.path())
         .mode(SledMode::HighThroughput)
@@ -1124,6 +1426,48 @@ fn make_sled_persistent(dir: &TempDir) -> SledDb {
         .flush_every_ms(None)
         .open()
         .expect("sled open")
+}
+
+/// LMDB environment + its main (unnamed) database, held together because
+/// every op needs the env to open a txn and the handle to address rows.
+#[cfg(feature = "comparators")]
+struct Lmdb {
+    env: LmdbEnv,
+    db: LmdbDatabase<Bytes, Bytes>,
+}
+
+/// LMDB requires its memory map (the cap on total DB file size) to be sized
+/// up front. The file is sparse, so over-provisioning only reserves virtual
+/// address space — cheap on 64-bit. Budget 384 B/entry (≈50 B path key +
+/// ≈60 B JSON value + B+tree page overhead), floor 1 GiB, page-aligned.
+#[cfg(feature = "comparators")]
+fn lmdb_map_size(n_keys: usize) -> usize {
+    const PAGE: usize = 4096;
+    let bytes = (n_keys.max(1) * 384).max(1 << 30);
+    bytes.div_ceil(PAGE) * PAGE
+}
+
+#[cfg(feature = "comparators")]
+fn make_lmdb(dir: &StoreDir, cfg: &StressConfig) -> Lmdb {
+    let mut opts = EnvOpenOptions::new();
+    opts.map_size(lmdb_map_size(cfg.n_keys));
+    opts.max_dbs(1);
+    if !cfg.wal_sync {
+        // async-durable profile: don't fsync on commit (matches holt
+        // Wal{sync:false}, rocksdb sync=false, sqlite synchronous=OFF). A
+        // crash can lose the last commits but not corrupt the DB — hence
+        // unsafe. The sync-durable profile (wal_sync=true) leaves the
+        // default msync-on-commit behavior in place.
+        unsafe {
+            opts.flags(EnvFlags::NO_SYNC | EnvFlags::NO_META_SYNC);
+        }
+    }
+    let env = unsafe { opts.open(dir.path()) }.expect("lmdb open");
+    let mut wtxn = env.write_txn().expect("lmdb create wtxn");
+    let db: LmdbDatabase<Bytes, Bytes> =
+        env.create_database(&mut wtxn, None).expect("lmdb create db");
+    wtxn.commit().expect("lmdb create commit");
+    Lmdb { env, db }
 }
 
 fn print_holt_shape(label: &str, tree: &Tree) {
@@ -1173,6 +1517,56 @@ fn report(engine: &str, op: &str, ops: usize, elapsed: Duration) {
     println!("{engine:<8} {op:<8} {ns:>10.1} ns/op {mops:>8.3} Mops/s");
 }
 
+/// E7 space amplification: total on-disk bytes for the (settled) store.
+/// Call after preload + checkpoint/reopen so each engine's data is merged
+/// to its steady on-disk form (sqlite WAL checkpointed, rocksdb flushed,
+/// holt WAL drained to blobs). holt's 512 KiB frames at ~0.38 fill make this
+/// its honest weak axis.
+fn dir_size_bytes(path: &std::path::Path) -> u64 {
+    let mut total = 0u64;
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            match entry.file_type() {
+                Ok(ft) if ft.is_dir() => total += dir_size_bytes(&entry.path()),
+                // Actual allocated blocks (du-equivalent), not apparent length:
+                // LMDB's data file is a sparse map_size reservation, so len()
+                // would report the whole reservation rather than used pages.
+                Ok(_) => total += entry.metadata().map(|m| m.blocks() * 512).unwrap_or(0),
+                Err(_) => {}
+            }
+        }
+    }
+    total
+}
+
+fn print_space(engine: &str, dir: &std::path::Path, n_keys: usize) {
+    let bytes = dir_size_bytes(dir);
+    let per_key = bytes as f64 / n_keys.max(1) as f64;
+    println!("space engine={engine} bytes={bytes} n_keys={n_keys} bytes_per_key={per_key:.1}");
+}
+
+/// Device read amplification: bytes actually fetched from storage by this
+/// process, from `/proc/self/io` (`read_bytes`). Sampled before/after a timed
+/// phase, the delta is the cross-engine cold read-amp — counts O_DIRECT
+/// (holt, rocksdb-direct), mmap page faults (lmdb), and buffered reads
+/// (sqlite) uniformly. Returns 0 off Linux (e.g. the mac dev box).
+fn proc_read_bytes() -> u64 {
+    std::fs::read_to_string("/proc/self/io")
+        .ok()
+        .and_then(|s| {
+            s.lines().find_map(|l| {
+                l.strip_prefix("read_bytes:")
+                    .and_then(|v| v.trim().parse::<u64>().ok())
+            })
+        })
+        .unwrap_or(0)
+}
+
+fn print_read_amp(engine: &str, op: &str, ops: usize, bytes: u64) {
+    let per_op = bytes as f64 / ops.max(1) as f64;
+    println!("read_amp engine={engine} op={op} read_bytes={bytes} bytes_per_op={per_op:.1}");
+}
+
 fn env_usize(name: &str, default: usize) -> usize {
     env::var(name)
         .ok()
@@ -1190,5 +1584,33 @@ fn progress(engine: &str, stage: &str, done: usize, total: usize) {
         .unwrap_or(total >= 1_000_000)
     {
         eprintln!("{engine} {stage}: {done}/{total}");
+    }
+}
+
+/// Cold regime: flush dirty pages and drop the OS page cache (+ dentries
+/// and inodes) so the next timed phase reads from the device. Holt's reads
+/// are O_DIRECT (page-cache-independent), but the page-cache comparators
+/// (lmdb, sqlite, buffered rocksdb) would otherwise serve the whole dataset
+/// from RAM — an unfair cold comparison. No-op unless `HOLT_STRESS_DROP_CACHES`
+/// is set; the password is never handled here.
+fn maybe_drop_caches(cfg: &StressConfig, engine: &str) {
+    if !cfg.drop_caches {
+        return;
+    }
+    // Flush dirty pages, then drop the page cache via `sudo -n` (relies on a
+    // sudo timestamp warmed in the same pty before the run; the password is
+    // never handled here). Run the harness inside a pty (tmux / ssh -t) so a
+    // child process can reuse the interactively-authenticated ticket.
+    let _ = std::process::Command::new("sync").status();
+    let status = std::process::Command::new("sudo")
+        .args(["-n", "sh", "-c", "echo 3 > /proc/sys/vm/drop_caches"])
+        .status();
+    match status {
+        Ok(s) if s.success() => eprintln!("{engine} drop_caches: ok"),
+        Ok(s) => panic!(
+            "drop_caches failed (exit {s}); warm the sudo timestamp (`sudo -v`) in the \
+             same pty before running — see benches/eval_cold.sh"
+        ),
+        Err(e) => panic!("drop_caches: failed to spawn sudo: {e}"),
     }
 }

--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -332,7 +332,7 @@ impl DB {
                 .collect::<Vec<_>>();
             let mut trees = HashMap::with_capacity(scoped.len());
             for (_, name, prefix, tree) in scoped {
-                trees.insert(name, tree.snapshot_unlocked(prefix)?);
+                trees.insert(name, tree.snapshot_unlocked_unfenced(prefix)?);
             }
             DBView { trees }
         };
@@ -421,7 +421,7 @@ impl DB {
 
             let mut snaps = Vec::with_capacity(families.len());
             for (name, _, tree) in &families {
-                snaps.push((name.clone(), tree.snapshot_unlocked(b"")?));
+                snaps.push((name.clone(), tree.snapshot_unlocked_unfenced(b"")?));
             }
             snaps
         };

--- a/src/api/tree.rs
+++ b/src/api/tree.rs
@@ -1694,6 +1694,18 @@ impl Tree {
     /// Used by [`crate::DB::view`] to capture several trees atomically
     /// under a single coordinated freeze.
     pub(crate) fn snapshot_unlocked(&self, prefix: &[u8]) -> Result<Snapshot> {
+        self.snapshot_unlocked_with_scan_fence(prefix, true)
+    }
+
+    pub(crate) fn snapshot_unlocked_unfenced(&self, prefix: &[u8]) -> Result<Snapshot> {
+        self.snapshot_unlocked_with_scan_fence(prefix, false)
+    }
+
+    fn snapshot_unlocked_with_scan_fence(
+        &self,
+        prefix: &[u8],
+        fence_live_writers: bool,
+    ) -> Result<Snapshot> {
         use crate::store::STRUCTURAL_SEQ;
 
         let snap_root = engine::fresh_blob_guid();
@@ -1719,6 +1731,12 @@ impl Tree {
             Arc::clone(&self.store),
             snap_root,
             root_pin,
+            fence_live_writers.then(|| {
+                (
+                    Arc::clone(&self.maintenance_gate),
+                    Arc::clone(&self.mutation_gate),
+                )
+            }),
         );
         Ok(Snapshot::new(view, Arc::clone(&self.store), epoch))
     }
@@ -2633,6 +2651,19 @@ where
         stats.torn_tail_at.is_none() || stats.records_seen > 0 || stats.highest_seq.is_none(),
         "a torn tail without complete records must not report a highest seq",
     );
+    // Physically drop a torn tail record before the writer reopens with
+    // O_APPEND. Otherwise the next session appends a good record *after*
+    // the torn bytes, turning them into a MID-log torn record; a later
+    // replay's torn-tail `break` stops there and silently discards every
+    // acked record written after it. The torn record was never acked (the
+    // crash hit mid-write, before its fdatasync), so truncating it to the
+    // last complete record loses nothing durable — standard WAL recovery.
+    if let Some(off) = stats.torn_tail_at {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)?
+            .set_len(off)?;
+    }
     // After commit, the blob image is durable; we still want the
     // next allocated seq to be strictly greater than anything
     // ever seen in the log.

--- a/src/api/view.rs
+++ b/src/api/view.rs
@@ -24,7 +24,8 @@ pub struct View {
     store: Arc<BufferManager>,
     root_guid: BlobGuid,
     root_pin: Arc<CachedBlob>,
-    maintenance_gate: Arc<Gate>,
+    range_gate: Arc<Gate>,
+    scan_fence: Option<(Arc<Gate>, Arc<Gate>)>,
 }
 
 impl View {
@@ -33,13 +34,15 @@ impl View {
         store: Arc<BufferManager>,
         root_guid: BlobGuid,
         root_pin: Arc<CachedBlob>,
+        scan_fence: Option<(Arc<Gate>, Arc<Gate>)>,
     ) -> Self {
         Self {
             scope,
             store,
             root_guid,
             root_pin,
-            maintenance_gate: Arc::new(Gate::new()),
+            range_gate: Arc::new(Gate::new()),
+            scan_fence,
         }
     }
 
@@ -135,13 +138,21 @@ impl View {
     }
 
     fn range_builder(&self, prefix: &[u8]) -> RangeBuilder {
-        RangeBuilder::new(
+        let builder = RangeBuilder::new(
             Arc::clone(&self.store),
             Arc::clone(&self.root_pin),
             self.root_guid,
-            Arc::clone(&self.maintenance_gate),
-        )
-        .prefix(prefix)
+            self.scan_fence.as_ref().map_or_else(
+                || Arc::clone(&self.range_gate),
+                |(gate, _)| Arc::clone(gate),
+            ),
+        );
+        let builder = if let Some((_, mutation_gate)) = &self.scan_fence {
+            builder.with_mutation_gate(Arc::clone(mutation_gate))
+        } else {
+            builder.snapshot_cursor()
+        };
+        builder.prefix(prefix)
     }
 
     fn ensure_in_scope(&self, prefix_or_key: &[u8]) -> Result<()> {

--- a/src/checkpoint/mod.rs
+++ b/src/checkpoint/mod.rs
@@ -526,6 +526,121 @@ mod tests {
         }
     }
 
+    /// A store whose `needs_flush()` is gated by an explicit flag, so a test
+    /// can hold "store durability still pending" true while the BufferManager
+    /// dirty/flushing/pending counters all read 0 — the exact window in which
+    /// the I/O worker has retired a written-through blob (after `pwrite`) but
+    /// not yet run the data fsync + manifest persist.
+    struct FlushGateStore {
+        inner: MemoryBlobStore,
+        flush_pending: AtomicBool,
+    }
+
+    impl FlushGateStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryBlobStore::new(),
+                flush_pending: AtomicBool::new(true),
+            }
+        }
+
+        fn release_flush(&self) {
+            self.flush_pending.store(false, AtomicOrdering::Release);
+        }
+    }
+
+    impl BlobStore for FlushGateStore {
+        fn read_blob(&self, guid: BlobGuid, dst: &mut AlignedBlobBuf) -> Result<()> {
+            self.inner.read_blob(guid, dst)
+        }
+        fn write_blob(&self, guid: BlobGuid, src: &AlignedBlobBuf) -> Result<()> {
+            self.inner.write_blob(guid, src)
+        }
+        fn write_blobs_with_data_sync(&self, writes: &[(BlobGuid, &AlignedBlobBuf)]) -> Result<()> {
+            self.inner.write_blobs_with_data_sync(writes)
+        }
+        fn delete_blob(&self, guid: BlobGuid) -> Result<()> {
+            self.inner.delete_blob(guid)
+        }
+        fn list_blobs(&self) -> Result<Vec<BlobGuid>> {
+            self.inner.list_blobs()
+        }
+        fn flush(&self) -> Result<()> {
+            // Deliberately does NOT clear `flush_pending`; the test controls
+            // when the store reports durable so the truncate gate is exercised.
+            self.inner.flush()
+        }
+        fn needs_flush(&self) -> bool {
+            self.flush_pending.load(AtomicOrdering::Acquire)
+        }
+    }
+
+    /// Regression for the nightly crash-soak durability bug: `maybe_truncate`
+    /// must NOT truncate the WAL while the store still owes a flush (data
+    /// fsync / manifest-delta persist), even though dirty/flushing/pending all
+    /// read 0. Truncating there drops the only recoverable copy of an
+    /// acknowledged write across a crash. (On the pre-fix gate this test
+    /// truncates immediately once the dirty blob is written through.)
+    #[test]
+    fn truncate_waits_for_store_flush() {
+        let store = Arc::new(FlushGateStore::new()); // needs_flush() == true
+        let bm = Arc::new(BufferManager::new(store.clone(), 8));
+
+        let dir = tempfile::tempdir().unwrap();
+        let journal = Arc::new(Journal::open_or_create(&dir.path().join("wal.log"), 0).unwrap());
+        journal.submit(vec![1, 2, 3, 4], false).unwrap(); // -> needs_checkpoint()
+        assert!(journal.needs_checkpoint());
+
+        bm.write_blob([0x55; 16], &test_blob([0x55; 16])).unwrap();
+        let _pin = bm.pin([0x55; 16]).unwrap();
+        bm.mark_dirty([0x55; 16], 1);
+
+        let ck = Checkpointer::spawn(
+            Arc::clone(&bm),
+            Some(Arc::clone(&journal)),
+            maintenance_gate(),
+            commit_gate(),
+            no_merge_cfg(),
+        )
+        .expect("spawn");
+
+        // Wait until the dirty blob is written through (dirty retired).
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if bm.dirty_count() == 0 && ck.blobs_flushed() >= 1 {
+                break;
+            }
+            assert!(Instant::now() < deadline, "checkpoint never drained dirty");
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        // dirty/flushing/pending are all 0 now, but the store still needs a
+        // flush — the WAL must stay intact across several truncate attempts.
+        thread::sleep(Duration::from_millis(60));
+        assert_eq!(
+            ck.truncates(),
+            0,
+            "WAL truncated while store flush was still pending"
+        );
+
+        // Once the store reports durable, truncate is allowed to proceed
+        // (no deadlock / unbounded WAL growth).
+        store.release_flush();
+        ck.wake();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if ck.truncates() >= 1 {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "WAL never truncated after the store flush completed"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        drop(ck);
+    }
+
     /// Tests that don't construct a real Tree skip the merge pass —
     /// `collect_blob_guids` would otherwise try to pin a
     /// non-existent root.

--- a/src/checkpoint/round.rs
+++ b/src/checkpoint/round.rs
@@ -153,9 +153,23 @@ impl Pipeline {
             return Ok(());
         }
         let _commit = shared.commit_gate.enter_checkpoint();
+        // The dirty/flushing/pending counters are BufferManager state and do
+        // NOT capture the store's own deferred durability: the I/O worker
+        // retires a dirty entry right after the data `pwrite` but BEFORE the
+        // data fsync + manifest-delta persist (`flush_inner`). So all three
+        // counters can read 0 while `store.needs_flush()` is still true —
+        // i.e. a just-written blob's new slot mapping is only in the in-memory
+        // manifest, not yet in `manifest.log`. Truncating the WAL there leaves
+        // a crashed reopen with the acked write in NEITHER the (truncated) WAL
+        // nor the (un-persisted) manifest — a lost acknowledged write. The
+        // SIGKILL crash soak hits exactly this (lazy routing keeps the root
+        // blob a perpetual compaction target, so it is re-written every round).
+        // `run_round`'s early-skip gates on the same `needs_flush()` for this
+        // recovery edge; mirror it here so truncate waits for store durability.
         if shared.bm.dirty_count() == 0
             && shared.bm.flushing_count() == 0
             && shared.bm.pending_delete_count() == 0
+            && !shared.bm.needs_flush()
         {
             journal.truncate()?;
             use std::sync::atomic::Ordering;

--- a/src/engine/walker/erase.rs
+++ b/src/engine/walker/erase.rs
@@ -111,7 +111,22 @@ pub fn erase_multi_conditional(
         };
         match root_lookup {
             (root_guid, LookupResult::Crossing(crossing)) => {
-                let child_pin = bm.pin(crossing.child_guid)?;
+                let child_pin = match bm.pin(crossing.child_guid) {
+                    Ok(pin) => pin,
+                    Err(e) if is_blob_store_not_found(&e) => {
+                        drop(root_read);
+                        return erase_from_root(
+                            bm,
+                            root_pin,
+                            key,
+                            seq,
+                            condition,
+                            &mut blob_hops,
+                            &mut max_cross_blob_depth,
+                        );
+                    }
+                    Err(e) => return Err(e),
+                };
                 // Copy-on-write: a shared root child must be forked by
                 // repointing the root's BlobNode, which needs the root's
                 // exclusive latch — bail to the root-local path below.
@@ -165,6 +180,26 @@ pub fn erase_multi_conditional(
         }
     }
 
+    erase_from_root(
+        bm,
+        root_pin,
+        key,
+        seq,
+        condition,
+        &mut blob_hops,
+        &mut max_cross_blob_depth,
+    )
+}
+
+fn erase_from_root(
+    bm: &BufferManager,
+    root_pin: &Arc<CachedBlob>,
+    key: SearchKey<'_>,
+    seq: u64,
+    condition: EraseCondition,
+    blob_hops: &mut u64,
+    max_cross_blob_depth: &mut usize,
+) -> Result<EraseOutcome> {
     let mut guard = root_pin.write();
     let root_guid = {
         let frame = guard.frame();
@@ -180,11 +215,11 @@ pub fn erase_multi_conditional(
         seq,
         condition,
         0,
-        &mut blob_hops,
-        &mut max_cross_blob_depth,
+        blob_hops,
+        max_cross_blob_depth,
     );
     if outcome.is_ok() {
-        bm.note_walker_blob_hops(blob_hops, max_cross_blob_depth);
+        bm.note_walker_blob_hops(*blob_hops, *max_cross_blob_depth);
     }
     outcome
 }

--- a/src/engine/walker/insert.rs
+++ b/src/engine/walker/insert.rs
@@ -125,75 +125,114 @@ pub fn insert_multi_conditional(
         return Ok(outcome);
     }
 
-    // Fast path for the large-tree steady state: the root blob is
-    // often just a router to child blobs. Hold the root in shared
-    // mode long enough to acquire the child write guard, then let
-    // the normal lock-coupled writer mutate from that child down.
-    // This preserves the parent->child edge-stability rule without
-    // making every cross-blob put take the root's exclusive latch.
-    {
-        let root_read = root_pin.read();
-        let root_version = root_pin.content_version();
-        let root_crossing = {
-            let frame = BlobFrameRef::wrap(root_read.as_slice());
-            let root_guid = frame.header().blob_guid;
-            let root_slot = frame.header().root_slot;
-            match lookup_at(frame, root_slot, key, 0)? {
-                LookupResult::Crossing(crossing) => Some((root_guid, crossing)),
-                LookupResult::Found(_) | LookupResult::NotFound => None,
-            }
-        };
-        if let Some((root_guid, crossing)) = root_crossing {
-            let child_pin = bm.pin(crossing.child_guid)?;
-            // Copy-on-write: if the root's child may be shared with a
-            // live snapshot, forking it requires repointing the root's
-            // own BlobNode, which needs the root's exclusive latch. Bail
-            // to the root-local exclusive path below, whose crossing arm
-            // performs the fork. No snapshot ⇒ barrier 0 ⇒ no probe.
-            let child_shared = child_is_snapshot_shared(bm, child_pin.as_ref());
-            if !child_shared {
-                if let Some(cache) = route_cache {
-                    cache.learn(
-                        key,
-                        root_guid,
-                        0,
-                        root_version,
-                        crossing.child_guid,
-                        crossing.child_depth,
-                    );
-                    bm.mark_route_resident(crossing.child_guid);
-                }
-                child_pin.prefetch_header();
-                let child_guard = child_pin.write();
-                drop(root_read);
-
-                blob_hops = 1;
-                let outcome = lock_coupled_insert_in_blob(
-                    bm,
-                    child_guard,
-                    child_pin.as_ref(),
-                    crossing.child_guid,
-                    false,
-                    key,
-                    value,
-                    seq,
-                    condition,
-                    crossing.child_depth,
-                    &mut blob_hops,
-                    &mut max_cross_blob_depth,
-                );
-                drop(child_pin);
-                if outcome.is_ok() {
-                    bm.note_walker_blob_hops(blob_hops, max_cross_blob_depth);
-                }
-                return outcome;
-            }
-            drop(child_pin);
-        }
-        drop(root_read);
+    if let Some(outcome) = try_insert_from_root_router(
+        bm,
+        root_pin,
+        route_cache,
+        key,
+        value,
+        seq,
+        condition,
+        &mut blob_hops,
+        &mut max_cross_blob_depth,
+    )? {
+        return Ok(outcome);
     }
 
-    // Root-local mutation fallback.
+    insert_multi_from_root(
+        bm,
+        root_pin,
+        key,
+        value,
+        seq,
+        condition,
+        &mut blob_hops,
+        &mut max_cross_blob_depth,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn try_insert_from_root_router(
+    bm: &BufferManager,
+    root_pin: &Arc<CachedBlob>,
+    route_cache: Option<&RouteCache>,
+    key: SearchKey<'_>,
+    value: &[u8],
+    seq: u64,
+    condition: InsertCondition,
+    blob_hops: &mut u64,
+    max_cross_blob_depth: &mut usize,
+) -> Result<Option<InsertOutcome>> {
+    let root_read = root_pin.read();
+    let root_version = root_pin.content_version();
+    let root_crossing = {
+        let frame = BlobFrameRef::wrap(root_read.as_slice());
+        let root_guid = frame.header().blob_guid;
+        let root_slot = frame.header().root_slot;
+        match lookup_at(frame, root_slot, key, 0)? {
+            LookupResult::Crossing(crossing) => Some((root_guid, crossing)),
+            LookupResult::Found(_) | LookupResult::NotFound => None,
+        }
+    };
+    let Some((root_guid, crossing)) = root_crossing else {
+        return Ok(None);
+    };
+    let child_pin = match bm.pin(crossing.child_guid) {
+        Ok(pin) => pin,
+        Err(e) if is_blob_store_not_found(&e) => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    if child_is_snapshot_shared(bm, child_pin.as_ref()) {
+        return Ok(None);
+    }
+    if let Some(cache) = route_cache {
+        cache.learn(
+            key,
+            root_guid,
+            0,
+            root_version,
+            crossing.child_guid,
+            crossing.child_depth,
+        );
+        bm.mark_route_resident(crossing.child_guid);
+    }
+    child_pin.prefetch_header();
+    let child_guard = child_pin.write();
+    drop(root_read);
+
+    *blob_hops = 1;
+    let outcome = lock_coupled_insert_in_blob(
+        bm,
+        child_guard,
+        child_pin.as_ref(),
+        crossing.child_guid,
+        false,
+        key,
+        value,
+        seq,
+        condition,
+        crossing.child_depth,
+        blob_hops,
+        max_cross_blob_depth,
+    );
+    drop(child_pin);
+    if outcome.is_ok() {
+        bm.note_walker_blob_hops(*blob_hops, *max_cross_blob_depth);
+    }
+    outcome.map(Some)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_multi_from_root(
+    bm: &BufferManager,
+    root_pin: &Arc<CachedBlob>,
+    key: SearchKey<'_>,
+    value: &[u8],
+    seq: u64,
+    condition: InsertCondition,
+    blob_hops: &mut u64,
+    max_cross_blob_depth: &mut usize,
+) -> Result<InsertOutcome> {
     let mut guard = root_pin.write();
     let root_guid = {
         let frame = guard.frame();
@@ -210,11 +249,11 @@ pub fn insert_multi_conditional(
         seq,
         condition,
         0,
-        &mut blob_hops,
-        &mut max_cross_blob_depth,
+        blob_hops,
+        max_cross_blob_depth,
     );
     if outcome.is_ok() {
-        bm.note_walker_blob_hops(blob_hops, max_cross_blob_depth);
+        bm.note_walker_blob_hops(*blob_hops, *max_cross_blob_depth);
     }
     outcome
 }
@@ -429,7 +468,14 @@ fn try_insert_batch_from_first_blob(
                 bm.mark_route_resident(crossing.child_guid);
             }
             let run_len = same_child_prefix_run_len(items, crossing.child_depth);
-            let child_pin = bm.pin(crossing.child_guid)?;
+            let child_pin = match bm.pin(crossing.child_guid) {
+                Ok(pin) => pin,
+                Err(e) if is_blob_store_not_found(&e) => {
+                    drop(root_read);
+                    return insert_batch_from_root(bm, root_pin, items);
+                }
+                Err(e) => return Err(e),
+            };
             child_pin.prefetch_header();
             let child_guard = child_pin.write();
             drop(root_read);
@@ -450,6 +496,14 @@ fn try_insert_batch_from_first_blob(
         drop(root_read);
     }
 
+    insert_batch_from_root(bm, root_pin, items)
+}
+
+fn insert_batch_from_root(
+    bm: &BufferManager,
+    root_pin: &Arc<CachedBlob>,
+    items: &[InsertBatchItem<'_>],
+) -> Result<InsertBatchOutcome> {
     let mut guard = root_pin.write();
     let root_guid = {
         let frame = guard.frame();

--- a/src/engine/walker/range.rs
+++ b/src/engine/walker/range.rs
@@ -359,6 +359,7 @@ pub struct RangeBuilder {
     maintenance_gate: Arc<Gate>,
     mutation_gate: Option<Arc<Gate>>,
     dropped: Option<Arc<AtomicBool>>,
+    snapshot_cursor: bool,
     prefix: KeyBuf,
     start_after: Option<KeyBuf>,
     delimiter: Option<u8>,
@@ -382,6 +383,7 @@ impl RangeBuilder {
             maintenance_gate,
             mutation_gate: None,
             dropped: None,
+            snapshot_cursor: false,
             prefix: KeyBuf::new(),
             start_after: None,
             delimiter: None,
@@ -395,6 +397,11 @@ impl RangeBuilder {
 
     pub(crate) fn with_mutation_gate(mut self, mutation_gate: Arc<Gate>) -> Self {
         self.mutation_gate = Some(mutation_gate);
+        self
+    }
+
+    pub(crate) fn snapshot_cursor(mut self) -> Self {
+        self.snapshot_cursor = true;
         self
     }
 
@@ -454,6 +461,7 @@ impl RangeBuilder {
             maintenance_gate: self.maintenance_gate,
             mutation_gate: self.mutation_gate,
             dropped: self.dropped,
+            snapshot_cursor: self.snapshot_cursor,
             stack: Vec::with_capacity(8),
             curr_key: Vec::with_capacity(self.prefix.len().saturating_add(64)),
             emit_buf: Vec::with_capacity(self.prefix.len().saturating_add(64)),
@@ -708,6 +716,7 @@ pub struct RangeIter {
     maintenance_gate: Arc<Gate>,
     mutation_gate: Option<Arc<Gate>>,
     dropped: Option<Arc<AtomicBool>>,
+    snapshot_cursor: bool,
     /// Descent stack. Empty = no init done (if `!initialized`) or
     /// exhausted (if `terminated`).
     stack: Vec<Frame>,
@@ -1317,7 +1326,7 @@ impl RangeIter {
                         let is_candidate = {
                             let top = &self.stack[idx];
                             let guard = top.pin.read();
-                            if top.pin.content_version() != top.version {
+                            if !self.frame_content_still_valid(top) {
                                 return Ok(InitResult::Restart);
                             }
                             let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1350,7 +1359,7 @@ impl RangeIter {
                         let top = &self.stack[idx];
                         let guard = top_pin.read();
                         let version = top_pin.content_version();
-                        if version != top.version {
+                        if !self.frame_version_still_valid(top, version) {
                             return Ok(InitResult::Restart);
                         }
                         let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1399,7 +1408,7 @@ impl RangeIter {
                         let top = &self.stack[idx];
                         let guard = top.pin.read();
                         let version = top.pin.content_version();
-                        if version != top.version {
+                        if !self.frame_version_still_valid(top, version) {
                             return Ok(InitResult::Restart);
                         }
                         let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1428,7 +1437,7 @@ impl RangeIter {
                             }
                             self.stack[idx].next = 1;
                             if !self.push_in_other_blob(child_guid, p_bytes.as_slice())? {
-                                return Ok(InitResult::Restart);
+                                self.pop_frame();
                             }
                         }
                     }
@@ -1454,7 +1463,7 @@ impl RangeIter {
                         let top = &self.stack[idx];
                         let guard = top_pin.read();
                         let version = top_pin.content_version();
-                        if version != top.version {
+                        if !self.frame_version_still_valid(top, version) {
                             return Ok(InitResult::Restart);
                         }
                         let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1512,7 +1521,7 @@ impl RangeIter {
                         let kv = {
                             let top = &self.stack[idx];
                             let guard = top.pin.read();
-                            if top.pin.content_version() != top.version {
+                            if !self.frame_content_still_valid(top) {
                                 return Ok(RangeAdvance::Restart);
                             }
                             let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1651,7 +1660,7 @@ impl RangeIter {
                             let top = &self.stack[idx];
                             let guard = top_pin.read();
                             let version = top_pin.content_version();
-                            if version != top.version {
+                            if !self.frame_version_still_valid(top, version) {
                                 return Ok(RangeAdvance::Restart);
                             }
                             let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1699,7 +1708,7 @@ impl RangeIter {
                             let top = &self.stack[idx];
                             let guard = top.pin.read();
                             let version = top.pin.content_version();
-                            if version != top.version {
+                            if !self.frame_version_still_valid(top, version) {
                                 return Ok(RangeAdvance::Restart);
                             }
                             let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1714,8 +1723,9 @@ impl RangeIter {
                             )
                         };
                         self.stack[idx].next = 1;
-                        let Some(child_pin) = self.pin_scan_or_restart(child_guid)? else {
-                            return Ok(RangeAdvance::Restart);
+                        let Some(child_pin) = self.pin_scan_child(child_guid)? else {
+                            self.pop_frame();
+                            continue;
                         };
                         child_pin.prefetch_header();
                         let child_can_rollup = {
@@ -1751,7 +1761,7 @@ impl RangeIter {
                         let top = &self.stack[idx];
                         let guard = top_pin.read();
                         let version = top_pin.content_version();
-                        if version != top.version {
+                        if !self.frame_version_still_valid(top, version) {
                             return Ok(RangeAdvance::Restart);
                         }
                         let frame = BlobFrameRef::wrap(guard.as_slice());
@@ -1779,18 +1789,20 @@ impl RangeIter {
                                 // drained, collect the upcoming child-blob guids
                                 // from this (cached) parent so they can be pinned
                                 // concurrently (device queue depth) below.
-                                let prefetch_guids =
-                                    if child_ntype == NodeType::Blob && self.prefetch.is_empty() {
-                                        collect_blob_child_window(
-                                            frame,
-                                            top.off,
-                                            top_ntype,
-                                            child_off,
-                                            next_cursor,
-                                        )
-                                    } else {
-                                        Vec::new()
-                                    };
+                                let prefetch_guids = if !self.snapshot_cursor
+                                    && child_ntype == NodeType::Blob
+                                    && self.prefetch.is_empty()
+                                {
+                                    collect_blob_child_window(
+                                        frame,
+                                        top.off,
+                                        top_ntype,
+                                        child_off,
+                                        next_cursor,
+                                    )
+                                } else {
+                                    Vec::new()
+                                };
                                 Some((
                                     byte,
                                     child_off,
@@ -1865,7 +1877,7 @@ impl RangeIter {
     }
 
     fn push_in_other_blob(&mut self, child_guid: BlobGuid, prefix_bytes: &[u8]) -> Result<bool> {
-        let Some(child_pin) = self.pin_scan_or_restart(child_guid)? else {
+        let Some(child_pin) = self.pin_scan_child(child_guid)? else {
             return Ok(false);
         };
         child_pin.prefetch_header();
@@ -1873,7 +1885,7 @@ impl RangeIter {
         Ok(true)
     }
 
-    fn pin_scan_or_restart(&mut self, child_guid: BlobGuid) -> Result<Option<Arc<CachedBlob>>> {
+    fn pin_scan_child(&mut self, child_guid: BlobGuid) -> Result<Option<Arc<CachedBlob>>> {
         // Consume a read-ahead pin if one was warmed for this child.
         if let Some(pin) = self.prefetch.remove(&child_guid) {
             return Ok(Some(pin));
@@ -1912,9 +1924,20 @@ impl RangeIter {
     }
 
     fn path_is_still_valid(&self) -> bool {
+        if self.snapshot_cursor {
+            return true;
+        }
         self.stack
             .iter()
             .all(|frame| frame.pin.validate_content_version(frame.version))
+    }
+
+    fn frame_content_still_valid(&self, frame: &Frame) -> bool {
+        self.snapshot_cursor || frame.pin.content_version() == frame.version
+    }
+
+    fn frame_version_still_valid(&self, frame: &Frame, current_version: u64) -> bool {
+        self.snapshot_cursor || current_version == frame.version
     }
 
     fn restart_cursor(&mut self) {

--- a/tests/scan_contention_diag.rs
+++ b/tests/scan_contention_diag.rs
@@ -1,0 +1,126 @@
+//! Diagnostic + regression: range scans must make progress under
+//! concurrent writes. The optimistic cursor restarts whenever a writer
+//! rewrites a blob on its descent path; without a bounded fallback that
+//! fences the churn, a long scan can spin forever (the nightly db-normal
+//! soak hung 45 min in `RangeIter::pin_scan_or_restart`). An in-test
+//! watchdog fails the test instead of hanging the suite if the
+//! regression returns.
+
+use holt::{Durability, Tree, TreeConfig};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
+
+/// Soak-shaped key: spreads across 256 buckets so keys do not pack
+/// pathologically into a single blob frame's slot table.
+fn k(idx: u64) -> Vec<u8> {
+    format!(
+        "bucket-{:03}/tenant-{:02}/path/object-{:010}.bin",
+        idx % 256,
+        idx % 32,
+        idx
+    )
+    .into_bytes()
+}
+
+const SEED: u64 = 60_000;
+const PREFIX: &[u8] = b"bucket-";
+
+fn seeded() -> (tempfile::TempDir, Arc<Tree>) {
+    let dir = tempfile::tempdir().unwrap();
+    let mut cfg = TreeConfig::new(dir.path());
+    cfg.durability = Durability::Wal { sync: false };
+    cfg.buffer_pool_size = 2048;
+    let tree = Arc::new(Tree::open(cfg).unwrap());
+    for i in 0..SEED {
+        tree.put(&k(i), b"v").unwrap();
+    }
+    (dir, tree)
+}
+
+fn spawn_writers(
+    tree: &Arc<Tree>,
+    stop: &Arc<AtomicBool>,
+    n: usize,
+) -> Vec<thread::JoinHandle<()>> {
+    (0..n)
+        .map(|w| {
+            let tree = Arc::clone(tree);
+            let stop = Arc::clone(stop);
+            thread::spawn(move || {
+                let mut i = 0u64;
+                while !stop.load(Ordering::Relaxed) {
+                    // Atomic batch = exclusive `enter_batch`, matching the
+                    // db-normal soak's write path (db.atomic).
+                    let _ = tree.atomic(|b| b.put(&k(w as u64 * 9_000_000 + i), b"v"));
+                    i += 1;
+                }
+            })
+        })
+        .collect()
+}
+
+/// Run `scan` on a worker thread; fail (don't hang) if it stalls.
+fn with_watchdog<F: FnOnce() + Send + 'static>(label: &'static str, scan: F) {
+    let (tx, rx) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        scan();
+        let _ = tx.send(());
+    });
+    if rx.recv_timeout(Duration::from_secs(25)).is_err() {
+        panic!("{label}: scans made no progress within 25s — livelock");
+    }
+    worker.join().unwrap();
+}
+
+#[test]
+fn live_scan_progresses_under_writes() {
+    let (_dir, tree) = seeded();
+    let stop = Arc::new(AtomicBool::new(false));
+    let writers = spawn_writers(&tree, &stop, 4);
+    let t = Arc::clone(&tree);
+    with_watchdog("live", move || {
+        for _ in 0..20 {
+            let mut n = 0u64;
+            t.scan_keys(PREFIX)
+                .visit(usize::MAX, |_| {
+                    n += 1;
+                    Ok(())
+                })
+                .unwrap();
+            assert!(n > 0, "live scan returned nothing");
+        }
+    });
+    stop.store(true, Ordering::Relaxed);
+    for h in writers {
+        h.join().unwrap();
+    }
+}
+
+#[test]
+fn view_scan_progresses_under_writes() {
+    let (_dir, tree) = seeded();
+    let stop = Arc::new(AtomicBool::new(false));
+    let writers = spawn_writers(&tree, &stop, 4);
+    let t = Arc::clone(&tree);
+    with_watchdog("view", move || {
+        for _ in 0..20 {
+            let n: u64 = t
+                .view(PREFIX, |v| {
+                    let mut n = 0u64;
+                    v.scan_keys(PREFIX)?.visit(usize::MAX, |_| {
+                        n += 1;
+                        Ok(())
+                    })?;
+                    Ok(n)
+                })
+                .unwrap();
+            assert!(n > 0, "view scan returned nothing");
+        }
+    });
+    stop.store(true, Ordering::Relaxed);
+    for h in writers {
+        h.join().unwrap();
+    }
+}

--- a/tests/wal_torn_tail_recovery.rs
+++ b/tests/wal_torn_tail_recovery.rs
@@ -1,0 +1,59 @@
+//! Regression: a torn WAL tail (crash mid-write) must be physically
+//! truncated on reopen. Otherwise the next session's `O_APPEND` writes a good
+//! record *after* the torn bytes, turning them into a MID-log torn record; a
+//! later replay's torn-tail `break` stops there and silently strands every
+//! acked record written after it.
+
+use holt::{Durability, Tree, TreeConfig};
+
+fn cfg(dir: &std::path::Path) -> TreeConfig {
+    let mut c = TreeConfig::new(dir);
+    c.durability = Durability::Wal { sync: true };
+    // Disable the checkpointer so the WAL is never truncated out from under
+    // us — we want the torn tail to survive into the next session.
+    c.checkpoint.enabled = false;
+    c
+}
+
+#[test]
+fn torn_tail_reopen_does_not_strand_later_appends() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Session 1: two complete, durable records.
+    {
+        let t = Tree::open(cfg(dir.path())).unwrap();
+        t.put(b"a", b"1").unwrap();
+        t.put(b"b", b"2").unwrap();
+    }
+
+    // Simulate a crash mid-write: lop the CRC off the last record so it
+    // decodes as a torn tail ("record body truncated"), leaving "a" intact.
+    let wal = cfg(dir.path()).wal_path().expect("file-backed WAL");
+    let len = std::fs::metadata(&wal).unwrap().len();
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&wal)
+        .unwrap()
+        .set_len(len - 4)
+        .unwrap();
+
+    // Session 2: reopen (the fix truncates the torn tail), then append.
+    {
+        let t = Tree::open(cfg(dir.path())).unwrap();
+        assert_eq!(t.get(b"a").unwrap().as_deref(), Some(&b"1"[..]));
+        t.put(b"c", b"3").unwrap();
+    }
+
+    // Session 3: reopen again. With the torn tail dropped in session 2, "c"
+    // sits cleanly after "a"; without it, "c" was appended behind a mid-log
+    // torn record and is lost (or the log fails to replay).
+    {
+        let t = Tree::open(cfg(dir.path())).unwrap();
+        assert_eq!(t.get(b"a").unwrap().as_deref(), Some(&b"1"[..]));
+        assert_eq!(
+            t.get(b"c").unwrap().as_deref(),
+            Some(&b"3"[..]),
+            "append after a torn-tail reopen was stranded behind a mid-log torn record",
+        );
+    }
+}

--- a/tests/write_delete_churn.rs
+++ b/tests/write_delete_churn.rs
@@ -1,0 +1,94 @@
+//! Regression: writes must not fail with `blob ... is pending delete`
+//! (and must not hang) while concurrent delete churn drives merges that
+//! de-route blobs. The merge pass marks a folded-away child for deferred
+//! delete; if a concurrent write follows a stale route to that child it
+//! surfaced the deferred-delete sentinel as a hard error instead of
+//! restarting its descent (nightly db-normal soak). An out-of-thread
+//! watchdog turns a hang into a test failure instead of a stuck suite.
+
+use holt::{Durability, Tree, TreeConfig};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+fn k(idx: u64) -> Vec<u8> {
+    format!(
+        "bucket-{:03}/tenant-{:02}/path/object-{:010}.bin",
+        idx % 256,
+        idx % 32,
+        idx
+    )
+    .into_bytes()
+}
+
+const N: u64 = 40_000;
+
+fn run_churn() -> Result<u64, String> {
+    let dir = tempfile::tempdir().unwrap();
+    let mut cfg = TreeConfig::new(dir.path());
+    cfg.durability = Durability::Wal { sync: false };
+    // Small pool → eviction + the cold-read route cache are engaged, and
+    // delete churn keeps the merge pass de-routing blobs.
+    cfg.buffer_pool_size = 128;
+    let tree = Arc::new(Tree::open(cfg).map_err(|e| format!("open: {e}"))?);
+    for i in 0..N {
+        tree.put(&k(i), b"v").map_err(|e| format!("seed: {e}"))?;
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let ops = Arc::new(AtomicU64::new(0));
+    let failure: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let mut handles = Vec::new();
+    for w in 0..8u64 {
+        let tree = Arc::clone(&tree);
+        let stop = Arc::clone(&stop);
+        let ops = Arc::clone(&ops);
+        let failure = Arc::clone(&failure);
+        handles.push(thread::spawn(move || {
+            let mut i = w;
+            while !stop.load(Ordering::Relaxed) {
+                // Churn the seeded range so blobs empty and refill, which
+                // makes them merge candidates (→ de-route → mark_for_delete).
+                let key = k(i % N);
+                let r = if (i / N) % 2 == 0 {
+                    tree.atomic(|b| b.delete(&key))
+                } else {
+                    tree.atomic(|b| b.put(&key, b"v"))
+                };
+                if let Err(e) = r {
+                    *failure.lock().unwrap() = Some(format!("{e}"));
+                    stop.store(true, Ordering::Relaxed);
+                    return;
+                }
+                ops.fetch_add(1, Ordering::Relaxed);
+                i += 8;
+            }
+        }));
+    }
+
+    thread::sleep(Duration::from_secs(15));
+    stop.store(true, Ordering::Relaxed);
+    // A livelocked worker stuck inside an op never observes `stop`; its
+    // join hangs and the out-of-thread watchdog fails the test.
+    for h in handles {
+        h.join().unwrap();
+    }
+    if let Some(e) = failure.lock().unwrap().take() {
+        return Err(e);
+    }
+    Ok(ops.load(Ordering::Relaxed))
+}
+
+#[test]
+fn writes_progress_under_delete_churn() {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(run_churn());
+    });
+    match rx.recv_timeout(Duration::from_secs(50)) {
+        Ok(Ok(ops)) => assert!(ops > 5_000, "writes stalled under churn: only {ops} ops"),
+        Ok(Err(e)) => panic!("write failed under delete churn: {e}"),
+        Err(_) => panic!("write/delete churn hung (a worker never completed)"),
+    }
+}


### PR DESCRIPTION
## Summary

- fix WAL torn-tail reopen so later appends are not stranded behind torn bytes
- delay WAL truncation until blob store flush/manifest durability is complete
- fix DB/view scan progress under concurrent atomic writes and pending-delete churn
- extend stress benchmarks with cold/hot eval helpers, LMDB comparator, cold-read controls, and paper/usage docs
- add regression tests for scan contention, torn WAL tail recovery, and write/delete churn

## Root Cause

Nightly exposed two related classes of failures:

- crash soak could truncate WAL after dirty bookkeeping retired but before the store had durably flushed blob data and manifest state
- DB normal soak could livelock or surface `blob ... is pending delete` when scans/writes followed stale child blob routes during delete/merge churn

## Validation

- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --manifest-path tools/soak/Cargo.toml --locked -- -D warnings`
- `cargo run --manifest-path tools/soak/Cargo.toml --locked -- --mode db-normal --dir target/holt-soak-db-codex-short --reset --duration-secs 60 --keys 100000 --ops 200000 --threads 8 --buffer-pool 128 --wal-sync false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added LMDB support to benchmark comparisons
  * Enhanced snapshot capture with unfenced variant option
  * Improved cold/hot regime evaluation benchmarking infrastructure

* **Bug Fixes**
  * Fixed WAL torn tail recovery to prevent data loss on reopened sessions
  * Corrected flush synchronization in checkpoint operations
  * Enhanced range scan forward progress under concurrent writes

* **Documentation**
  * Added comprehensive evaluation methodology documentation
  * Published benchmark results analysis and findings
  * Added engine architecture and design blog post

* **Tests**
  * Added regression tests for WAL recovery scenarios
  * Added concurrent scan contention tests
  * Added write/delete stress tests with buffer pool constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->