### PR TITLE
Fix spillover reclaim on hot update churn

### DIFF
--- a/src/engine/walker/insert.rs
+++ b/src/engine/walker/insert.rs
@@ -23,7 +23,7 @@ use super::MAX_SPILLOVER_ATTEMPTS;
 use crate::engine::RouteCache;
 use crate::store::BlobWriteGuard;
 use crate::store::{decode_child_off, encode_child_off};
-use crate::store::{BlobFrame, BlobFrameRef, BufferManager, CachedBlob};
+use crate::store::{AllocError, BlobFrame, BlobFrameRef, BufferManager, CachedBlob};
 
 // ---------- public entry points ----------
 
@@ -751,6 +751,79 @@ enum InsertStep {
     Crossing(InsertBlobCrossing),
 }
 
+#[derive(Debug, Clone, Copy)]
+enum InsertAllocMiss {
+    Space,
+    Slots,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReclaimSnapshot {
+    num_slots: u16,
+    space_used: u32,
+    dead_bytes: u32,
+    tombstone_leaf_cnt: u32,
+}
+
+fn reclaim_snapshot(guard: &mut BlobWriteGuard<'_>) -> ReclaimSnapshot {
+    let frame = guard.frame();
+    let h = frame.header();
+    ReclaimSnapshot {
+        num_slots: h.num_slots,
+        space_used: h.space_used,
+        dead_bytes: h.dead_bytes,
+        tombstone_leaf_cnt: h.tombstone_leaf_cnt,
+    }
+}
+
+fn compact_made_retry_worthwhile(
+    miss: InsertAllocMiss,
+    before: ReclaimSnapshot,
+    after: ReclaimSnapshot,
+) -> bool {
+    match miss {
+        InsertAllocMiss::Space => {
+            after.space_used < before.space_used
+                || after.dead_bytes < before.dead_bytes
+                || after.tombstone_leaf_cnt < before.tombstone_leaf_cnt
+        }
+        InsertAllocMiss::Slots => after.num_slots < before.num_slots,
+    }
+}
+
+fn should_compact_before_spillover(miss: InsertAllocMiss, before: ReclaimSnapshot) -> bool {
+    match miss {
+        InsertAllocMiss::Space => before.dead_bytes != 0 || before.tombstone_leaf_cnt != 0,
+        InsertAllocMiss::Slots => true,
+    }
+}
+
+fn reclaim_or_spillover(
+    bm: &BufferManager,
+    guard: &mut BlobWriteGuard<'_>,
+    current_guid: crate::layout::BlobGuid,
+    seq: u64,
+    miss: InsertAllocMiss,
+) -> Result<()> {
+    let before = reclaim_snapshot(guard);
+    if should_compact_before_spillover(miss, before) {
+        compact_blob(guard).map_err(|e| e.with_blob_guid(current_guid))?;
+        let after = reclaim_snapshot(guard);
+        if compact_made_retry_worthwhile(miss, before, after) {
+            return Ok(());
+        }
+    }
+
+    {
+        let mut frame = guard.frame();
+        spillover_blob(bm, &mut frame, seq).map_err(|e| e.with_blob_guid(current_guid))?;
+    }
+    bm.note_merge_candidate(current_guid);
+    bm.note_spillover();
+    compact_blob(guard).map_err(|e| e.with_blob_guid(current_guid))?;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)] // hot-path helper mirrors insert_at's call shape
 fn lock_coupled_insert_in_blob(
     bm: &BufferManager,
@@ -780,25 +853,25 @@ fn lock_coupled_insert_in_blob(
         };
         match r {
             Ok(InsertStep::Done(out)) => {
-                let needs_compaction = {
+                let (blob_dirty, needs_compaction) = {
                     let mut frame = guard.frame();
                     if out.mutated {
                         frame.header_mut().root_slot = encode_child_off(out.off_after);
-                        blob_needs_compaction(frame.as_ref())
+                        (true, blob_needs_compaction(frame.as_ref()))
                     } else {
-                        false
+                        (current_dirty, false)
                     }
                 };
                 drop(guard);
                 if needs_compaction {
                     bm.note_compaction_candidate(current_guid);
                 }
-                if out.mutated && !is_top_blob {
+                if blob_dirty && !is_top_blob {
                     bm.mark_dirty_cached(current_guid, seq, current_entry);
                 }
 
                 return Ok(InsertOutcome {
-                    root_dirty: is_top_blob && out.mutated,
+                    root_dirty: is_top_blob && blob_dirty,
                     mutated: out.mutated,
                 });
             }
@@ -819,41 +892,13 @@ fn lock_coupled_insert_in_blob(
                     max_cross_blob_depth,
                 );
             }
-            Err(Error::Alloc(crate::store::AllocError::OutOfSpace { .. })) => {
-                {
-                    let mut frame = guard.frame();
-                    spillover_blob(bm, &mut frame, seq)
-                        .map_err(|e| e.with_blob_guid(current_guid))?;
-                }
-                bm.note_merge_candidate(current_guid);
-                bm.note_spillover();
-                compact_blob(&mut guard).map_err(|e| e.with_blob_guid(current_guid))?;
+            Err(Error::Alloc(AllocError::OutOfSpace { .. })) => {
+                reclaim_or_spillover(bm, &mut guard, current_guid, seq, InsertAllocMiss::Space)?;
                 current_dirty = true;
             }
-            Err(Error::Alloc(crate::store::AllocError::OutOfSlots)) => {
-                // The slot table filled. Structural ops abandon old nodes
-                // (offset-addressing R1 = abandon-on-free); those dead
-                // slots are reclaimed only by compaction, and under
-                // concurrent write pressure the *background* compactor
-                // can be starved of this blob's exclusive latch — so
-                // reclaim inline here, where we already hold it. If
-                // compaction frees slots the retry proceeds; only if the
-                // blob is genuinely full of *live* nodes do we spill a
-                // subtree out (now with post-compaction slot headroom for
-                // the spillover BlobNode).
-                let before = guard.frame().header().num_slots;
-                compact_blob(&mut guard).map_err(|e| e.with_blob_guid(current_guid))?;
+            Err(Error::Alloc(AllocError::OutOfSlots)) => {
+                reclaim_or_spillover(bm, &mut guard, current_guid, seq, InsertAllocMiss::Slots)?;
                 current_dirty = true;
-                if guard.frame().header().num_slots >= before {
-                    {
-                        let mut frame = guard.frame();
-                        spillover_blob(bm, &mut frame, seq)
-                            .map_err(|e| e.with_blob_guid(current_guid))?;
-                    }
-                    bm.note_merge_candidate(current_guid);
-                    bm.note_spillover();
-                    compact_blob(&mut guard).map_err(|e| e.with_blob_guid(current_guid))?;
-                }
             }
             Err(e) => return Err(e.with_blob_guid(current_guid)),
         }

--- a/tests/tree_smoke.rs
+++ b/tests/tree_smoke.rs
@@ -1581,6 +1581,25 @@ fn atomic_insert_run_handles_blob_spillover() {
 }
 
 #[test]
+fn large_same_key_update_churn_compacts_before_spillover() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+    let key = b"registry/hot/object";
+    let mut value = vec![0u8; 32 * 1024];
+
+    for rev in 0..48u8 {
+        value.fill(rev);
+        tree.put(key, &value).unwrap();
+    }
+
+    assert_eq!(tree.get(key).unwrap().as_deref(), Some(&value[..]));
+    assert_eq!(
+        tree.stats().unwrap().blob_count,
+        1,
+        "same-key churn should reclaim local dead bytes instead of spilling"
+    );
+}
+
+#[test]
 fn is_prefix_empty_tracks_live_keys() {
     let tree = Tree::open(TreeConfig::memory()).unwrap();
     assert!(tree.is_prefix_empty(b"dir/").unwrap());

--- a/tests/wal_tree_integration.rs
+++ b/tests/wal_tree_integration.rs
@@ -1196,6 +1196,148 @@ fn spillover_new_blobs_deferred_to_store_until_checkpoint() {
 }
 
 #[test]
+fn k8s_shaped_hot_prefix_updates_do_not_expose_spillover_gap() {
+    let dir = tempdir().unwrap();
+    let mut cfg = TreeConfig::new(dir.path());
+    cfg.durability = Durability::Wal { sync: false };
+    let tree = Tree::open(cfg).unwrap();
+
+    let prefixes = [
+        "/registry/p0",
+        "/registry/p1",
+        "/registry/p2",
+        "/registry/p3",
+        "/registry/p4",
+        "/registry/p5",
+        "/registry/p6",
+        "/registry/p7",
+    ];
+    let mut value = vec![0u8; 24 * 1024];
+
+    for i in 0..768u64 {
+        let prefix = prefixes[(i as usize) % prefixes.len()];
+        let obj = i / prefixes.len() as u64;
+        value.fill((i & 0xff) as u8);
+        put_k8s_update(&tree, prefix, obj, i + 1, &value);
+    }
+
+    tree.checkpoint().unwrap();
+
+    for round in 0..64u64 {
+        assert!(tree
+            .atomic(|batch| {
+                for slot in 0..16u64 {
+                    let prefix = prefixes[((round + slot) as usize) % prefixes.len()];
+                    let obj = (round * 16 + slot) % 128;
+                    let rev = round * 16 + slot + 1024;
+                    value.fill((rev & 0xff) as u8);
+                    let object_key = format!("{prefix}/objects/{obj:08}");
+                    let head_key = format!("{prefix}/heads/{obj:08}");
+                    let event_key = format!("{prefix}/watch/{rev:012}");
+                    let head_value = format!("rev={rev};object={object_key}");
+                    batch.put(object_key.as_bytes(), &value);
+                    batch.put(head_key.as_bytes(), head_value.as_bytes());
+                    batch.put(event_key.as_bytes(), object_key.as_bytes());
+                }
+            })
+            .unwrap());
+    }
+
+    for prefix in prefixes {
+        for obj in 0..8u64 {
+            let head_key = format!("{prefix}/heads/{obj:08}");
+            assert!(tree.get(head_key.as_bytes()).unwrap().is_some());
+        }
+    }
+}
+
+fn put_k8s_update(tree: &Tree, prefix: &str, obj: u64, rev: u64, value: &[u8]) {
+    assert!(tree
+        .atomic(|batch| {
+            let object_key = format!("{prefix}/objects/{obj:08}");
+            let head_key = format!("{prefix}/heads/{obj:08}");
+            let event_key = format!("{prefix}/watch/{rev:012}");
+            let head_value = format!("rev={rev};object={object_key}");
+            batch.put(object_key.as_bytes(), value);
+            batch.put(head_key.as_bytes(), head_value.as_bytes());
+            batch.put(event_key.as_bytes(), object_key.as_bytes());
+        })
+        .unwrap());
+}
+
+#[test]
+#[ignore = "heavy issue #23 reproducer; run explicitly in release mode"]
+fn issue_23_k8s_shaped_spillover_reproducer() {
+    let dir = tempdir().unwrap();
+    let mut cfg = TreeConfig::new(dir.path());
+    cfg.durability = Durability::Wal { sync: false };
+    let tree = Arc::new(Tree::open(cfg).unwrap());
+    let prefixes = [
+        "/registry/p0",
+        "/registry/p1",
+        "/registry/p2",
+        "/registry/p3",
+        "/registry/p4",
+        "/registry/p5",
+        "/registry/p6",
+        "/registry/p7",
+    ];
+
+    for i in 0..20_000u64 {
+        let prefix = prefixes[(i as usize) % prefixes.len()];
+        let obj = i / prefixes.len() as u64;
+        let mut value = vec![0u8; issue_23_value_len(i)];
+        value.fill((i & 0xff) as u8);
+        put_k8s_update(&tree, prefix, obj, i + 1, &value);
+    }
+
+    tree.checkpoint().unwrap();
+
+    let barrier = Arc::new(Barrier::new(5));
+    let mut handles = Vec::new();
+    for worker in 0..4u64 {
+        let tree = Arc::clone(&tree);
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            for round in 0..128u64 {
+                let base = 20_000 + worker * 128 * 16 + round * 16;
+                assert!(tree
+                    .atomic(|batch| {
+                        for slot in 0..16u64 {
+                            let rev = base + slot + 1;
+                            let prefix = prefixes[((rev + worker) as usize) % prefixes.len()];
+                            let obj = rev % 2_500;
+                            let mut value = vec![0u8; issue_23_value_len(rev)];
+                            value.fill((rev & 0xff) as u8);
+                            let object_key = format!("{prefix}/objects/{obj:08}");
+                            let head_key = format!("{prefix}/heads/{obj:08}");
+                            let event_key = format!("{prefix}/watch/{rev:012}");
+                            let head_value = format!("rev={rev};object={object_key}");
+                            batch.put(object_key.as_bytes(), &value);
+                            batch.put(head_key.as_bytes(), head_value.as_bytes());
+                            batch.put(event_key.as_bytes(), object_key.as_bytes());
+                        }
+                    })
+                    .unwrap());
+            }
+        }));
+    }
+    barrier.wait();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    tree.checkpoint().unwrap();
+    let stats = tree.stats().unwrap();
+    assert!(stats.blob_count > 1);
+}
+
+fn issue_23_value_len(seed: u64) -> usize {
+    20 * 1024 + ((seed as usize * 7919) % (20 * 1024 + 1))
+}
+
+#[test]
 fn compact_does_not_leak_pre_wal_state_to_store() {
     // Regression test: `Tree::compact` used to call
     // `bm.commit(*guid)` for every touched blob, which pushes


### PR DESCRIPTION
## Summary

Fixes the insert/spillover failure behind issue #23 where hot update churn could surface:

```text
spillover: no non-Blob subtree to migrate
```

The root cause was that the insert walker treated every `OutOfSpace` allocation miss as a true live-full blob and immediately tried spillover. For metadata-shaped hot prefixes, the blob can instead be full of reclaimable dead bytes or tombstoned leaves. In that case spillover may have no valid non-Blob subtree left to migrate, so the correct first action is local reclaim/compaction.

## Changes

- Split allocation misses into `Space` and `Slots` so the retry policy can distinguish byte pressure from slot-table pressure.
- Compact before spillover only when the blob header shows reclaimable debt (`dead_bytes` / tombstones), preserving spillover-first behavior for genuinely live-full blobs.
- Keep `OutOfSlots` compaction-first, then spill only if compaction cannot free slots.
- Propagate physical blob dirtiness after reclaim/spillover even when the final logical retry is a no-op.
- Add focused same-key churn and k8s-shaped WAL/checkpoint regression tests, plus an ignored release-mode heavy reproducer for issue #23.

## Validation

Run locally on macOS:

```bash
cargo fmt --check
cargo clippy --workspace --all-features --all-targets --locked -- -D warnings
cargo test --workspace --all-features --locked
cargo test --release --test wal_tree_integration issue_23_k8s_shaped_spillover_reproducer -- --ignored --nocapture
```
