### PR TITLE
[codex] bound DB normal nightly soak

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -177,15 +177,18 @@ jobs:
 
       - name: holt-soak db-normal
         run: |
+          # DB normal does a full oracle verification across every named
+          # tree after reopen. Keep this bounded on hosted runners; the
+          # long DB durability coverage lives in the DB crash soak above.
           cargo run --manifest-path tools/soak/Cargo.toml --locked -- \
             --mode db-normal \
             --dir target/holt-soak-db-nightly \
             --reset \
             --duration-secs "$SOAK_SECONDS" \
-            --keys 500000 \
-            --ops 1000000 \
-            --threads 8 \
-            --buffer-pool 128 \
+            --keys 20000 \
+            --ops 50000 \
+            --threads 4 \
+            --buffer-pool 64 \
             --wal-sync false
 
   fuzz-long:


### PR DESCRIPTION
## Summary

- bound the nightly `DB normal soak` job to a hosted-runner-sized DB regression
- keep multi-tree atomic/view/reopen coverage while leaving long durability coverage to `DB crash soak`
- document why this job should stay smaller than the crash soak

## Root Cause

The nightly `DB normal soak` job used `500k keys / 1M ops / 8 threads` and then performed a full oracle verification across every named tree after reopen. On GitHub hosted runners this job has either timed out around the 45 minute job limit or been canceled by the runner shortly after start. The logs did not show a Holt panic or oracle mismatch.

## Validation

- `cargo run --manifest-path tools/soak/Cargo.toml --locked -- --mode db-normal --dir target/holt-soak-db-nightly-local --reset --duration-secs 600 --keys 20000 --ops 50000 --threads 4 --buffer-pool 64 --wal-sync false`
- `cargo test --test tree_smoke db_ --all-features --locked`
- `cargo test --test wal_tree_integration db_ --all-features --locked`
- `git diff --check`
