### PR TITLE
feat(node): prepare @nokv-lab/holt npm release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,20 @@ updates:
       dev-deps:
         dependency-type: "development"
 
+  # Node binding build dependencies.
+  - package-ecosystem: "npm"
+    directory: "/crates/holt-node"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "node"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
   # GitHub Actions workflow dependencies (uses: actions/*@vX, etc).
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,312 @@
+name: Node package
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "node-v*.*.*"
+    paths:
+      - ".github/workflows/npm-release.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "src/**"
+      - "crates/holt-node/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/npm-release.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "src/**"
+      - "crates/holt-node/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: "0"
+  MACOSX_DEPLOYMENT_TARGET: "10.15"
+
+jobs:
+  release-tests:
+    name: Release test suite
+    if: startsWith(github.ref, 'refs/tags/node-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: crates/holt-node/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Node dependencies
+        run: npm ci
+        working-directory: crates/holt-node
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run Rust release tests
+        run: cargo test --workspace --lib --tests --examples --locked
+
+      - name: Audit Node dependencies
+        run: npm audit --audit-level=high
+        working-directory: crates/holt-node
+
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            build_args: ""
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            build_args: ""
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            build_args: "--use-napi-cross"
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            build_args: "--use-napi-cross"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: crates/holt-node/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: node-${{ matrix.target }}
+
+      - name: Install Node dependencies
+        run: npm ci
+        working-directory: crates/holt-node
+
+      - name: Build native binding
+        run: npm run build -- --target ${{ matrix.target }} ${{ matrix.build_args }}
+        working-directory: crates/holt-node
+
+      - name: Upload native binding
+        uses: actions/upload-artifact@v7
+        with:
+          name: bindings-${{ matrix.target }}
+          path: crates/holt-node/index.*.node
+          if-no-files-found: error
+          retention-days: 3
+
+  test:
+    name: Test ${{ matrix.target }} on Node ${{ matrix.node }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            architecture: x64
+            node: 18
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            architecture: x64
+            node: 24
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            architecture: arm64
+            node: 18
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            architecture: arm64
+            node: 24
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            architecture: x64
+            node: 18
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            architecture: x64
+            node: 24
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            architecture: arm64
+            node: 18
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            architecture: arm64
+            node: 24
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          architecture: ${{ matrix.architecture }}
+          cache: npm
+          cache-dependency-path: crates/holt-node/package-lock.json
+
+      - name: Install runtime dependencies
+        run: npm ci --omit=dev --ignore-scripts
+        working-directory: crates/holt-node
+
+      - name: Download native binding
+        uses: actions/download-artifact@v8
+        with:
+          name: bindings-${{ matrix.target }}
+          path: crates/holt-node
+
+      - name: Run Node tests
+        run: npm test
+        working-directory: crates/holt-node
+
+  publish:
+    name: Publish npm packages
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/node-v')
+    needs: [release-tests, build, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify release version
+        shell: bash
+        working-directory: crates/holt-node
+        run: |
+          tag_version="${GITHUB_REF_NAME#node-v}"
+          package_version="$(node -p "require('./package.json').version")"
+          cargo_version="$(cargo metadata --no-deps --format-version 1 | node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => { input += chunk });
+            process.stdin.on("end", () => {
+              const metadata = JSON.parse(input);
+              process.stdout.write(metadata.packages.find((pkg) => pkg.name === "holt-node").version);
+            });
+          ')"
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          test "$tag_version" = "$package_version"
+          test "$tag_version" = "$cargo_version"
+
+      - name: Install Node dependencies
+        run: npm ci
+        working-directory: crates/holt-node
+
+      - name: Create platform packages
+        run: npm run create:npm-dirs
+        working-directory: crates/holt-node
+
+      - name: Download all native bindings
+        uses: actions/download-artifact@v8
+        with:
+          path: crates/holt-node/artifacts
+
+      - name: Collect native bindings
+        run: npm run artifacts -- --output-dir artifacts --npm-dir npm
+        working-directory: crates/holt-node
+
+      - name: Prepare and verify package metadata
+        working-directory: crates/holt-node
+        run: |
+          npm run release:prepare
+          npm run release:verify
+
+      - name: Inspect package tarballs
+        shell: bash
+        working-directory: crates/holt-node
+        run: |
+          npm pack --dry-run --ignore-scripts
+          for target in darwin-x64 darwin-arm64 linux-x64-gnu linux-arm64-gnu; do
+            npm pack --dry-run --ignore-scripts "./npm/$target"
+          done
+
+      - name: Test an installed package
+        shell: bash
+        working-directory: crates/holt-node
+        run: |
+          package_name="$(node -p "require('./package.json').name")"
+          package_dir="$(mktemp -d)"
+          install_dir="$(mktemp -d)"
+          root_tarball="$(npm pack --ignore-scripts --pack-destination "$package_dir" --json | node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => { input += chunk });
+            process.stdin.on("end", () => process.stdout.write(JSON.parse(input)[0].filename));
+          ')"
+          platform_tarball="$(npm pack ./npm/linux-x64-gnu --ignore-scripts --pack-destination "$package_dir" --json | node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => { input += chunk });
+            process.stdin.on("end", () => process.stdout.write(JSON.parse(input)[0].filename));
+          ')"
+          cd "$install_dir"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts "$package_dir/$root_tarball" "$package_dir/$platform_tarball"
+          PACKAGE_NAME="$package_name" node -e '
+            const { Tree } = require(process.env.PACKAGE_NAME);
+            (async () => {
+              const tree = await Tree.openMemory();
+              await tree.put(Buffer.from("release/check"), Buffer.from("ok"));
+              const value = await tree.get(Buffer.from("release/check"));
+              if (value?.toString() !== "ok") throw new Error("installed package returned the wrong value");
+              await tree.close();
+            })().catch((error) => { console.error(error); process.exit(1); });
+          '
+
+      - name: Publish packages
+        shell: bash
+        working-directory: crates/holt-node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          npm_tag="latest"
+          if [[ "$version" == *-* ]]; then
+            npm_tag="next"
+          fi
+
+          publish_package() {
+            package_dir="$1"
+            package_name="$(node -p "require('./${package_dir#./}/package.json').name")"
+            if npm view "$package_name@$version" version >/dev/null 2>&1; then
+              echo "$package_name@$version already exists; skipping"
+              return
+            fi
+            npm publish "$package_dir" --ignore-scripts --access public --provenance --tag "$npm_tag"
+          }
+
+          for target in darwin-x64 darwin-arm64 linux-x64-gnu linux-arm64-gnu; do
+            publish_package "./npm/$target"
+          done
+          publish_package "."

--- a/crates/holt-node/.gitignore
+++ b/crates/holt-node/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
+artifacts/
+npm/
+*.tgz
 *.node

--- a/crates/holt-node/LICENSE
+++ b/crates/holt-node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 the holt contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/holt-node/README.md
+++ b/crates/holt-node/README.md
@@ -1,18 +1,32 @@
-# @holt/node
+# @nokv-lab/holt
 
-Node.js bindings for the [Holt](https://github.com/EnderRomantice/holt)
+Node.js bindings for the [Holt](https://github.com/NoKV-Lab/holt)
 path-shaped metadata engine.
 
 The package is a Node-API native addon built directly on the Rust `holt`
-crate. Keys and values are `Buffer`/`Uint8Array` instances; scans return
+crate. Keys and values are `Buffer`/`Uint8Array` instances. Scans return
 `kind`, `path`, `value`, and `version` fields. `version` is a JavaScript
 `bigint` in the generated typings.
 
-The package exposes the core `Tree` API plus `Database`, Holt's multi-tree
-handle. It is currently Unix-only, matching Holt's file-store support.
+The package exposes a focused subset of Holt's `Tree` and `Database` APIs. It
+does not yet have full Rust API parity. It is currently Unix-only, matching
+Holt's file-store support.
+
+## Install
+
+```sh
+npm install @nokv-lab/holt
+```
+
+Prebuilt packages support these targets:
+
+- macOS on x64 and arm64
+- Linux with glibc on x64 and arm64
+
+The release workflow does not publish Windows or Linux musl builds.
 
 ```ts
-import { Tree } from "@holt/node";
+import { Tree } from "@nokv-lab/holt";
 
 const tree = await Tree.openMemory();
 await tree.put(Buffer.from("bucket/a"), Buffer.from("metadata"));
@@ -24,7 +38,7 @@ await tree.close();
 Multiple named trees can share one database, WAL, and checkpoint boundary:
 
 ```ts
-import { Database } from "@holt/node";
+import { Database } from "@nokv-lab/holt";
 
 const db = await Database.open("/var/lib/app/holt", { walSync: true });
 const objects = await db.openOrCreateTree("objects");
@@ -44,6 +58,28 @@ All storage operations return Promises and execute on native worker threads,
 so file I/O, WAL sync, replay, checkpoints, and scans do not block the Node.js
 event loop.
 
+## API coverage
+
+The Node package currently supports:
+
+- file-backed and in-memory trees and databases
+- named tree creation, lookup, listing, and removal
+- point reads, writes, deletes, records with versions, and compare-and-put
+- prefix scans with `startAfter` and delimiter rollups
+- explicit tree and database checkpoints
+
+The Node package does not expose these Rust APIs yet:
+
+- conditional insert and delete, rename, and single-tree or cross-tree atomic batches
+- snapshots and consistent scoped views
+- prefix counts and empty-prefix checks
+- garbage collection, vacuum, compaction, statistics, and metrics
+- database checkpoint export and install
+- scan limits, visitor-based streaming, and scan statistics
+- buffer-pool and checkpoint tuning, custom storage backends, and durability modes beyond WAL sync
+
+Node scans currently materialize all results in an array.
+
 Build the native artifact locally with:
 
 ```sh
@@ -51,7 +87,7 @@ npm install
 npm run build
 ```
 
-The repository intentionally does not commit platform-specific `.node`
-artifacts. A release pipeline should build and publish one napi-rs platform
-package per supported Unix target, then attach them to the main package as
-optional dependencies.
+The repository does not commit platform-specific `.node` artifacts. The
+release workflow builds and tests each target before it publishes the platform
+packages and the root package. Maintainers can find the release procedure in
+[the repository release guide](https://github.com/NoKV-Lab/holt/blob/main/crates/holt-node/RELEASING.md).

--- a/crates/holt-node/RELEASING.md
+++ b/crates/holt-node/RELEASING.md
@@ -1,0 +1,65 @@
+# Releasing the Node package
+
+The Node package has its own version and tag sequence. A tag named
+`node-v0.1.0` releases package version `0.1.0`. Rust crate tags still use the
+`v0.8.2` form.
+
+The workflow publishes one root package and four platform packages. npm treats
+each published version as immutable. Do not push a release tag until every
+check in this file passes.
+
+## Initial setup
+
+1. Confirm that the npm organization `nokv-lab` exists and that the release
+   account can publish `@nokv-lab/holt` and all four suffixed package names.
+   An available package name alone does not grant scope access.
+2. Add a GitHub Actions secret named `NPM_TOKEN`. Use a granular npm token with
+   read and write access and bypass 2FA enabled for CI publishing.
+3. Protect `node-v*` tags so that only release maintainers can create them.
+
+After the initial release, configure `npm-release.yml` as the trusted publisher
+for the root and platform packages. Then remove `NPM_TOKEN` from the workflow
+and revoke the token.
+
+## Prepare a release
+
+1. Update `version` in `package.json` and `Cargo.toml` under this directory.
+2. Run `npm install --package-lock-only` to update `package-lock.json`.
+3. Run the local checks:
+
+   ```sh
+   npm ci
+   npm run build
+   npm test
+   npm audit
+   npm pack --dry-run --ignore-scripts
+   ```
+
+4. Merge the version change into `main` and wait for the Node package workflow
+   to pass.
+5. Create and push the release tag:
+
+   ```sh
+   git tag -s node-v0.1.0 -m "Release @nokv-lab/holt 0.1.0"
+   git push origin node-v0.1.0
+   ```
+
+The workflow verifies the tag, builds each target, tests each native artifact,
+checks every tarball, and publishes the platform packages before the root
+package. A rerun skips package versions that already exist. This supports
+recovery from a partial npm release without replacing published files.
+
+## Verify the release
+
+Check the root package and each platform package after the workflow completes:
+
+```sh
+npm view @nokv-lab/holt@0.1.0 version dist.integrity repository
+npm view @nokv-lab/holt-darwin-x64@0.1.0 version dist.integrity
+npm view @nokv-lab/holt-darwin-arm64@0.1.0 version dist.integrity
+npm view @nokv-lab/holt-linux-x64-gnu@0.1.0 version dist.integrity
+npm view @nokv-lab/holt-linux-arm64-gnu@0.1.0 version dist.integrity
+```
+
+Install the root package in a clean project on each supported target. Run a
+memory operation and a file-backed checkpoint and reopen test.

--- a/crates/holt-node/index.js
+++ b/crates/holt-node/index.js
@@ -75,8 +75,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-android-arm64')
-        const bindingPackageVersion = require('@holt/node-android-arm64/package.json').version
+        const binding = require('@nokv-lab/holt-android-arm64')
+        const bindingPackageVersion = require('@nokv-lab/holt-android-arm64/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -91,8 +91,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-android-arm-eabi')
-        const bindingPackageVersion = require('@holt/node-android-arm-eabi/package.json').version
+        const binding = require('@nokv-lab/holt-android-arm-eabi')
+        const bindingPackageVersion = require('@nokv-lab/holt-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -112,8 +112,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-win32-x64-gnu')
-        const bindingPackageVersion = require('@holt/node-win32-x64-gnu/package.json').version
+        const binding = require('@nokv-lab/holt-win32-x64-gnu')
+        const bindingPackageVersion = require('@nokv-lab/holt-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -128,8 +128,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-win32-x64-msvc')
-        const bindingPackageVersion = require('@holt/node-win32-x64-msvc/package.json').version
+        const binding = require('@nokv-lab/holt-win32-x64-msvc')
+        const bindingPackageVersion = require('@nokv-lab/holt-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -145,8 +145,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-win32-ia32-msvc')
-        const bindingPackageVersion = require('@holt/node-win32-ia32-msvc/package.json').version
+        const binding = require('@nokv-lab/holt-win32-ia32-msvc')
+        const bindingPackageVersion = require('@nokv-lab/holt-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -161,8 +161,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-win32-arm64-msvc')
-        const bindingPackageVersion = require('@holt/node-win32-arm64-msvc/package.json').version
+        const binding = require('@nokv-lab/holt-win32-arm64-msvc')
+        const bindingPackageVersion = require('@nokv-lab/holt-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -180,8 +180,8 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      const binding = require('@holt/node-darwin-universal')
-      const bindingPackageVersion = require('@holt/node-darwin-universal/package.json').version
+      const binding = require('@nokv-lab/holt-darwin-universal')
+      const bindingPackageVersion = require('@nokv-lab/holt-darwin-universal/package.json').version
       if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -196,8 +196,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-darwin-x64')
-        const bindingPackageVersion = require('@holt/node-darwin-x64/package.json').version
+        const binding = require('@nokv-lab/holt-darwin-x64')
+        const bindingPackageVersion = require('@nokv-lab/holt-darwin-x64/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -212,8 +212,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-darwin-arm64')
-        const bindingPackageVersion = require('@holt/node-darwin-arm64/package.json').version
+        const binding = require('@nokv-lab/holt-darwin-arm64')
+        const bindingPackageVersion = require('@nokv-lab/holt-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -232,8 +232,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-freebsd-x64')
-        const bindingPackageVersion = require('@holt/node-freebsd-x64/package.json').version
+        const binding = require('@nokv-lab/holt-freebsd-x64')
+        const bindingPackageVersion = require('@nokv-lab/holt-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -248,8 +248,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-freebsd-arm64')
-        const bindingPackageVersion = require('@holt/node-freebsd-arm64/package.json').version
+        const binding = require('@nokv-lab/holt-freebsd-arm64')
+        const bindingPackageVersion = require('@nokv-lab/holt-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -269,8 +269,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-x64-musl')
-          const bindingPackageVersion = require('@holt/node-linux-x64-musl/package.json').version
+          const binding = require('@nokv-lab/holt-linux-x64-musl')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -285,8 +285,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-x64-gnu')
-          const bindingPackageVersion = require('@holt/node-linux-x64-gnu/package.json').version
+          const binding = require('@nokv-lab/holt-linux-x64-gnu')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -303,8 +303,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-arm64-musl')
-          const bindingPackageVersion = require('@holt/node-linux-arm64-musl/package.json').version
+          const binding = require('@nokv-lab/holt-linux-arm64-musl')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -319,8 +319,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-arm64-gnu')
-          const bindingPackageVersion = require('@holt/node-linux-arm64-gnu/package.json').version
+          const binding = require('@nokv-lab/holt-linux-arm64-gnu')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -337,8 +337,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-arm-musleabihf')
-          const bindingPackageVersion = require('@holt/node-linux-arm-musleabihf/package.json').version
+          const binding = require('@nokv-lab/holt-linux-arm-musleabihf')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -353,8 +353,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('@holt/node-linux-arm-gnueabihf/package.json').version
+          const binding = require('@nokv-lab/holt-linux-arm-gnueabihf')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -371,8 +371,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-loong64-musl')
-          const bindingPackageVersion = require('@holt/node-linux-loong64-musl/package.json').version
+          const binding = require('@nokv-lab/holt-linux-loong64-musl')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -387,8 +387,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-loong64-gnu')
-          const bindingPackageVersion = require('@holt/node-linux-loong64-gnu/package.json').version
+          const binding = require('@nokv-lab/holt-linux-loong64-gnu')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -405,8 +405,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-riscv64-musl')
-          const bindingPackageVersion = require('@holt/node-linux-riscv64-musl/package.json').version
+          const binding = require('@nokv-lab/holt-linux-riscv64-musl')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -421,8 +421,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@holt/node-linux-riscv64-gnu')
-          const bindingPackageVersion = require('@holt/node-linux-riscv64-gnu/package.json').version
+          const binding = require('@nokv-lab/holt-linux-riscv64-gnu')
+          const bindingPackageVersion = require('@nokv-lab/holt-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -438,8 +438,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-linux-ppc64-gnu')
-        const bindingPackageVersion = require('@holt/node-linux-ppc64-gnu/package.json').version
+        const binding = require('@nokv-lab/holt-linux-ppc64-gnu')
+        const bindingPackageVersion = require('@nokv-lab/holt-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -454,8 +454,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-linux-s390x-gnu')
-        const bindingPackageVersion = require('@holt/node-linux-s390x-gnu/package.json').version
+        const binding = require('@nokv-lab/holt-linux-s390x-gnu')
+        const bindingPackageVersion = require('@nokv-lab/holt-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -474,8 +474,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-openharmony-arm64')
-        const bindingPackageVersion = require('@holt/node-openharmony-arm64/package.json').version
+        const binding = require('@nokv-lab/holt-openharmony-arm64')
+        const bindingPackageVersion = require('@nokv-lab/holt-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -490,8 +490,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-openharmony-x64')
-        const bindingPackageVersion = require('@holt/node-openharmony-x64/package.json').version
+        const binding = require('@nokv-lab/holt-openharmony-x64')
+        const bindingPackageVersion = require('@nokv-lab/holt-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -506,8 +506,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@holt/node-openharmony-arm')
-        const bindingPackageVersion = require('@holt/node-openharmony-arm/package.json').version
+        const binding = require('@nokv-lab/holt-openharmony-arm')
+        const bindingPackageVersion = require('@nokv-lab/holt-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '0.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -523,47 +523,163 @@ function requireNative() {
   }
 }
 
-nativeBinding = requireNative()
+function createLoadErrorChain(errors) {
+  return errors.reduce((previous, current) => {
+    let message
+    try {
+      message =
+        current && typeof current.message === 'string'
+          ? current.message
+          : String(current)
+    } catch {
+      message = 'Unknown error'
+    }
+    const error = new Error(message)
+    error.cause = previous
+    return error
+  }, null)
+}
 
 // NAPI_RS_FORCE_WASI is a tri-state flag:
 //   unset / any other value → native binding preferred, WASI is only a fallback
-//   'true'                   → force WASI fallback even if native loaded
-//   'error'                  → force WASI and throw if no WASI binding is found
+//   'true'                   → prefer WASI, but retain native as a lazy fallback
+//   'error'                  → require WASI without initializing a native fallback
 // Treating any non-empty string as truthy (the historical behavior) meant
 // NAPI_RS_FORCE_WASI=false, NAPI_RS_FORCE_WASI=0, etc. inadvertently triggered
 // the WASI path, causing ENOENT for packages shipped without a .wasi.cjs file.
+//
+// NAPI_RS_WASI_FLAVOR selects one exact generated flavor and implies strict
+// WASI loading. It never crosses into another flavor or falls back to native.
+const __napiWasiFlavors = ["wasm32-wasi"]
+const __napiWasiFlavor = process.env.NAPI_RS_WASI_FLAVOR
+const __napiWasiFlavorRequested =
+  typeof __napiWasiFlavor === 'string' && __napiWasiFlavor.length > 0
+if (
+  __napiWasiFlavorRequested &&
+  __napiWasiFlavors.indexOf(__napiWasiFlavor) === -1
+) {
+  throw new Error(
+    'Unsupported WASI flavor "' +
+      __napiWasiFlavor +
+      '". Available flavors: ' +
+      __napiWasiFlavors.join(', '),
+  )
+}
+const forceWasiError = process.env.NAPI_RS_FORCE_WASI === 'error'
 const forceWasi =
-  process.env.NAPI_RS_FORCE_WASI === 'true' || process.env.NAPI_RS_FORCE_WASI === 'error'
+  process.env.NAPI_RS_FORCE_WASI === 'true' ||
+  forceWasiError ||
+  __napiWasiFlavorRequested
+
+if (!forceWasi) {
+  nativeBinding = requireNative()
+}
 
 if (!nativeBinding || forceWasi) {
   let wasiBinding = null
-  let wasiBindingError = null
-  try {
-    wasiBinding = require('./index.wasi.cjs')
-    nativeBinding = wasiBinding
-  } catch (err) {
-    if (forceWasi) {
-      wasiBindingError = err
-    }
-  }
-  if (!nativeBinding || forceWasi) {
+  let wasiBindingLoaded = false
+  const wasiBindingErrors = []
+  const __napiWasiResolveCandidate = (specifier, isPackage, localArtifacts) => {
     try {
-      wasiBinding = require('@holt/node-wasm32-wasi')
-      nativeBinding = wasiBinding
-    } catch (err) {
-      if (forceWasi) {
-        if (!wasiBindingError) {
-          wasiBindingError = err
-        } else {
-          wasiBindingError.cause = err
-        }
-        loadErrors.push(err)
+      require.resolve(specifier)
+    } catch (resolveError) {
+      if (!resolveError || resolveError.code !== 'MODULE_NOT_FOUND') {
+        throw resolveError
       }
+      if (isPackage) {
+        try {
+          require.resolve(specifier + '/package.json')
+        } catch (packageError) {
+          if (packageError && packageError.code === 'MODULE_NOT_FOUND') {
+            return resolveError
+          }
+          // An exports restriction proves the package exists even when its
+          // package.json is not public. Preserve the root resolution failure.
+          throw resolveError
+        }
+        // The package exists but its main/export target is broken.
+        throw resolveError
+      }
+      return resolveError
+    }
+    if (localArtifacts) {
+      let artifactError = null
+      for (let i = 0; i < localArtifacts.length; i++) {
+        try {
+          require.resolve(localArtifacts[i])
+          return null
+        } catch (resolveError) {
+          if (!resolveError || resolveError.code !== 'MODULE_NOT_FOUND') {
+            throw resolveError
+          }
+          artifactError = resolveError
+        }
+      }
+      return artifactError
+    }
+    return null
+  }
+  if (!wasiBindingLoaded && (!__napiWasiFlavorRequested || __napiWasiFlavor === "wasm32-wasi")) {
+    let candidateError = null
+    let candidateFailed = false
+    try {
+      candidateError = __napiWasiResolveCandidate('./index.wasi.cjs', false, ["./index.wasm32-wasi.debug.wasm","./index.wasm32-wasi.wasm"])
+      candidateFailed = candidateError !== null
+      if (!candidateFailed) {
+        wasiBinding = require('./index.wasi.cjs')
+        nativeBinding = wasiBinding
+        wasiBindingLoaded = true
+      }
+    } catch (err) {
+      candidateError = err
+      candidateFailed = true
+    }
+    if (candidateFailed) {
+      wasiBindingErrors.push(candidateError)
+      loadErrors.push(candidateError)
     }
   }
-  if (process.env.NAPI_RS_FORCE_WASI === 'error' && !wasiBinding) {
-    const error = new Error('WASI binding not found and NAPI_RS_FORCE_WASI is set to error')
-    error.cause = wasiBindingError
+  if (!wasiBindingLoaded && (!__napiWasiFlavorRequested || __napiWasiFlavor === "wasm32-wasi")) {
+    let candidateError = null
+    let candidateFailed = false
+    try {
+      candidateError = __napiWasiResolveCandidate('@nokv-lab/holt-wasm32-wasi', true, undefined)
+      candidateFailed = candidateError !== null
+      if (!candidateFailed) {
+        if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          const bindingPackageVersion = require('@nokv-lab/holt-wasm32-wasi/package.json').version
+          if (bindingPackageVersion !== '0.1.0') {
+            throw new Error(`WASI binding package version mismatch, expected 0.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          }
+        }
+        wasiBinding = require('@nokv-lab/holt-wasm32-wasi')
+        nativeBinding = wasiBinding
+        wasiBindingLoaded = true
+      }
+    } catch (err) {
+      candidateError = err
+      candidateFailed = true
+    }
+    if (candidateFailed) {
+      wasiBindingErrors.push(candidateError)
+      loadErrors.push(candidateError)
+    }
+  }
+  if (
+    !wasiBindingLoaded &&
+    forceWasi &&
+    !forceWasiError &&
+    !__napiWasiFlavorRequested
+  ) {
+    nativeBinding = requireNative()
+  }
+  if ((forceWasiError || __napiWasiFlavorRequested) && !wasiBindingLoaded) {
+    const error = new Error(
+      __napiWasiFlavorRequested
+        ? 'WASI binding for flavor "' + __napiWasiFlavor + '" not found'
+        : 'WASI binding not found and NAPI_RS_FORCE_WASI is set to error',
+    )
+    error.cause = createLoadErrorChain(wasiBindingErrors)
     throw error
   }
 }
@@ -577,10 +693,7 @@ if (!nativeBinding) {
     )
     // assign instead of the `new Error(message, { cause })` options form,
     // which Node < 16.9 silently ignores
-    error.cause = loadErrors.reduce((err, cur) => {
-      cur.cause = err
-      return cur
-    })
+    error.cause = createLoadErrorChain(loadErrors)
     throw error
   }
   throw new Error(`Failed to load native binding`)

--- a/crates/holt-node/package-lock.json
+++ b/crates/holt-node/package-lock.json
@@ -1,15 +1,23 @@
 {
-  "name": "@holt/node",
+  "name": "@nokv-lab/holt",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@holt/node",
+      "name": "@nokv-lab/holt",
       "version": "0.1.0",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
       "license": "MIT",
+      "os": [
+        "darwin",
+        "linux"
+      ],
       "devDependencies": {
-        "@napi-rs/cli": "^3.5.0"
+        "@napi-rs/cli": "^3.8.4"
       },
       "engines": {
         "node": ">=18"
@@ -28,12 +36,13 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -394,9 +403,9 @@
       }
     },
     "node_modules/@napi-rs/cli": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.7.3.tgz",
-      "integrity": "sha512-iu5BOoYjYVixp5jwE7JniHvg72XuKWXUfXteu+6Gt/XY4/mslsS+Qbipleg1+3CAUGHkWc+ebaMJj7Pc93BXSQ==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.8.4.tgz",
+      "integrity": "sha512-/uIzAUHXAMHzzye6+DWdVV6oc3lCRr7ck98UNeW5Gbs+KaxXRztWFmehbz46ufLdTtzjcyZGXOplDHEWh3qxew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -406,26 +415,27 @@
         "@octokit/rest": "^22.0.1",
         "clipanion": "^4.0.0-rc.4",
         "colorette": "^2.0.20",
-        "emnapi": "^1.11.1",
+        "emnapi": "2.0.0-alpha.3",
         "es-toolkit": "^1.47.0",
         "js-yaml": "^4.2.0",
         "obug": "^2.1.2",
         "semver": "^7.8.2",
-        "typanion": "^3.14.0"
+        "typanion": "^3.14.0",
+        "typescript": "^6.0.3"
       },
       "bin": {
         "napi": "dist/cli.js",
         "napi-raw": "cli.mjs"
       },
       "engines": {
-        "node": ">= 16"
+        "node": "^20.17.0 || ^22.13.0 || >= 23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/runtime": "2.0.0-alpha.3"
       },
       "peerDependenciesMeta": {
         "@emnapi/runtime": {
@@ -788,6 +798,17 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
+    "node_modules/@napi-rs/lzma-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@napi-rs/lzma-win32-arm64-msvc": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.5.1.tgz",
@@ -1108,6 +1129,17 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@napi-rs/tar-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@napi-rs/tar-win32-arm64-msvc": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/tar-win32-arm64-msvc/-/tar-win32-arm64-msvc-1.1.1.tgz",
@@ -1160,22 +1192,25 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@napi-rs/wasm-tools": {
@@ -1701,9 +1736,9 @@
       }
     },
     "node_modules/emnapi": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/emnapi/-/emnapi-1.11.2.tgz",
-      "integrity": "sha512-iMt/XQc69fFn2EvcU6tm14HmXKwyy0lnABugsQlqp6xFuZIUuO+ONVSg2mz+MTVF8WbC+bic65AvRXdoldALKg==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/emnapi/-/emnapi-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-K9bc9Xx4OwSfhJpdSOpcfIKzn7/6emuubaIorf6I5e7WBAM79665rf6iHr9y50NL4qYMUP/AheTpD1Z4yU1EBw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1771,9 +1806,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -1881,6 +1916,20 @@
       "workspaces": [
         "website"
       ]
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",

--- a/crates/holt-node/package.json
+++ b/crates/holt-node/package.json
@@ -1,31 +1,67 @@
 {
-  "name": "@holt/node",
+  "name": "@nokv-lab/holt",
   "version": "0.1.0",
   "description": "Node.js bindings for the Holt metadata engine",
+  "author": "the holt contributors",
   "license": "MIT",
+  "keywords": [
+    "holt",
+    "metadata",
+    "storage",
+    "database",
+    "napi-rs"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/EnderRomantice/holt.git",
+    "url": "git+https://github.com/NoKV-Lab/holt.git",
     "directory": "crates/holt-node"
+  },
+  "homepage": "https://github.com/NoKV-Lab/holt#readme",
+  "bugs": {
+    "url": "https://github.com/NoKV-Lab/holt/issues"
   },
   "main": "index.js",
   "types": "index.d.ts",
   "engines": {
     "node": ">=18"
   },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
   "files": [
     "index.js",
-    "index.d.ts",
-    "*.node",
-    "npm"
+    "index.d.ts"
   ],
+  "napi": {
+    "binaryName": "index",
+    "targets": [
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu"
+    ]
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
+    "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
+    "create:npm-dirs": "napi create-npm-dirs && node scripts/copy-platform-license.mjs",
+    "release:prepare": "napi pre-publish -t npm --skip-optional-publish --no-gh-release",
+    "release:verify": "node scripts/verify-release.mjs",
     "test": "node --test test/*.test.mjs"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.5.0"
+    "@napi-rs/cli": "^3.8.4"
   },
   "optionalDependencies": {}
 }

--- a/crates/holt-node/scripts/copy-platform-license.mjs
+++ b/crates/holt-node/scripts/copy-platform-license.mjs
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const npmDirectory = path.join(root, "npm");
+const license = path.join(root, "LICENSE");
+const packageDirectories = fs
+  .readdirSync(npmDirectory, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => path.join(npmDirectory, entry.name));
+
+if (packageDirectories.length === 0) {
+  throw new Error("napi did not create any platform package directories");
+}
+
+for (const packageDirectory of packageDirectories) {
+  fs.copyFileSync(license, path.join(packageDirectory, "LICENSE"));
+}
+
+console.log(`Copied LICENSE into ${packageDirectories.length} platform packages.`);

--- a/crates/holt-node/scripts/verify-release.mjs
+++ b/crates/holt-node/scripts/verify-release.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const targetMetadata = {
+  "x86_64-apple-darwin": {
+    suffix: "darwin-x64",
+    os: "darwin",
+    cpu: "x64",
+  },
+  "aarch64-apple-darwin": {
+    suffix: "darwin-arm64",
+    os: "darwin",
+    cpu: "arm64",
+  },
+  "x86_64-unknown-linux-gnu": {
+    suffix: "linux-x64-gnu",
+    os: "linux",
+    cpu: "x64",
+    libc: "glibc",
+  },
+  "aarch64-unknown-linux-gnu": {
+    suffix: "linux-arm64-gnu",
+    os: "linux",
+    cpu: "arm64",
+    libc: "glibc",
+  },
+};
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+const root = process.cwd();
+const packageJson = readJson(path.join(root, "package.json"));
+const configuredTargets = packageJson.napi?.targets ?? [];
+const license = fs.readFileSync(path.join(root, "LICENSE"));
+
+assert.deepEqual(
+  license,
+  fs.readFileSync(path.resolve(root, "../../LICENSE")),
+  "the Node package license must match the repository license",
+);
+
+assert.deepEqual(
+  [...configuredTargets].sort(),
+  Object.keys(targetMetadata).sort(),
+  "package.json must configure the reviewed release targets",
+);
+
+const expectedDependencies = {};
+
+for (const triple of configuredTargets) {
+  const target = targetMetadata[triple];
+  const binary = `index.${target.suffix}.node`;
+  const rootBinary = path.join(root, binary);
+  const packageDirectory = path.join(root, "npm", target.suffix);
+  const platformBinary = path.join(packageDirectory, binary);
+  const platformPackage = readJson(path.join(packageDirectory, "package.json"));
+  const expectedName = `${packageJson.name}-${target.suffix}`;
+
+  assert.ok(fs.statSync(rootBinary).size > 0, `${binary} is missing or empty`);
+  assert.ok(
+    fs.statSync(platformBinary).size > 0,
+    `${path.relative(root, platformBinary)} is missing or empty`,
+  );
+  assert.deepEqual(
+    fs.readFileSync(path.join(packageDirectory, "LICENSE")),
+    license,
+    `${path.relative(root, packageDirectory)} has the wrong license text`,
+  );
+  assert.equal(platformPackage.name, expectedName);
+  assert.equal(platformPackage.version, packageJson.version);
+  assert.equal(platformPackage.main, binary);
+  assert.deepEqual(platformPackage.files, [binary]);
+  assert.deepEqual(platformPackage.os, [target.os]);
+  assert.deepEqual(platformPackage.cpu, [target.cpu]);
+  assert.deepEqual(
+    platformPackage.libc,
+    target.libc ? [target.libc] : undefined,
+  );
+  assert.equal(platformPackage.publishConfig?.access, "public");
+  assert.equal(
+    platformPackage.repository?.url,
+    packageJson.repository.url,
+  );
+  assert.equal(
+    platformPackage.repository?.directory,
+    packageJson.repository.directory,
+  );
+
+  expectedDependencies[expectedName] = packageJson.version;
+}
+
+assert.deepEqual(
+  packageJson.optionalDependencies,
+  expectedDependencies,
+  "optionalDependencies must contain each platform package at the exact release version",
+);
+
+console.log(
+  `Verified ${packageJson.name}@${packageJson.version} and ${configuredTargets.length} platform packages.`,
+);


### PR DESCRIPTION
The Node binding had no repeatable path for publishing native binaries. This prepares `@nokv-lab/holt` 0.1.0 for a tag-driven npm release.

Consumers will install one root package. npm will select a tested native package for macOS or glibc Linux on x64 or arm64.

## Release flow

- Build four native targets and test them on Node 18 and Node 24.
- Publish platform packages before the root package.
- Verify versions, package metadata, licenses, tarballs, and a clean installed package.
- Skip immutable versions during a rerun so partial releases can recover.

The README now states the current Node API coverage and the missing Rust APIs. The release guide documents token setup, tagging, and post-publish checks.

## Validation

- `npm ci`
- `npm run build`
- `npm test`: 6 passed
- `npm audit`: 0 vulnerabilities
- `npm pack --dry-run --ignore-scripts`
- `cargo fmt --all --check`
- `cargo test --workspace --lib --tests --examples --locked`
- Four-platform release metadata and tarball simulation
- README and release guide prose lint: 0.00 violations per 100 words

The local macOS arm64 build passed. The pull request CI provides the first native build and runtime evidence for the other targets.

This pull request does not publish to npm. After merge, maintainers must configure `NPM_TOKEN` and push the `node-v0.1.0` tag.
