### PR TITLE
docs: point version references at 0.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ a minor release, but minor releases may still break source compatibility
 before 1.0. Pin exact versions for production evaluation:
 
 ```toml
-holt = "=0.8.2"
+holt = "=0.8.3"
 ```
 
 The engine is covered by unit, integration, property, fuzz, soak, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ minor release plus the previous minor.
 
 | Version | Supported |
 |---------|-----------|
-| `0.8.2` | Yes (current) |
-| `< 0.8.2` | No |
+| `0.8.3` | Yes (current) |
+| `< 0.8.3` | No |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Summary

The 0.8.3 bump missed two files that the 0.8.2 release commit (af3de0e) had kept in sync: the README install snippet still pins `=0.8.2` and the SECURITY supported-versions table still lists 0.8.2 as current. #43 restored the standalone lockfiles; this covers the remaining two documentation references.

## Test plan

- [x] docs-only change; no code paths affected
- [ ] full CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)