### PR TITLE
feat: add read-only absent batch guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ versioning follows [Semantic Versioning](https://semver.org/).
 For design background see [ARCHITECTURE.md](ARCHITECTURE.md);
 fine-grained per-commit history is in `git log`.
 
+## [Unreleased]
+
+### Added
+
+- `AtomicBatch` and `DBAtomicBatch` now provide a read-only
+  `assert_absent` guard. The guard publishes no marker, appends no WAL
+  operation, and consumes no record version. A failed guard aborts the
+  complete batch without publishing its mutations.
+
 ## [0.8.3] — 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+## [0.8.4] — 2026-08-10
+
 ### Added
 
 - `AtomicBatch` and `DBAtomicBatch` now provide a read-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ fine-grained per-commit history is in `git log`.
   operation, and consumes no record version. A failed guard aborts the
   complete batch without publishing its mutations.
 
+### Fixed
+
+- `Tree::atomic` and `DB::atomic` now reject oversized WAL records before
+  they reserve record versions or apply walker mutations. A capacity error
+  leaves the WAL, visible keys, and dirty state unchanged.
+
 ## [0.8.3] — 2026-08-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holt"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 rust-version = "1.82"
 autobenches = false

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ a minor release, but minor releases may still break source compatibility
 before 1.0. Pin exact versions for production evaluation:
 
 ```toml
-holt = "=0.8.2"
+holt = "=0.8.4"
 ```
 
 The engine is covered by unit, integration, property, fuzz, soak, and

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/fuzz/fuzz_targets/atomic_model.rs
+++ b/fuzz/fuzz_targets/atomic_model.rs
@@ -37,6 +37,7 @@ enum AtomicOp {
     Put { key: u8, value: u8 },
     Delete { key: u8 },
     PutIfAbsent { key: u8, value: u8 },
+    AssertAbsent { key: u8 },
     CompareAndPutCurrent { key: u8, value: u8 },
     DeleteIfCurrent { key: u8 },
     AssertCurrent { key: u8 },
@@ -105,7 +106,7 @@ impl<'a> Arbitrary<'a> for Op {
 
 impl<'a> Arbitrary<'a> for AtomicOp {
     fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
-        Ok(match u.int_in_range(0..=8u8)? {
+        Ok(match u.int_in_range(0..=9u8)? {
             0 => Self::Put {
                 key: key_id(u)?,
                 value: value_id(u)?,
@@ -115,14 +116,15 @@ impl<'a> Arbitrary<'a> for AtomicOp {
                 key: key_id(u)?,
                 value: value_id(u)?,
             },
-            3 => Self::CompareAndPutCurrent {
+            3 => Self::AssertAbsent { key: key_id(u)? },
+            4 => Self::CompareAndPutCurrent {
                 key: key_id(u)?,
                 value: value_id(u)?,
             },
-            4 => Self::DeleteIfCurrent { key: key_id(u)? },
-            5 => Self::AssertCurrent { key: key_id(u)? },
-            6 => Self::AssertStale { key: key_id(u)? },
-            7 => Self::AssertPrefixEmpty { dir: dir_id(u)? },
+            5 => Self::DeleteIfCurrent { key: key_id(u)? },
+            6 => Self::AssertCurrent { key: key_id(u)? },
+            7 => Self::AssertStale { key: key_id(u)? },
+            8 => Self::AssertPrefixEmpty { dir: dir_id(u)? },
             _ => Self::Rename {
                 src: key_id(u)?,
                 dst: key_id(u)?,
@@ -208,6 +210,11 @@ fn model_atomic(
                 staged.insert(key.clone(), value(v));
                 touched.insert(key);
             }
+            AtomicOp::AssertAbsent { key: id } => {
+                if staged.contains_key(&key(id)) {
+                    return Err(ModelErr::GuardFailed);
+                }
+            }
             AtomicOp::CompareAndPutCurrent { key: id, value: v } => {
                 let key = key(id);
                 if !model.contains_key(&key) || touched.contains(&key) {
@@ -268,6 +275,7 @@ fn apply_atomic(tree: &Tree, ops: &[AtomicOp]) -> Result<bool, holt::Error> {
                 AtomicOp::PutIfAbsent { key: id, value: v } => {
                     batch.put_if_absent(&key(id), &value(v));
                 }
+                AtomicOp::AssertAbsent { key: id } => batch.assert_absent(&key(id)),
                 AtomicOp::CompareAndPutCurrent { key: id, value: v } => {
                     let key = key(id);
                     batch.compare_and_put(&key, current_version(tree, &key), &value(v));

--- a/fuzz/fuzz_targets/db_model.rs
+++ b/fuzz/fuzz_targets/db_model.rs
@@ -56,6 +56,10 @@ enum AtomicOp {
         key: u8,
         value: u8,
     },
+    AssertAbsent {
+        tree: u8,
+        key: u8,
+    },
     AssertPrefixEmpty {
         tree: u8,
         dir: u8,
@@ -74,6 +78,7 @@ impl AtomicOp {
             Self::Put { tree, .. }
             | Self::Delete { tree, .. }
             | Self::PutIfAbsent { tree, .. }
+            | Self::AssertAbsent { tree, .. }
             | Self::AssertPrefixEmpty { tree, .. }
             | Self::Rename { tree, .. } => tree,
         }
@@ -150,7 +155,7 @@ impl<'a> Arbitrary<'a> for Op {
 
 impl<'a> Arbitrary<'a> for AtomicOp {
     fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
-        Ok(match u.int_in_range(0..=4u8)? {
+        Ok(match u.int_in_range(0..=5u8)? {
             0 => Self::Put {
                 tree: tree_id(u)?,
                 key: key_id(u)?,
@@ -165,7 +170,11 @@ impl<'a> Arbitrary<'a> for AtomicOp {
                 key: key_id(u)?,
                 value: value_id(u)?,
             },
-            3 => Self::AssertPrefixEmpty {
+            3 => Self::AssertAbsent {
+                tree: tree_id(u)?,
+                key: key_id(u)?,
+            },
+            4 => Self::AssertPrefixEmpty {
                 tree: tree_id(u)?,
                 dir: dir_id(u)?,
             },
@@ -261,6 +270,11 @@ fn model_atomic(model: &[TreeModel], ops: &[AtomicOp]) -> Result<Vec<TreeModel>,
                 }
                 tree.insert(key, value(v));
             }
+            AtomicOp::AssertAbsent { tree, key: id } => {
+                if live_tree(&staged, tree)?.contains_key(&key(id)) {
+                    return Err(ModelErr::GuardFailed);
+                }
+            }
             AtomicOp::AssertPrefixEmpty { tree, dir } => {
                 let prefix = prefix(dir);
                 if live_tree(&staged, tree)?
@@ -311,6 +325,9 @@ fn apply_db_atomic(db: &DB, ops: &[AtomicOp]) -> Result<bool, holt::Error> {
                     key: id,
                     value: v,
                 } => batch.put_if_absent(tree_name(tree), &key(id), &value(v)),
+                AtomicOp::AssertAbsent { tree, key: id } => {
+                    batch.assert_absent(tree_name(tree), &key(id));
+                }
                 AtomicOp::AssertPrefixEmpty { tree, dir } => {
                     batch.assert_prefix_empty(tree_name(tree), &prefix(dir));
                 }

--- a/src/api/atomic.rs
+++ b/src/api/atomic.rs
@@ -89,6 +89,9 @@ pub(crate) enum BatchOp {
         key: Vec<u8>,
         expected: RecordVersion,
     },
+    AssertAbsent {
+        key: Vec<u8>,
+    },
     AssertPrefixEmpty {
         prefix: Vec<u8>,
     },
@@ -103,7 +106,7 @@ impl BatchOp {
     pub(crate) const fn emits_wal(&self) -> bool {
         !matches!(
             self,
-            Self::AssertVersion { .. } | Self::AssertPrefixEmpty { .. }
+            Self::AssertVersion { .. } | Self::AssertAbsent { .. } | Self::AssertPrefixEmpty { .. }
         )
     }
 }
@@ -166,6 +169,16 @@ impl AtomicBatch {
             key: key.to_vec(),
             expected,
         });
+    }
+
+    /// Require that `key` is absent when the batch commits. If the key exists,
+    /// the whole atomic batch returns `Ok(false)` and publishes no mutations.
+    ///
+    /// This guard does not write a marker, append a WAL operation, or consume a
+    /// record version.
+    pub fn assert_absent(&mut self, key: &[u8]) {
+        self.pending
+            .push(BatchOp::AssertAbsent { key: key.to_vec() });
     }
 
     /// Require that no live key starts with `prefix` when the batch

--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -1288,6 +1288,11 @@ impl DBAtomicBatch {
         );
     }
 
+    /// Require that `key` is absent in `tree`.
+    pub fn assert_absent(&mut self, tree: &str, key: &[u8]) {
+        self.push(tree, BatchOp::AssertAbsent { key: key.to_vec() });
+    }
+
     /// Require that no live key starts with `prefix` in `tree`.
     pub fn assert_prefix_empty(&mut self, tree: &str, prefix: &[u8]) {
         self.push(
@@ -1342,7 +1347,9 @@ fn encoded_db_batch_record_len(groups: &[DBBatchGroup]) -> usize {
                     1 + 8 + 4 + key.len()
                 }
                 BatchOp::Rename { src, dst, .. } => 1 + 8 + 4 + src.len() + 4 + dst.len() + 1,
-                BatchOp::AssertVersion { .. } | BatchOp::AssertPrefixEmpty { .. } => 0,
+                BatchOp::AssertVersion { .. }
+                | BatchOp::AssertAbsent { .. }
+                | BatchOp::AssertPrefixEmpty { .. } => 0,
             };
         }
     }

--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -1018,6 +1018,12 @@ impl DB {
     fn apply_atomic(&self, pending: Vec<DBBatchOp>) -> Result<bool> {
         let _maintenance = self.maintenance_gate.enter_shared();
         let groups = self.group_batch_ops(pending)?;
+        let count = count_wal_ops(&groups);
+        if count != 0 {
+            if let Some(journal) = &self.journal {
+                journal.preflight_submit(encoded_db_batch_record_len(&groups))?;
+            }
+        }
         let mut gates = groups
             .iter()
             .map(|group| (group.tree_id, group.tree.mutation_gate()))
@@ -1034,7 +1040,6 @@ impl DB {
                 self.store.flush_write_deltas_for_tree(group.tree_id)?;
             }
         }
-        let count = count_wal_ops(&groups);
         let base_seq = self.next_seq.fetch_add(count, Ordering::Relaxed);
         if !Self::preflight_batch_groups(&groups, base_seq)? {
             return Ok(false);
@@ -1157,6 +1162,11 @@ impl DB {
             ops,
         }];
         let count = count_wal_ops(&groups);
+        if count != 0 {
+            if let Some(journal) = &self.journal {
+                journal.preflight_submit(encoded_db_batch_record_len(&groups))?;
+            }
+        }
         let base_seq = self.next_seq.fetch_add(count, Ordering::Relaxed);
         if !Self::preflight_batch_groups(&groups, base_seq)? {
             return Err(Error::Internal("system DB batch preflight failed"));

--- a/src/api/tree.rs
+++ b/src/api/tree.rs
@@ -1314,11 +1314,16 @@ impl Tree {
     }
 
     pub(crate) fn apply_batch(&self, pending: Vec<BatchOp>) -> Result<bool> {
+        let count = pending.iter().filter(|op| op.emits_wal()).count() as u64;
+        if count != 0 {
+            if let Some(journal) = &self.journal {
+                journal.preflight_submit(encoded_batch_record_len(&pending))?;
+            }
+        }
         self.flush_write_delta_for_tree()?;
         let _maintenance = self.maintenance_gate.enter_shared();
         self.ensure_live()?;
         let _tree_mutation = self.mutation_gate.enter_batch();
-        let count = pending.iter().filter(|op| op.emits_wal()).count() as u64;
         // Reserve a contiguous seq range so each inner op's seq is
         // `base + mutating_index` and replay can derive it without
         // storing per-inner seqs in the body. Non-mutating prefix

--- a/src/api/tree.rs
+++ b/src/api/tree.rs
@@ -328,7 +328,9 @@ fn encoded_batch_record_len(ops: &[BatchOp]) -> usize {
         len += match &ops[i] {
             BatchOp::Delete { key } | BatchOp::DeleteIfVersion { key, .. } => 1 + 8 + 4 + key.len(),
             BatchOp::Rename { src, dst, .. } => 1 + 8 + 4 + src.len() + 4 + dst.len() + 1,
-            BatchOp::AssertVersion { .. } | BatchOp::AssertPrefixEmpty { .. } => 0,
+            BatchOp::AssertVersion { .. }
+            | BatchOp::AssertAbsent { .. }
+            | BatchOp::AssertPrefixEmpty { .. } => 0,
             BatchOp::Put { .. } | BatchOp::PutIfAbsent { .. } | BatchOp::CompareAndPut { .. } => {
                 unreachable!("insert-like ops handled above")
             }
@@ -383,6 +385,7 @@ fn batch_insert_parts(op: &BatchOp) -> Option<(&[u8], &[u8])> {
         BatchOp::Delete { .. }
         | BatchOp::DeleteIfVersion { .. }
         | BatchOp::AssertVersion { .. }
+        | BatchOp::AssertAbsent { .. }
         | BatchOp::AssertPrefixEmpty { .. }
         | BatchOp::Rename { .. } => None,
     }
@@ -398,6 +401,7 @@ fn batch_insert_condition(op: &BatchOp) -> Option<engine::InsertCondition> {
         BatchOp::Delete { .. }
         | BatchOp::DeleteIfVersion { .. }
         | BatchOp::AssertVersion { .. }
+        | BatchOp::AssertAbsent { .. }
         | BatchOp::AssertPrefixEmpty { .. }
         | BatchOp::Rename { .. } => None,
     }
@@ -1434,6 +1438,11 @@ impl Tree {
                     _ => return Ok(false),
                 }
             }
+            BatchOp::AssertAbsent { key } => {
+                if self.projected_record(overlay, key)?.is_some() {
+                    return Ok(false);
+                }
+            }
             BatchOp::AssertPrefixEmpty { prefix } => {
                 if !self.projected_prefix_empty(overlay, prefix)? {
                     return Ok(false);
@@ -1660,7 +1669,9 @@ impl Tree {
                         enc.push_erase(self.tree_id, key);
                     }
                 }
-                BatchOp::AssertVersion { .. } | BatchOp::AssertPrefixEmpty { .. } => {}
+                BatchOp::AssertVersion { .. }
+                | BatchOp::AssertAbsent { .. }
+                | BatchOp::AssertPrefixEmpty { .. } => {}
                 BatchOp::Rename { src, dst, force } => {
                     self.apply_batch_rename_walker(src, dst, *force, seq)?;
                     if let Some(enc) = enc.as_deref_mut() {

--- a/src/journal/group_commit.rs
+++ b/src/journal/group_commit.rs
@@ -313,18 +313,25 @@ impl Journal {
         })
     }
 
-    /// Submit one fully encoded WAL record. The caller passes an owned buffer
-    /// (recycled here after the ring copies it). Sync appends return an ack.
-    pub(crate) fn submit(&self, bytes: Vec<u8>, sync: bool) -> Result<Option<JournalAck>> {
+    /// Validate that one encoded record can be accepted without reserving ring
+    /// space or changing journal counters.
+    pub(crate) fn preflight_submit(&self, record_len: usize) -> Result<()> {
         if let Some(m) = self.shared.sticky_err() {
             return Err(Error::Internal(m));
         }
-        if bytes.is_empty() {
+        if record_len == 0 {
             return Err(Error::Internal("journal record must not be empty"));
         }
-        if bytes.len() as u64 > self.shared.ring.capacity() {
+        if record_len as u64 > self.shared.ring.capacity() {
             return Err(Error::Internal("journal record exceeds WAL ring capacity"));
         }
+        Ok(())
+    }
+
+    /// Submit one fully encoded WAL record. The caller passes an owned buffer
+    /// (recycled here after the ring copies it). Sync appends return an ack.
+    pub(crate) fn submit(&self, bytes: Vec<u8>, sync: bool) -> Result<Option<JournalAck>> {
+        self.preflight_submit(bytes.len())?;
         // Reserve → backpressure wait → memcpy → publish. Backpressure parks on
         // the flusher advancing `flush_cursor`, so a full ring does not spin.
         let ticket = self.shared.ring.reserve(bytes.len() as u64);

--- a/tests/tree_smoke.rs
+++ b/tests/tree_smoke.rs
@@ -141,6 +141,20 @@ fn db_atomic_commits_and_aborts_across_trees() {
         })
         .unwrap());
     assert!(lock.get(b"should-not-appear").unwrap().is_none());
+
+    assert!(db
+        .atomic(|batch| {
+            batch.assert_absent("mvcc/default", b"new-key");
+            batch.put("mvcc/lock", b"absence-guarded", b"x");
+        })
+        .unwrap());
+    assert!(!db
+        .atomic(|batch| {
+            batch.assert_absent("mvcc/default", b"user-key");
+            batch.put("mvcc/lock", b"must-not-appear", b"x");
+        })
+        .unwrap());
+    assert!(lock.get(b"must-not-appear").unwrap().is_none());
 }
 
 #[test]
@@ -1631,6 +1645,58 @@ fn atomic_assert_prefix_empty_failure_is_invisible() {
         tree.get(b"dir/child").unwrap().as_deref(),
         Some(&b"child"[..])
     );
+}
+
+#[test]
+fn atomic_assert_absent_is_read_only_and_fail_closed() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+
+    assert!(tree
+        .atomic(|batch| {
+            batch.assert_absent(b"guard");
+            batch.put(b"side", b"published");
+        })
+        .unwrap());
+    assert!(tree.get(b"guard").unwrap().is_none());
+    assert_eq!(
+        tree.get(b"side").unwrap().as_deref(),
+        Some(&b"published"[..])
+    );
+
+    tree.put(b"guard", b"present").unwrap();
+    let committed = tree
+        .atomic(|batch| {
+            batch.assert_absent(b"guard");
+            batch.put(b"side", b"must-not-replace");
+        })
+        .unwrap();
+    assert!(!committed);
+    assert_eq!(
+        tree.get(b"side").unwrap().as_deref(),
+        Some(&b"published"[..])
+    );
+}
+
+#[test]
+fn atomic_assert_absent_observes_staged_updates() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+
+    assert!(!tree
+        .atomic(|batch| {
+            batch.put(b"guard", b"staged");
+            batch.assert_absent(b"guard");
+        })
+        .unwrap());
+    assert!(tree.get(b"guard").unwrap().is_none());
+
+    tree.put(b"guard", b"present").unwrap();
+    assert!(tree
+        .atomic(|batch| {
+            batch.delete(b"guard");
+            batch.assert_absent(b"guard");
+        })
+        .unwrap());
+    assert!(tree.get(b"guard").unwrap().is_none());
 }
 
 #[test]

--- a/tests/wal_tree_integration.rs
+++ b/tests/wal_tree_integration.rs
@@ -953,6 +953,7 @@ fn atomic_assert_only_batch_does_not_append_wal_or_consume_seq() {
 
         assert!(tree
             .atomic(|b| {
+                b.assert_absent(b"missing");
                 b.assert_version(b"seed", seed.version);
                 b.assert_prefix_empty(b"empty/");
             })

--- a/tests/wal_tree_integration.rs
+++ b/tests/wal_tree_integration.rs
@@ -38,6 +38,8 @@ fn durable_cfg(dir: &std::path::Path) -> TreeConfig {
     cfg
 }
 
+const OVERSIZED_ATOMIC_OPS: u32 = 257;
+
 #[test]
 fn db_named_trees_replay_from_one_wal() {
     let dir = tempdir().unwrap();
@@ -973,6 +975,96 @@ fn atomic_assert_only_batch_does_not_append_wal_or_consume_seq() {
 
     let tree = Tree::open(cfg).unwrap();
     assert_eq!(tree.get(b"seed").unwrap().as_deref(), Some(&b"payload"[..]));
+}
+
+#[test]
+fn oversized_tree_atomic_record_fails_before_publish_or_seq_reservation() {
+    let dir = tempdir().unwrap();
+    let tree = Tree::open(durable_cfg(dir.path())).unwrap();
+    tree.put(b"seed", b"value").unwrap();
+    let seed_version = tree.get_version(b"seed").unwrap().unwrap();
+    let wal_len = fs::metadata(wal_path(dir.path())).unwrap().len();
+    let stats_before = tree.stats().unwrap();
+    let journal_before = stats_before.journal.unwrap();
+    let value = vec![0xA5; u16::MAX as usize];
+
+    let err = tree
+        .atomic(|batch| {
+            for i in 0..OVERSIZED_ATOMIC_OPS {
+                let key = format!("oversized/tree/{i:03}");
+                batch.put(key.as_bytes(), &value);
+            }
+        })
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            holt::Error::Internal("journal record exceeds WAL ring capacity")
+        ),
+        "expected the WAL record limit, got {err:?}",
+    );
+    assert_eq!(fs::metadata(wal_path(dir.path())).unwrap().len(), wal_len);
+    let stats_after = tree.stats().unwrap();
+    let journal_after = stats_after.journal.unwrap();
+    assert_eq!(journal_after.appends, journal_before.appends);
+    assert_eq!(journal_after.queued_work, journal_before.queued_work);
+    assert_eq!(stats_after.bm_dirty_count, stats_before.bm_dirty_count);
+    for i in 0..OVERSIZED_ATOMIC_OPS {
+        let key = format!("oversized/tree/{i:03}");
+        assert!(tree.get(key.as_bytes()).unwrap().is_none(), "visible {key}");
+    }
+
+    tree.put(b"after", b"value").unwrap();
+    let after_version = tree.get_version(b"after").unwrap().unwrap();
+    assert_eq!(after_version.as_u64(), seed_version.as_u64() + 1);
+}
+
+#[test]
+fn oversized_db_atomic_record_fails_before_publish_or_seq_reservation() {
+    let dir = tempdir().unwrap();
+    let db = DB::open(durable_cfg(dir.path())).unwrap();
+    let left = db.create_tree("left").unwrap();
+    let right = db.create_tree("right").unwrap();
+    left.put(b"seed", b"value").unwrap();
+    let seed_version = left.get_version(b"seed").unwrap().unwrap();
+    let wal_len = fs::metadata(wal_path(dir.path())).unwrap().len();
+    let stats_before = db.stats();
+    let journal_before = stats_before.journal.unwrap();
+    let value = vec![0x5A; u16::MAX as usize];
+
+    let err = db
+        .atomic(|batch| {
+            for i in 0..OVERSIZED_ATOMIC_OPS {
+                let tree = if i % 2 == 0 { "left" } else { "right" };
+                let key = format!("oversized/db/{i:03}");
+                batch.put(tree, key.as_bytes(), &value);
+            }
+        })
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            holt::Error::Internal("journal record exceeds WAL ring capacity")
+        ),
+        "expected the WAL record limit, got {err:?}",
+    );
+    assert_eq!(fs::metadata(wal_path(dir.path())).unwrap().len(), wal_len);
+    let stats_after = db.stats();
+    let journal_after = stats_after.journal.unwrap();
+    assert_eq!(journal_after.appends, journal_before.appends);
+    assert_eq!(journal_after.queued_work, journal_before.queued_work);
+    assert_eq!(stats_after.bm_dirty_count, stats_before.bm_dirty_count);
+    for i in 0..OVERSIZED_ATOMIC_OPS {
+        let tree = if i % 2 == 0 { &left } else { &right };
+        let key = format!("oversized/db/{i:03}");
+        assert!(tree.get(key.as_bytes()).unwrap().is_none(), "visible {key}");
+    }
+
+    right.put(b"after", b"value").unwrap();
+    let after_version = right.get_version(b"after").unwrap().unwrap();
+    assert_eq!(after_version.as_u64(), seed_version.as_u64() + 1);
 }
 
 #[test]

--- a/tools/soak/Cargo.lock
+++ b/tools/soak/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "holt"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",


### PR DESCRIPTION
## What changed

NoKV's metadata adapter needs an atomic absence check that does not create marker rows or consume record versions. This adds `assert_absent` to single-tree and multi-tree batches.

The same commit series rejects oversized WAL envelopes before it reserves versions or changes live state. Capacity failures leave the WAL, visible keys, and dirty state unchanged.

The branch prepares Holt 0.8.4. After this PR merges, we will tag the resulting `main` commit.

## Validation

- `cargo build --workspace --all-targets`
- `cargo test --workspace --all-targets`
- `cargo test --workspace --doc`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo publish --dry-run --locked`
- 64-run smoke tests for `atomic_model` and `db_model`

Regression tests cover staged absence checks, cross-tree aborts, WAL-free assertion batches, and oversized Tree and DB batches.
