### PR TITLE
docs: point SECURITY supported versions at 0.8.4

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ minor release plus the previous minor.
 
 | Version | Supported |
 |---------|-----------|
-| `0.8.2` | Yes (current) |
-| `< 0.8.2` | No |
+| `0.8.4` | Yes (current) |
+| `< 0.8.4` | No |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Summary

Replaces #46 (branch renamed for 0.8.4). The 0.8.4 release prep refreshed the README install snippet, so the only remaining stale reference is the SECURITY supported-versions table, which still lists 0.8.2 as current.

## Test plan

- [x] docs-only change; no code paths affected
- [ ] full CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)