### PR TITLE
fix(ci): sync standalone locks for 0.8.3

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/tools/soak/Cargo.lock
+++ b/tools/soak/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "holt"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",


### PR DESCRIPTION
Holt 0.8.3 updated the root package and workspace lockfile. The independent benchmark and soak lockfiles still recorded Holt 0.8.2, so their `--locked` CI commands stopped before compilation.

This change updates only those two path-package entries to Holt 0.8.3. It restores the soak clippy check, both soak smoke runs, and the benchmark job on macOS and Linux. Source code and third-party dependency versions remain unchanged.

Validation:

- `cargo fmt --all --check`
- `cargo fmt --manifest-path tools/soak/Cargo.toml --check`
- workspace and soak clippy with `--locked -D warnings`
- both soak smoke modes from CI
- the macOS regression benchmark from CI
- `cargo test --workspace --all-features --lib --tests --examples --locked`
- `git diff --check`
