### PR TITLE
Add atomic FFI batches and shared read-only opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -492,6 +492,11 @@ state-machine mode. It contains breaking API and on-disk changes — see
 - Kept pending-delete cleanup from reclaiming cache and route-resident
   state until the delete has been applied to the inner blob store.
 
+### Added
+
+- Exposed put and delete batches through `holt_tree_atomic` in the C ABI.
+  The wrapper validates every operation before it calls `Tree::atomic`.
+
 ## [0.4.1] — 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+### Added
+
+- Exposed put and delete batches through `holt_tree_atomic` in the C ABI.
+  The wrapper validates every operation before it calls `Tree::atomic`.
+- Added existing-only read-only opens through `AccessMode`,
+  `TreeConfig::read_only`, `TreeBuilder::read_only`, and
+  `holt_tree_open_read_only`. Read-only handles replay the WAL in memory and
+  reject mutations and maintenance.
+- Added shared reader locks for file-backed stores. Writers keep an exclusive
+  lock, so multiple readers can share one store without overlapping a writer.
+
 ## [0.8.4] — 2026-08-10
 
 ### Added
@@ -491,11 +502,6 @@ state-machine mode. It contains breaking API and on-disk changes — see
   image` and blocking crash-safe checkpoint completion.
 - Kept pending-delete cleanup from reclaiming cache and route-resident
   state until the delete has been applied to the inner blob store.
-
-### Added
-
-- Exposed put and delete batches through `holt_tree_atomic` in the C ABI.
-  The wrapper validates every operation before it calls `Tree::atomic`.
 
 ## [0.4.1] — 2026-05-27
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Read-only handles require an existing file-backed tree:
+
+```rust
+let reader = holt::TreeBuilder::new("/var/lib/app/meta.holt")
+    .read_only()
+    .open()?;
+let value = reader.get(b"objects/bucket-a/images/01.jpg")?;
+```
+
+Holt replays durable WAL records into the reader's memory state without
+changing files. Multiple readers take shared file locks. A writer takes an
+exclusive lock and cannot overlap those readers.
+
+Read-only handles reject mutations, checkpoints, compaction, garbage
+collection, and vacuum.
+
 ## Core API
 
 Point operations:

--- a/crates/holt-ffi/README.md
+++ b/crates/holt-ffi/README.md
@@ -40,6 +40,19 @@ Point operations:
 - `holt_tree_delete(tree, key, key_len, &existed)`
 - `holt_tree_checkpoint(tree)`
 
+Atomic mutations:
+
+- `holt_tree_atomic(tree, ops, op_count, &committed)`
+
+`HoltAtomicOp` supports `HOLT_ATOMIC_PUT` and
+`HOLT_ATOMIC_DELETE`. The function validates the full input array
+before it submits one `Tree::atomic` batch. Holt copies all key and
+value bytes during the call. Operations keep their array order, and
+delete operations require `value_len == 0`.
+
+An empty batch commits successfully. The function writes `committed`
+only when it returns `HOLT_OK`.
+
 Range operations:
 
 - `holt_tree_scan_keys(...)`
@@ -66,10 +79,10 @@ last error.
 
 The ABI exposes the same semantics as Holt's Rust iterators:
 
-- key-only scans use `Tree::scan_keys`;
-- record scans use `Tree::scan`;
-- delimiter values below zero mean "no delimiter";
-- delimiter values `0..=255` enable common-prefix rollup;
+- key-only scans use `Tree::scan_keys`.
+- record scans use `Tree::scan`.
+- delimiter values below zero mean "no delimiter".
+- delimiter values `0..=255` enable common-prefix rollup.
 - `start_after == NULL && start_after_len == 0` means "no marker".
 
 These iterators are restart-on-conflict cursors, not MVCC snapshots.

--- a/crates/holt-ffi/README.md
+++ b/crates/holt-ffi/README.md
@@ -30,8 +30,17 @@ checks the header-level ABI surface.
 Tree lifecycle:
 
 - `holt_tree_open_with_wal_sync(path, wal_sync, &tree)`
+- `holt_tree_open_read_only(path, &tree)`
 - `holt_tree_open_memory(&tree)`
 - `holt_tree_close(tree)`
+
+`holt_tree_open_read_only` requires an existing persistent tree. It
+replays durable WAL records into memory and holds a shared file lock.
+Multiple readers can share the store. A writer needs the exclusive
+file lock.
+
+Read-only handles do not create, repair, or checkpoint files.
+Mutation calls return `HOLT_ERR`.
 
 Point operations:
 
@@ -50,8 +59,8 @@ before it submits one `Tree::atomic` batch. Holt copies all key and
 value bytes during the call. Operations keep their array order, and
 delete operations require `value_len == 0`.
 
-An empty batch commits successfully. The function writes `committed`
-only when it returns `HOLT_OK`.
+On a writable handle, an empty batch commits successfully. The
+function writes `committed` only when it returns `HOLT_OK`.
 
 Range operations:
 

--- a/crates/holt-ffi/examples/abi_smoke.c
+++ b/crates/holt-ffi/examples/abi_smoke.c
@@ -22,6 +22,26 @@ int main(void) {
   }
 
   holt_record_free(&record);
+
+  const uint8_t next_key[] = {'n', 'e', 'x', 't'};
+  const uint8_t next_value[] = {'v', '2'};
+  const HoltAtomicOp ops[] = {
+      {HOLT_ATOMIC_PUT, next_key, sizeof(next_key), next_value,
+       sizeof(next_value)},
+      {HOLT_ATOMIC_DELETE, key, sizeof(key), 0, 0},
+  };
+  uint8_t committed = 0;
+  if (holt_tree_atomic(tree, ops, 2, &committed) != HOLT_OK || !committed) {
+    holt_tree_close(tree);
+    return 1;
+  }
+  if (holt_tree_get(tree, next_key, sizeof(next_key), &record) != HOLT_OK ||
+      !record.found) {
+    holt_tree_close(tree);
+    return 1;
+  }
+
+  holt_record_free(&record);
   holt_tree_close(tree);
   return 0;
 }

--- a/crates/holt-ffi/include/holt_ffi.h
+++ b/crates/holt-ffi/include/holt_ffi.h
@@ -22,6 +22,11 @@ enum {
   HOLT_ENTRY_COMMON_PREFIX = 2
 };
 
+enum {
+  HOLT_ATOMIC_PUT = 1,
+  HOLT_ATOMIC_DELETE = 2
+};
+
 typedef struct HoltBytes {
   uint8_t *ptr;
   size_t len;
@@ -40,6 +45,14 @@ typedef struct HoltEntry {
   uint64_t version;
 } HoltEntry;
 
+typedef struct HoltAtomicOp {
+  uint32_t kind;
+  const uint8_t *key;
+  size_t key_len;
+  const uint8_t *value;
+  size_t value_len;
+} HoltAtomicOp;
+
 const char *holt_last_error_message(void);
 
 int32_t holt_tree_open_with_wal_sync(const char *path, uint8_t wal_sync, HoltTree **out);
@@ -52,6 +65,8 @@ int32_t holt_tree_get(HoltTree *tree, const uint8_t *key, size_t key_len,
                       HoltRecord *out);
 int32_t holt_tree_delete(HoltTree *tree, const uint8_t *key, size_t key_len,
                          uint8_t *existed_out);
+int32_t holt_tree_atomic(HoltTree *tree, const HoltAtomicOp *ops, size_t op_count,
+                         uint8_t *committed_out);
 int32_t holt_tree_checkpoint(HoltTree *tree);
 
 int32_t holt_tree_scan_keys(HoltTree *tree, const uint8_t *prefix, size_t prefix_len,

--- a/crates/holt-ffi/include/holt_ffi.h
+++ b/crates/holt-ffi/include/holt_ffi.h
@@ -56,6 +56,7 @@ typedef struct HoltAtomicOp {
 const char *holt_last_error_message(void);
 
 int32_t holt_tree_open_with_wal_sync(const char *path, uint8_t wal_sync, HoltTree **out);
+int32_t holt_tree_open_read_only(const char *path, HoltTree **out);
 int32_t holt_tree_open_memory(HoltTree **out);
 void holt_tree_close(HoltTree *tree);
 

--- a/crates/holt-ffi/src/lib.rs
+++ b/crates/holt-ffi/src/lib.rs
@@ -289,6 +289,31 @@ pub unsafe extern "C" fn holt_tree_open_with_wal_sync(
     })
 }
 
+/// Open an existing file-backed tree for reads only.
+///
+/// The handle replays durable WAL records into memory but does not
+/// change the store. Mutations and maintenance return `HOLT_ERR`.
+///
+/// # Safety
+///
+/// `path` must be a non-null NUL-terminated UTF-8 string. `out`
+/// must be a valid writable pointer. On success, the caller owns
+/// `*out` and must pass it to [`holt_tree_close`].
+#[no_mangle]
+pub unsafe extern "C" fn holt_tree_open_read_only(
+    path: *const c_char,
+    out: *mut *mut HoltTree,
+) -> i32 {
+    boundary(|| {
+        let path = unsafe { open_path(path) }?;
+        let tree = TreeBuilder::new(path)
+            .read_only()
+            .open()
+            .map_err(|err| err.to_string())?;
+        assign_tree(out, tree)
+    })
+}
+
 /// Open an in-memory tree.
 ///
 /// # Safety
@@ -1034,6 +1059,58 @@ mod tests {
             assert_eq!(bytes(&record.value), value);
             holt_record_free(&mut record);
             holt_tree_close(reopened);
+        }
+    }
+
+    #[test]
+    fn read_only_tree_replays_wal_and_rejects_writes() {
+        unsafe {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("ffi-read-only.holt");
+            let path = CString::new(path.to_str().unwrap()).unwrap();
+            let key = b"objects/a";
+            let value = b"etag-a";
+
+            let mut writer = ptr::null_mut();
+            assert_eq!(
+                holt_tree_open_with_wal_sync(path.as_ptr(), 1, &mut writer),
+                HOLT_OK
+            );
+            assert_eq!(
+                holt_tree_put(writer, key.as_ptr(), key.len(), value.as_ptr(), value.len()),
+                HOLT_OK
+            );
+            holt_tree_close(writer);
+
+            let mut reader = ptr::null_mut();
+            assert_eq!(
+                holt_tree_open_read_only(path.as_ptr(), &mut reader),
+                HOLT_OK
+            );
+            let mut record = HoltRecord::default();
+            assert_eq!(
+                holt_tree_get(reader, key.as_ptr(), key.len(), &mut record),
+                HOLT_OK
+            );
+            assert_eq!(record.found, 1);
+            assert_eq!(bytes(&record.value), value);
+            holt_record_free(&mut record);
+
+            assert_eq!(
+                holt_tree_put(reader, key.as_ptr(), key.len(), value.as_ptr(), value.len()),
+                HOLT_ERR
+            );
+            let msg = CStr::from_ptr(holt_last_error_message()).to_str().unwrap();
+            assert_eq!(msg, "tree is read-only");
+            assert_eq!(holt_tree_checkpoint(reader), HOLT_ERR);
+
+            let mut second_reader = ptr::null_mut();
+            assert_eq!(
+                holt_tree_open_read_only(path.as_ptr(), &mut second_reader),
+                HOLT_OK
+            );
+            holt_tree_close(second_reader);
+            holt_tree_close(reader);
         }
     }
 

--- a/crates/holt-ffi/src/lib.rs
+++ b/crates/holt-ffi/src/lib.rs
@@ -33,6 +33,11 @@ pub const HOLT_ENTRY_KEY: u32 = 1;
 /// `HoltEntry` is a delimiter common-prefix rollup.
 pub const HOLT_ENTRY_COMMON_PREFIX: u32 = 2;
 
+/// `HoltAtomicOp` inserts or replaces one key/value pair.
+pub const HOLT_ATOMIC_PUT: u32 = 1;
+/// `HoltAtomicOp` deletes one key.
+pub const HOLT_ATOMIC_DELETE: u32 = 2;
+
 thread_local! {
     static LAST_ERROR: RefCell<CString> = RefCell::new(CString::new("").expect("empty CString"));
 }
@@ -100,6 +105,27 @@ pub struct HoltEntry {
     pub version: u64,
 }
 
+/// One operation passed to `holt_tree_atomic`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HoltAtomicOp {
+    /// `HOLT_ATOMIC_PUT` or `HOLT_ATOMIC_DELETE`.
+    pub kind: u32,
+    /// Key bytes.
+    pub key: *const u8,
+    /// Number of key bytes.
+    pub key_len: usize,
+    /// Value bytes for `HOLT_ATOMIC_PUT`.
+    pub value: *const u8,
+    /// Number of value bytes. Deletes require zero.
+    pub value_len: usize,
+}
+
+enum ParsedAtomicOp<'a> {
+    Put { key: &'a [u8], value: &'a [u8] },
+    Delete { key: &'a [u8] },
+}
+
 type FfiResult<T> = Result<T, String>;
 
 fn set_error(message: impl Into<String>) -> i32 {
@@ -147,6 +173,19 @@ unsafe fn bytes_arg<'a>(ptr: *const u8, len: usize, name: &str) -> FfiResult<&'a
         return Err(format!(
             "holt ffi: null {name} pointer with non-zero length"
         ));
+    }
+    Ok(unsafe { slice::from_raw_parts(ptr, len) })
+}
+
+unsafe fn atomic_ops_arg<'a>(
+    ptr: *const HoltAtomicOp,
+    len: usize,
+) -> FfiResult<&'a [HoltAtomicOp]> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err("holt ffi: null atomic ops pointer with non-zero count".to_owned());
     }
     Ok(unsafe { slice::from_raw_parts(ptr, len) })
 }
@@ -358,6 +397,70 @@ pub unsafe extern "C" fn holt_tree_delete(
                 *existed_out = u8::from(existed);
             }
         }
+        Ok(HOLT_OK)
+    })
+}
+
+/// Apply puts and deletes through one Holt atomic batch.
+///
+/// # Safety
+///
+/// `tree` must be a live Holt handle. `ops` must point to
+/// `op_count` readable entries unless `op_count` is zero. Each key
+/// and put value must remain readable for the call. `committed_out`
+/// must be a valid writable pointer. The function writes it only on
+/// success.
+#[no_mangle]
+pub unsafe extern "C" fn holt_tree_atomic(
+    tree: *mut HoltTree,
+    ops: *const HoltAtomicOp,
+    op_count: usize,
+    committed_out: *mut u8,
+) -> i32 {
+    boundary(|| {
+        let tree = unsafe { tree_ref(tree) }?;
+        if committed_out.is_null() {
+            return Err("holt ffi: null committed output pointer".to_owned());
+        }
+        let ops = unsafe { atomic_ops_arg(ops, op_count) }?;
+        let mut parsed = Vec::with_capacity(ops.len());
+
+        for (index, op) in ops.iter().enumerate() {
+            let key_name = format!("atomic op {index} key");
+            let key = unsafe { bytes_arg(op.key, op.key_len, &key_name) }?;
+            match op.kind {
+                HOLT_ATOMIC_PUT => {
+                    let value_name = format!("atomic op {index} value");
+                    let value = unsafe { bytes_arg(op.value, op.value_len, &value_name) }?;
+                    parsed.push(ParsedAtomicOp::Put { key, value });
+                }
+                HOLT_ATOMIC_DELETE => {
+                    if op.value_len != 0 {
+                        return Err(format!("holt ffi: atomic delete op {index} has a value"));
+                    }
+                    parsed.push(ParsedAtomicOp::Delete { key });
+                }
+                kind => {
+                    return Err(format!(
+                        "holt ffi: atomic op {index} has unknown kind {kind}"
+                    ));
+                }
+            }
+        }
+
+        let committed = tree
+            .tree
+            .atomic(|batch| {
+                for op in parsed {
+                    match op {
+                        ParsedAtomicOp::Put { key, value } => batch.put(key, value),
+                        ParsedAtomicOp::Delete { key } => batch.delete(key),
+                    }
+                }
+            })
+            .map_err(|err| err.to_string())?;
+        let committed_out = unsafe { out_mut(committed_out, "committed") }?;
+        *committed_out = u8::from(committed);
         Ok(HOLT_OK)
     })
 }
@@ -624,6 +727,146 @@ mod tests {
             );
             assert_eq!(record.found, 0);
 
+            holt_tree_close(tree);
+        }
+    }
+
+    #[test]
+    fn atomic_batch_applies_puts_and_deletes() {
+        unsafe {
+            let mut tree = ptr::null_mut();
+            assert_eq!(holt_tree_open_memory(&mut tree), HOLT_OK);
+
+            let old_key = b"old";
+            assert_eq!(
+                holt_tree_put(tree, old_key.as_ptr(), old_key.len(), b"x".as_ptr(), 1),
+                HOLT_OK
+            );
+
+            let key_a = b"a";
+            let value_a = b"one";
+            let key_b = b"b";
+            let value_b = b"two";
+            let ops = [
+                HoltAtomicOp {
+                    kind: HOLT_ATOMIC_PUT,
+                    key: key_a.as_ptr(),
+                    key_len: key_a.len(),
+                    value: value_a.as_ptr(),
+                    value_len: value_a.len(),
+                },
+                HoltAtomicOp {
+                    kind: HOLT_ATOMIC_PUT,
+                    key: key_b.as_ptr(),
+                    key_len: key_b.len(),
+                    value: value_b.as_ptr(),
+                    value_len: value_b.len(),
+                },
+                HoltAtomicOp {
+                    kind: HOLT_ATOMIC_DELETE,
+                    key: old_key.as_ptr(),
+                    key_len: old_key.len(),
+                    value: ptr::null(),
+                    value_len: 0,
+                },
+            ];
+
+            let mut committed = 0;
+            assert_eq!(
+                holt_tree_atomic(tree, ops.as_ptr(), ops.len(), &mut committed),
+                HOLT_OK
+            );
+            assert_eq!(committed, 1);
+
+            for (key, value) in [(&key_a[..], &value_a[..]), (&key_b[..], &value_b[..])] {
+                let mut record = HoltRecord::default();
+                assert_eq!(
+                    holt_tree_get(tree, key.as_ptr(), key.len(), &mut record),
+                    HOLT_OK
+                );
+                assert_eq!(record.found, 1);
+                assert_eq!(bytes(&record.value), value);
+                holt_record_free(&mut record);
+            }
+
+            let mut record = HoltRecord::default();
+            assert_eq!(
+                holt_tree_get(tree, old_key.as_ptr(), old_key.len(), &mut record),
+                HOLT_OK
+            );
+            assert_eq!(record.found, 0);
+
+            committed = 0;
+            assert_eq!(
+                holt_tree_atomic(tree, ptr::null(), 0, &mut committed),
+                HOLT_OK
+            );
+            assert_eq!(committed, 1);
+            holt_tree_close(tree);
+        }
+    }
+
+    #[test]
+    fn atomic_batch_rejects_all_ops_before_mutation() {
+        unsafe {
+            let mut tree = ptr::null_mut();
+            assert_eq!(holt_tree_open_memory(&mut tree), HOLT_OK);
+
+            let key = b"must-not-exist";
+            let value = b"value";
+            let ops = [
+                HoltAtomicOp {
+                    kind: HOLT_ATOMIC_PUT,
+                    key: key.as_ptr(),
+                    key_len: key.len(),
+                    value: value.as_ptr(),
+                    value_len: value.len(),
+                },
+                HoltAtomicOp {
+                    kind: 99,
+                    key: key.as_ptr(),
+                    key_len: key.len(),
+                    value: ptr::null(),
+                    value_len: 0,
+                },
+            ];
+
+            let mut committed = 9;
+            assert_eq!(
+                holt_tree_atomic(tree, ops.as_ptr(), ops.len(), &mut committed),
+                HOLT_ERR
+            );
+            assert_eq!(committed, 9);
+            let msg = CStr::from_ptr(holt_last_error_message()).to_str().unwrap();
+            assert!(msg.contains("atomic op 1 has unknown kind 99"));
+
+            let mut record = HoltRecord::default();
+            assert_eq!(
+                holt_tree_get(tree, key.as_ptr(), key.len(), &mut record),
+                HOLT_OK
+            );
+            assert_eq!(record.found, 0);
+
+            assert_eq!(
+                holt_tree_atomic(tree, ptr::null(), 1, &mut committed),
+                HOLT_ERR
+            );
+            let msg = CStr::from_ptr(holt_last_error_message()).to_str().unwrap();
+            assert!(msg.contains("atomic ops"));
+
+            let delete_with_value = HoltAtomicOp {
+                kind: HOLT_ATOMIC_DELETE,
+                key: key.as_ptr(),
+                key_len: key.len(),
+                value: value.as_ptr(),
+                value_len: value.len(),
+            };
+            assert_eq!(
+                holt_tree_atomic(tree, &delete_with_value, 1, &mut committed),
+                HOLT_ERR
+            );
+            let msg = CStr::from_ptr(holt_last_error_message()).to_str().unwrap();
+            assert!(msg.contains("atomic delete op 0 has a value"));
             holt_tree_close(tree);
         }
     }

--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -57,6 +57,15 @@ impl TreeBuilder {
         self
     }
 
+    /// Open an existing persistent tree without changing its files.
+    ///
+    /// The handle replays durable WAL records into memory and rejects
+    /// mutations and maintenance operations.
+    pub fn read_only(mut self) -> Self {
+        self.cfg = self.cfg.read_only();
+        self
+    }
+
     /// Background checkpointer policy.
     ///
     /// Persistent trees enable it by default so the dirty set and WAL

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -14,6 +14,15 @@ use crate::checkpoint::CheckpointConfig;
 const DEFAULT_FILE_BUFFER_POOL_SIZE: usize = 256;
 const DEFAULT_MEMORY_BUFFER_POOL_SIZE: usize = 64;
 
+/// Access policy for a file-backed tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessMode {
+    /// Open or create the tree and allow mutations.
+    ReadWrite,
+    /// Open an existing tree without changing files on disk.
+    ReadOnly,
+}
+
 /// Where the tree's data lives.
 ///
 /// `File` is the production target. `Memory` is for tests,
@@ -68,6 +77,12 @@ impl Durability {
 pub struct TreeConfig {
     /// Where the tree's data lives.
     pub storage: Storage,
+    /// Whether a file-backed tree may change its on-disk state.
+    ///
+    /// Read-only opens require an existing tree, take a shared
+    /// file lock, replay the WAL into memory, and do not repair
+    /// torn log tails or start a checkpointer.
+    pub access_mode: AccessMode,
     /// Cache budget, expressed in 512 KB blob-frame units. File-backed
     /// trees split this single total budget between resident blob frames,
     /// the read-index directory cache, and a small 4 KB indexed-read page
@@ -104,6 +119,7 @@ impl TreeConfig {
     pub fn new<P: Into<PathBuf>>(dir: P) -> Self {
         Self {
             storage: Storage::File { dir: dir.into() },
+            access_mode: AccessMode::ReadWrite,
             buffer_pool_size: DEFAULT_FILE_BUFFER_POOL_SIZE,
             durability: Durability::Wal { sync: false },
             memory_flush_on_write: false,
@@ -116,6 +132,7 @@ impl TreeConfig {
     pub fn memory() -> Self {
         Self {
             storage: Storage::Memory,
+            access_mode: AccessMode::ReadWrite,
             buffer_pool_size: DEFAULT_MEMORY_BUFFER_POOL_SIZE,
             durability: Durability::Wal { sync: false },
             memory_flush_on_write: true,
@@ -126,10 +143,24 @@ impl TreeConfig {
         }
     }
 
+    /// Require an existing file-backed tree and disable all writes.
+    #[must_use]
+    pub fn read_only(mut self) -> Self {
+        self.access_mode = AccessMode::ReadOnly;
+        self.checkpoint.enabled = false;
+        self
+    }
+
     /// `true` iff [`Storage::Memory`].
     #[must_use]
     pub fn is_memory(&self) -> bool {
         matches!(self.storage, Storage::Memory)
+    }
+
+    /// `true` when the tree was configured for a non-mutating open.
+    #[must_use]
+    pub fn is_read_only(&self) -> bool {
+        self.access_mode == AccessMode::ReadOnly
     }
 
     /// Path of the WAL file for this configuration, if any.
@@ -153,11 +184,19 @@ mod tests {
         let cfg = TreeConfig::new("/tmp/holt");
         assert_eq!(cfg.buffer_pool_size, 256);
         assert!(!cfg.memory_flush_on_write);
+        assert_eq!(cfg.access_mode, AccessMode::ReadWrite);
     }
 
     #[test]
     fn memory_default_buffer_pool_stays_small() {
         let cfg = TreeConfig::memory();
         assert_eq!(cfg.buffer_pool_size, 64);
+    }
+
+    #[test]
+    fn read_only_disables_background_checkpointing() {
+        let cfg = TreeConfig::new("/tmp/holt").read_only();
+        assert!(cfg.is_read_only());
+        assert!(!cfg.checkpoint.enabled);
     }
 }

--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -17,7 +17,9 @@ use super::config::TreeConfig;
 use super::errors::{Error, Result};
 use super::snapshot::Snapshot;
 use super::stats::{CheckpointerStats, DBStats, JournalStats, OpenStats, VacuumStats};
-use super::tree::{ensure_durable_root_blob, replay_wal, Tree, TreeRuntime};
+use super::tree::{
+    ensure_durable_root_blob, ensure_root_blob_for_open, replay_wal, Tree, TreeRuntime,
+};
 use super::view::View;
 use crate::concurrency::{CommitGate, Gate};
 use crate::engine::RangeEntry;
@@ -187,7 +189,9 @@ impl DB {
                 let next_seq = if path.exists() {
                     let start = std::time::Instant::now();
                     let (next_seq, replay_stats) =
-                        replay_wal(&path, &bm, |tree_id| Ok(root_guid_for_tree_id(tree_id)))?;
+                        replay_wal(&path, &bm, !cfg.is_read_only(), |tree_id| {
+                            Ok(root_guid_for_tree_id(tree_id))
+                        })?;
                     open_stats.wal_replay_micros = start.elapsed().as_micros() as u64;
                     open_stats.wal_replay_records = replay_stats.records_seen;
                     open_stats.wal_torn_tail = replay_stats.torn_tail_at.is_some();
@@ -198,8 +202,12 @@ impl DB {
                 } else {
                     1
                 };
-                let journal = Journal::open_or_create(&path, 0)?;
-                (Some(Arc::new(journal)), next_seq)
+                let journal = if cfg.is_read_only() {
+                    None
+                } else {
+                    Some(Arc::new(Journal::open_or_create(&path, 0)?))
+                };
+                (journal, next_seq)
             }
             _ => (None, 1),
         };
@@ -229,15 +237,27 @@ impl DB {
             .as_micros()
             .min(u128::from(u64::MAX)) as u64;
         db.restore_dropping_runtime_fences()?;
-        db.checkpointer = crate::checkpoint::Checkpointer::spawn(
-            Arc::clone(&db.store),
-            db.journal.clone(),
-            Arc::clone(&db.maintenance_gate),
-            Arc::clone(&db.commit_gate),
-            db.cfg.checkpoint.clone(),
-        )
-        .map(Arc::new);
+        db.checkpointer = if db.cfg.is_read_only() {
+            None
+        } else {
+            crate::checkpoint::Checkpointer::spawn(
+                Arc::clone(&db.store),
+                db.journal.clone(),
+                Arc::clone(&db.maintenance_gate),
+                Arc::clone(&db.commit_gate),
+                db.cfg.checkpoint.clone(),
+            )
+            .map(Arc::new)
+        };
         Ok(db)
+    }
+
+    fn ensure_writable(&self) -> Result<()> {
+        if self.cfg.is_read_only() {
+            Err(Error::ReadOnly)
+        } else {
+            Ok(())
+        }
     }
 
     /// Create a named tree inside this DB.
@@ -246,6 +266,7 @@ impl DB {
     /// handle is returned. Re-creating an existing name returns
     /// [`Error::TreeExists`].
     pub fn create_tree(&self, name: &str) -> Result<Tree> {
+        self.ensure_writable()?;
         let name_bytes = validate_tree_name(name)?;
         let _maintenance = self.maintenance_gate.enter_exclusive();
         if self.catalog_entry(name_bytes)?.is_some() {
@@ -361,6 +382,7 @@ impl DB {
     /// Snapshot roots are protected independently and do not by themselves
     /// retain a `Dropping` family's live root.
     pub fn drop_tree(&self, name: &str) -> Result<()> {
+        self.ensure_writable()?;
         let name_bytes = validate_tree_name(name)?;
         let _maintenance = self.maintenance_gate.enter_exclusive();
         let entry = match self.catalog_entry(name_bytes)? {
@@ -406,6 +428,7 @@ impl DB {
     where
         F: FnOnce(&mut DBAtomicBatch),
     {
+        self.ensure_writable()?;
         let mut batch = DBAtomicBatch::default();
         build(&mut batch);
         if batch.pending.is_empty() {
@@ -478,6 +501,7 @@ impl DB {
     /// idempotent. Concurrent create/drop operations serialize behind the
     /// same DB maintenance fence.
     pub fn gc(&self) -> Result<usize> {
+        self.ensure_writable()?;
         self.restore_dropping_runtime_fences()?;
         let (freed, cleanup_complete) = self.gc_reachability_pass(usize::MAX, true)?;
         if cleanup_complete && self.finalize_dropped_trees()? {
@@ -501,6 +525,7 @@ impl DB {
     /// hole-punch remaining reusable middle slots. GUID/key visibility is
     /// unchanged.
     pub fn vacuum(&self) -> Result<VacuumStats> {
+        self.ensure_writable()?;
         let unreachable = self.gc()?;
         let mut stats = self.store.vacuum_storage()?;
         stats.unreachable_blobs = unreachable;
@@ -573,6 +598,7 @@ impl DB {
     /// and the install retried — do not serve from a half-installed DB.
     /// Holt does not yet provide online replacement of a live DB image.
     pub fn install_checkpoint(&self, image: &CheckpointImage) -> Result<()> {
+        self.ensure_writable()?;
         let decoded = checkpoint::decode(image.as_bytes())?;
         for (name, kv) in &decoded.families {
             let name = std::str::from_utf8(name)
@@ -593,6 +619,7 @@ impl DB {
     /// catalog removals completed by that pass. It is not tied to any one
     /// named tree.
     pub fn checkpoint(&self) -> Result<()> {
+        self.ensure_writable()?;
         self.restore_dropping_runtime_fences()?;
         Tree::checkpoint_shared_store(
             &self.store,
@@ -618,6 +645,7 @@ impl DB {
     /// Run one online maintenance pass for the catalog and every
     /// named tree.
     pub fn compact(&self) -> Result<()> {
+        self.ensure_writable()?;
         self.catalog_tree()?.compact()?;
         for name in self.list_trees()? {
             self.open_tree(&name)?.compact()?;
@@ -733,6 +761,9 @@ impl DB {
     fn restore_epoch_high_water(&self) -> Result<()> {
         let catalog_root = root_guid_for_tree_id(DB_CATALOG_TREE_ID);
         if !self.store.has_blob(catalog_root)? {
+            if self.cfg.is_read_only() {
+                return ensure_root_blob_for_open(&self.store, catalog_root, false);
+            }
             let durable = self.store.store_blob_guids()?;
             let truly_fresh = durable.is_empty()
                 && self.store.cached_count() == 0
@@ -990,7 +1021,7 @@ impl DB {
             return Err(Error::TreeDropped);
         }
         let root_guid = root_guid_for_tree_id(tree_id);
-        ensure_durable_root_blob(&self.store, root_guid)?;
+        ensure_root_blob_for_open(&self.store, root_guid, !self.cfg.is_read_only())?;
         let open = OpenTree {
             root_guid,
             runtime: TreeRuntime::new(),

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -108,6 +108,8 @@ pub enum Error {
     },
     /// A named DB tree handle was used after `DB::drop_tree`.
     TreeDropped,
+    /// A mutation or maintenance operation used a read-only handle.
+    ReadOnly,
     /// A scoped [`crate::View`] read tried to access a key or range
     /// prefix outside the subtree captured when the view was opened.
     OutsideViewScope {
@@ -214,6 +216,7 @@ impl std::fmt::Display for Error {
             Self::TreeExists { name } => write!(f, "DB tree already exists: {name}"),
             Self::InvalidTreeName { reason } => write!(f, "invalid DB tree name: {reason}"),
             Self::TreeDropped => write!(f, "DB tree has been dropped"),
+            Self::ReadOnly => write!(f, "tree is read-only"),
             Self::OutsideViewScope {
                 requested_len,
                 scope_len,
@@ -331,6 +334,7 @@ mod tests {
                 "invalid DB tree name: empty",
             ),
             (Error::TreeDropped.to_string(), "DB tree has been dropped"),
+            (Error::ReadOnly.to_string(), "tree is read-only"),
             (
                 Error::SnapshotEpochExhausted.to_string(),
                 "snapshot epoch exhausted",
@@ -364,6 +368,7 @@ mod tests {
             .source()
             .is_none());
         assert!(Error::TreeDropped.source().is_none());
+        assert!(Error::ReadOnly.source().is_none());
         assert!(Error::SnapshotEpochExhausted.source().is_none());
     }
 }

--- a/src/api/tree.rs
+++ b/src/api/tree.rs
@@ -540,10 +540,14 @@ impl Tree {
             Storage::File { dir } => {
                 #[cfg(all(target_os = "linux", feature = "io-uring"))]
                 {
-                    let store = Arc::new(FileBlobStore::open_with_buffer_pool_hint(
-                        dir,
-                        cfg.buffer_pool_size,
-                    )?);
+                    let store = Arc::new(if cfg.is_read_only() {
+                        FileBlobStore::open_read_only_with_buffer_pool_hint(
+                            dir,
+                            cfg.buffer_pool_size,
+                        )?
+                    } else {
+                        FileBlobStore::open_with_buffer_pool_hint(dir, cfg.buffer_pool_size)?
+                    });
                     let store_dyn: Arc<dyn BlobStore> = store.clone();
                     let alloc_store = Arc::clone(&store);
                     Arc::new(BufferManager::new_file(
@@ -558,7 +562,11 @@ impl Tree {
                 }
                 #[cfg(not(all(target_os = "linux", feature = "io-uring")))]
                 {
-                    let store: Arc<dyn BlobStore> = Arc::new(FileBlobStore::open(dir)?);
+                    let store: Arc<dyn BlobStore> = Arc::new(if cfg.is_read_only() {
+                        FileBlobStore::open_read_only(dir)?
+                    } else {
+                        FileBlobStore::open(dir)?
+                    });
                     Arc::new(BufferManager::new_file(store, cfg.buffer_pool_size, || {
                         // SAFETY: BufferManager initializes every
                         // returned buffer before reading it.
@@ -572,7 +580,7 @@ impl Tree {
 
     fn open_inner(cfg: TreeConfig, bm: Arc<BufferManager>, attach_journal: bool) -> Result<Self> {
         let root_guid = ROOT_BLOB_GUID;
-        ensure_durable_root_blob(&bm, root_guid)?;
+        ensure_root_blob_for_open(&bm, root_guid, !cfg.is_read_only())?;
 
         let mut open_stats = OpenStats::default();
         // Restore the CoW epoch above every persisted frame's
@@ -595,16 +603,17 @@ impl Tree {
                 Some(path) => {
                     let next_seq = if path.exists() {
                         let start = std::time::Instant::now();
-                        let (next_seq, replay_stats) = replay_wal(&path, &bm, |tree_id| {
-                            if tree_id == 0 {
-                                Ok(root_guid)
-                            } else {
-                                Err(Error::ReplaySanityFailed {
-                                    context: "WAL record tree_id does not belong to this Tree",
-                                    record_offset: 0,
-                                })
-                            }
-                        })?;
+                        let (next_seq, replay_stats) =
+                            replay_wal(&path, &bm, !cfg.is_read_only(), |tree_id| {
+                                if tree_id == 0 {
+                                    Ok(root_guid)
+                                } else {
+                                    Err(Error::ReplaySanityFailed {
+                                        context: "WAL record tree_id does not belong to this Tree",
+                                        record_offset: 0,
+                                    })
+                                }
+                            })?;
                         open_stats.wal_replay_micros = start.elapsed().as_micros() as u64;
                         open_stats.wal_replay_records = replay_stats.records_seen;
                         open_stats.wal_torn_tail = replay_stats.torn_tail_at.is_some();
@@ -615,8 +624,14 @@ impl Tree {
                     } else {
                         1
                     };
-                    let journal = Journal::open_or_create(&path, /*tree_id=*/ 0)?;
-                    (Some(Arc::new(journal)), next_seq)
+                    let journal = if cfg.is_read_only() {
+                        None
+                    } else {
+                        Some(Arc::new(Journal::open_or_create(
+                            &path, /*tree_id=*/ 0,
+                        )?))
+                    };
+                    (journal, next_seq)
                 }
             }
         } else {
@@ -631,14 +646,18 @@ impl Tree {
         // Spawn the background checkpointer if opted-in.
         // `Checkpointer::spawn` returns `None` for disabled
         // configs, so the `Option` chain stays clean.
-        let checkpointer = crate::checkpoint::Checkpointer::spawn(
-            Arc::clone(&bm),
-            journal.clone(),
-            Arc::clone(&maintenance_gate),
-            Arc::clone(&commit_gate),
-            cfg.checkpoint.clone(),
-        )
-        .map(Arc::new);
+        let checkpointer = if cfg.is_read_only() {
+            None
+        } else {
+            crate::checkpoint::Checkpointer::spawn(
+                Arc::clone(&bm),
+                journal.clone(),
+                Arc::clone(&maintenance_gate),
+                Arc::clone(&commit_gate),
+                cfg.checkpoint.clone(),
+            )
+            .map(Arc::new)
+        };
 
         Self::from_shared(
             cfg,
@@ -697,6 +716,15 @@ impl Tree {
     fn ensure_live(&self) -> Result<()> {
         if self.dropped.load(Ordering::Acquire) {
             Err(Error::TreeDropped)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn ensure_writable(&self) -> Result<()> {
+        self.ensure_live()?;
+        if self.cfg.is_read_only() {
+            Err(Error::ReadOnly)
         } else {
             Ok(())
         }
@@ -785,6 +813,7 @@ impl Tree {
     /// Per-op `memory_flush_on_write` mode drains the dirty set
     /// inline after the WAL append.
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.ensure_writable()?;
         if self.can_stage_deferred_write() {
             self.put_deferred(key, value)
         } else {
@@ -799,6 +828,7 @@ impl Tree {
     /// when a live value already existed. The existence check and
     /// insert happen under the target blob's exclusive latch.
     pub fn put_if_absent(&self, key: &[u8], value: &[u8]) -> Result<bool> {
+        self.ensure_writable()?;
         self.flush_write_delta_for_tree()?;
         self.put_inner_conditional(key, value, engine::InsertCondition::IfAbsent)
             .map(|outcome| outcome.mutated)
@@ -815,6 +845,7 @@ impl Tree {
     /// keys within `entries` create once; later copies report
     /// `AlreadyExists`.
     pub fn put_many_if_absent(&self, entries: &[(&[u8], &[u8])]) -> Result<Vec<PutOutcome>> {
+        self.ensure_writable()?;
         self.flush_write_delta_for_tree()?;
         let _maintenance = self.maintenance_gate.enter_shared();
         self.ensure_live()?;
@@ -859,6 +890,7 @@ impl Tree {
         expected_version: RecordVersion,
         value: &[u8],
     ) -> Result<bool> {
+        self.ensure_writable()?;
         self.flush_write_delta_for_tree()?;
         self.put_inner_conditional(
             key,
@@ -887,7 +919,7 @@ impl Tree {
         Self::validate_insert_shape(key, value)?;
         let ack = {
             let _mutation = self.maintenance_gate.enter_shared();
-            self.ensure_live()?;
+            self.ensure_writable()?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             let creates_key = self.get_version(key)?.is_none();
@@ -928,7 +960,7 @@ impl Tree {
 
         let (outcome, journal_ack) = {
             let _mutation = self.maintenance_gate.enter_shared();
-            self.ensure_live()?;
+            self.ensure_writable()?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
@@ -1002,6 +1034,7 @@ impl Tree {
     /// fallback that unlinks a child blob queues the manifest
     /// delete through the same W2D-safe pending-delete protocol.
     pub fn delete(&self, key: &[u8]) -> Result<bool> {
+        self.ensure_writable()?;
         if self.can_stage_deferred_write() {
             self.delete_deferred(key)
         } else {
@@ -1017,6 +1050,7 @@ impl Tree {
     /// tombstoned, or has been updated since the caller obtained
     /// the version.
     pub fn delete_if_version(&self, key: &[u8], expected_version: RecordVersion) -> Result<bool> {
+        self.ensure_writable()?;
         self.flush_write_delta_for_tree()?;
         self.delete_inner_conditional(
             key,
@@ -1028,7 +1062,7 @@ impl Tree {
     fn delete_deferred(&self, key: &[u8]) -> Result<bool> {
         let ack = {
             let _mutation = self.maintenance_gate.enter_shared();
-            self.ensure_live()?;
+            self.ensure_writable()?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             if self.get_version(key)?.is_none() {
@@ -1077,7 +1111,7 @@ impl Tree {
 
         let (outcome, journal_ack) = {
             let _mutation = self.maintenance_gate.enter_shared();
-            self.ensure_live()?;
+            self.ensure_writable()?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
@@ -1153,13 +1187,14 @@ impl Tree {
     /// single `RenameObject` WAL record so its erase + insert phases
     /// recover atomically on replay.
     pub fn rename(&self, src: &[u8], dst: &[u8], force: bool) -> Result<()> {
+        self.ensure_writable()?;
         self.flush_write_delta_for_tree()?;
         let src_search = engine::SearchKey::user(src);
         let dst_search = engine::SearchKey::user(dst);
 
         let journal_ack = {
             let _mutation = self.maintenance_gate.enter_shared();
-            self.ensure_live()?;
+            self.ensure_writable()?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoints = self.endpoint_locks.lock_pair(src, dst);
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
@@ -1305,6 +1340,7 @@ impl Tree {
     where
         F: FnOnce(&mut AtomicBatch),
     {
+        self.ensure_writable()?;
         let mut batch = AtomicBatch::default();
         build(&mut batch);
         if batch.pending.is_empty() {
@@ -1314,6 +1350,7 @@ impl Tree {
     }
 
     pub(crate) fn apply_batch(&self, pending: Vec<BatchOp>) -> Result<bool> {
+        self.ensure_writable()?;
         let count = pending.iter().filter(|op| op.emits_wal()).count() as u64;
         if count != 0 {
             if let Some(journal) = &self.journal {
@@ -1972,6 +2009,7 @@ impl Tree {
     /// share one buffer manager, so a safe sweep needs a DB-wide pass and
     /// this returns [`Error::GcRequiresStandaloneTree`].
     pub fn gc(&self) -> Result<usize> {
+        self.ensure_writable()?;
         if self.tree_id != 0 {
             return Err(Error::GcRequiresStandaloneTree);
         }
@@ -2307,6 +2345,7 @@ impl Tree {
     /// `memory_flush_on_write = false` callers rely on this to make
     /// batched writes survive a crash.
     pub fn checkpoint(&self) -> Result<()> {
+        self.ensure_writable()?;
         if self.tree_id != 0 {
             return Self::checkpoint_shared_store(
                 &self.store,
@@ -2890,7 +2929,7 @@ impl Tree {
     /// settled if you want to force a tree all the way down after a
     /// heavy churn phase.
     pub fn compact(&self) -> Result<()> {
-        self.ensure_live()?;
+        self.ensure_writable()?;
         if self.store.compaction_candidate_count() == 0 && self.store.merge_candidate_count() == 0 {
             self.seed_maintenance_candidates()?;
         }
@@ -3048,7 +3087,21 @@ impl Tree {
 /// Ensure a deterministic empty root exists beyond the store's durability
 /// frontier before any catalog or replay path publishes a reference to it.
 pub(crate) fn ensure_durable_root_blob(bm: &Arc<BufferManager>, root_guid: BlobGuid) -> Result<()> {
+    ensure_root_blob_for_open(bm, root_guid, true)
+}
+
+pub(crate) fn ensure_root_blob_for_open(
+    bm: &Arc<BufferManager>,
+    root_guid: BlobGuid,
+    create_if_missing: bool,
+) -> Result<()> {
     if !bm.has_blob(root_guid)? {
+        if !create_if_missing {
+            return Err(Error::BlobStoreIo(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "read-only tree root blob is missing",
+            )));
+        }
         let mut scratch = bm.alloc_blob_buf_zeroed();
         BlobFrame::init(scratch.as_mut_slice(), root_guid)?;
         bm.write_blob(root_guid, &scratch)?;
@@ -3060,7 +3113,9 @@ pub(crate) fn ensure_durable_root_blob(bm: &Arc<BufferManager>, root_guid: BlobG
     // Always retry the durability barrier. Custom stores may have submitted
     // a prior root write before returning a flush error, and `has_blob` alone
     // does not imply that mapping survived a crash.
-    bm.flush()?;
+    if create_if_missing {
+        bm.flush()?;
+    }
     Ok(())
 }
 
@@ -3092,6 +3147,7 @@ pub(crate) fn ensure_durable_root_blob(bm: &Arc<BufferManager>, root_guid: BlobG
 pub(crate) fn replay_wal<F>(
     path: &std::path::Path,
     bm: &Arc<BufferManager>,
+    allow_recovery_writes: bool,
     mut root_for_tree_id: F,
 ) -> Result<(u64, crate::journal::reader::ReplayStats)>
 where
@@ -3107,7 +3163,7 @@ where
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 let guid = root_for_tree_id(tree_id)?;
-                ensure_durable_root_blob(bm, guid)?;
+                ensure_root_blob_for_open(bm, guid, allow_recovery_writes)?;
                 let pin = bm.pin(guid)?;
                 let (guid, pin) = entry.insert((guid, pin));
                 (*guid, Arc::clone(pin))
@@ -3186,11 +3242,13 @@ where
     // acked record written after it. The torn record was never acked (the
     // crash hit mid-write, before its fdatasync), so truncating it to the
     // last complete record loses nothing durable — standard WAL recovery.
-    if let Some(off) = stats.torn_tail_at {
-        std::fs::OpenOptions::new()
-            .write(true)
-            .open(path)?
-            .set_len(off)?;
+    if allow_recovery_writes {
+        if let Some(off) = stats.torn_tail_at {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(path)?
+                .set_len(off)?;
+        }
     }
     // After commit, the blob image is durable; we still want the
     // next allocated seq to be strictly greater than anything

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub mod metrics;
 // Core handle + configuration.
 pub use api::builder::TreeBuilder;
 pub use api::checkpoint::CheckpointImage;
-pub use api::config::{Durability, Storage, TreeConfig};
+pub use api::config::{AccessMode, Durability, Storage, TreeConfig};
 pub use api::db::{DBAtomicBatch, DBView, DB};
 pub use api::errors::{Error, Result};
 pub use api::key::{KeyPathBuf, KeyPathError, KeyPrefixBuf};

--- a/src/store/blob_store/file/mod.rs
+++ b/src/store/blob_store/file/mod.rs
@@ -24,10 +24,9 @@
 //!     value.seg      — optional packed read value payloads, one
 //!                      slot per blob slot; referenced only by
 //!                      `read.idx` entries and rebuildable
-//!     store.lock     — zero-byte advisory lock file; held
-//!                      exclusively (flock) for the lifetime of an
-//!                      open instance so a second opener cannot
-//!                      corrupt the manifest
+//!     store.lock     — zero-byte advisory lock file; readers hold a
+//!                      shared flock and writers hold an exclusive
+//!                      flock for the lifetime of an open instance
 //! ```
 //!
 //! Design rationale:
@@ -110,8 +109,8 @@ use self::uring::UringContext;
 
 /// Filename of the packed blob data file inside `data_dir`.
 const DATA_FILENAME: &str = "blobs.dat";
-/// Advisory lock file inside `data_dir`, flock'd exclusively for
-/// the lifetime of an open instance.
+/// Advisory lock file inside `data_dir`, flock'd for the lifetime of
+/// an open instance. Readers hold shared locks; writers hold exclusive locks.
 const LOCK_FILENAME: &str = "store.lock";
 /// How long `open` waits for a previous instance to release the
 /// directory lock before failing. Covers the handover pattern where
@@ -192,14 +191,10 @@ const VALUE_SEGMENT_SLOT_BYTES: usize = PAGE_SIZE as usize;
 #[derive(Debug)]
 pub struct FileBlobStore {
     data_dir: PathBuf,
-    /// Exclusive advisory lock on `data_dir`, held for the lifetime
-    /// of this instance. Two live instances on one directory would
-    /// each replay `manifest.log` into the same `next_slot`, assign
-    /// the same slot to different blob GUIDs, and append conflicting
-    /// set deltas — permanently corrupting the manifest. The kernel
-    /// releases the lock when this handle closes, so a crashed
-    /// holder never leaves a stale lock behind.
+    /// Shared read or exclusive write advisory lock on `data_dir`.
+    /// The kernel releases the lock when this handle closes.
     _dir_lock: File,
+    access: FileAccess,
     data_file: File,
     read_index_file: File,
     value_segment_file: File,
@@ -297,30 +292,47 @@ struct FreeSlotRange {
     end: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileAccess {
+    ReadWrite,
+    ReadOnly,
+}
+
+impl FileAccess {
+    fn is_read_only(self) -> bool {
+        self == Self::ReadOnly
+    }
+}
+
 impl FreeSlotRange {
     fn slot_count(self) -> u64 {
         self.end.saturating_sub(self.next).saturating_add(1)
     }
 }
 
-/// Acquire the exclusive advisory lock on `data_dir`, waiting up to
-/// `timeout` for a previous instance to release it.
+/// Acquire the advisory lock for `access`, waiting up to `timeout`
+/// for an incompatible instance to release it.
 ///
 /// `flock(2)` locks are per open-file-description, so this also
-/// rejects a second instance inside the same process — the scenario
-/// `fcntl` record locks would silently allow. The polling wait lets
-/// an open racing a previous instance's drop (the common handover
-/// pattern `store = reopen(path)`) serialize instead of failing.
-fn acquire_dir_lock(data_dir: &Path, timeout: Duration) -> Result<File> {
-    let lock_file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .custom_flags(libc::O_CLOEXEC)
-        .open(data_dir.join(LOCK_FILENAME))?;
+/// rejects incompatible instances inside the same process while
+/// allowing several read-only instances. The polling wait lets an
+/// open racing a previous instance's drop (the common handover pattern
+/// `store = reopen(path)`) serialize instead of failing.
+fn acquire_dir_lock(data_dir: &Path, access: FileAccess, timeout: Duration) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).custom_flags(libc::O_CLOEXEC);
+    if !access.is_read_only() {
+        options.write(true).create(true);
+    }
+    let lock_file = options.open(data_dir.join(LOCK_FILENAME))?;
+    let operation = if access.is_read_only() {
+        libc::LOCK_SH | libc::LOCK_NB
+    } else {
+        libc::LOCK_EX | libc::LOCK_NB
+    };
     let deadline = Instant::now() + timeout;
     loop {
-        let rc = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        let rc = unsafe { libc::flock(lock_file.as_raw_fd(), operation) };
         if rc == 0 {
             return Ok(lock_file);
         }
@@ -332,9 +344,8 @@ fn acquire_dir_lock(data_dir: &Path, timeout: Duration) -> Result<File> {
                     return Err(Error::BlobStoreIo(io::Error::new(
                         io::ErrorKind::WouldBlock,
                         format!(
-                            "blob store at {} is locked by another live instance \
-                             (waited {timeout:?}); a second opener would corrupt \
-                             the manifest",
+                            "blob store at {} has an incompatible live access mode \
+                             (waited {timeout:?})",
                             data_dir.display()
                         ),
                     )));
@@ -351,6 +362,28 @@ fn align_up(value: usize, align: usize) -> usize {
     (value + align - 1) & !(align - 1)
 }
 
+fn open_store_file(path: &Path, custom_flags: i32, access: FileAccess) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).custom_flags(custom_flags);
+    if !access.is_read_only() {
+        options.write(true).create(true);
+    }
+    options.open(path)
+}
+
+fn open_read_accelerator_file(
+    path: &Path,
+    custom_flags: i32,
+    access: FileAccess,
+) -> io::Result<File> {
+    match open_store_file(path, custom_flags, access) {
+        Err(err) if access.is_read_only() && err.kind() == io::ErrorKind::NotFound => {
+            open_store_file(Path::new("/dev/null"), custom_flags, FileAccess::ReadOnly)
+        }
+        result => result,
+    }
+}
+
 impl FileBlobStore {
     /// Open or create a persistent store at `data_dir`.
     ///
@@ -359,7 +392,23 @@ impl FileBlobStore {
     /// with `O_CLOEXEC` only (macOS additionally sets `F_NOCACHE`).
     /// Loads the manifest if present; otherwise starts empty.
     pub fn open<P: Into<PathBuf>>(data_dir: P) -> Result<Self> {
-        Self::open_with_registered_buffer_capacity(data_dir, REGISTERED_BUFFER_MAX_SLOTS)
+        Self::open_with_registered_buffer_capacity(
+            data_dir,
+            REGISTERED_BUFFER_MAX_SLOTS,
+            FileAccess::ReadWrite,
+        )
+    }
+
+    /// Open an existing persistent store without changing its files.
+    ///
+    /// The returned handle holds a shared file lock. Store mutation
+    /// methods return [`Error::ReadOnly`].
+    pub fn open_read_only<P: Into<PathBuf>>(data_dir: P) -> Result<Self> {
+        Self::open_with_registered_buffer_capacity(
+            data_dir,
+            REGISTERED_BUFFER_MAX_SLOTS,
+            FileAccess::ReadOnly,
+        )
     }
 
     /// Open with a registered-buffer hot-pool hint derived from the
@@ -372,20 +421,32 @@ impl FileBlobStore {
         buffer_pool_size: usize,
     ) -> Result<Self> {
         let slots = registered_buffer_slots(buffer_pool_size);
-        Self::open_with_registered_buffer_capacity(data_dir, slots)
+        Self::open_with_registered_buffer_capacity(data_dir, slots, FileAccess::ReadWrite)
+    }
+
+    #[cfg(all(target_os = "linux", feature = "io-uring"))]
+    pub(crate) fn open_read_only_with_buffer_pool_hint<P: Into<PathBuf>>(
+        data_dir: P,
+        buffer_pool_size: usize,
+    ) -> Result<Self> {
+        let slots = registered_buffer_slots(buffer_pool_size);
+        Self::open_with_registered_buffer_capacity(data_dir, slots, FileAccess::ReadOnly)
     }
 
     #[cfg(all(target_os = "linux", feature = "io-uring"))]
     fn open_with_registered_buffer_capacity<P: Into<PathBuf>>(
         data_dir: P,
         registered_buffer_slots: usize,
+        access: FileAccess,
     ) -> Result<Self> {
         let data_dir = data_dir.into();
-        std::fs::create_dir_all(&data_dir)?;
+        if !access.is_read_only() {
+            std::fs::create_dir_all(&data_dir)?;
+        }
         // Take the lock before touching any store file: manifest
         // replay (including torn-tail truncation) must not run
         // while another instance can still append deltas.
-        let dir_lock = acquire_dir_lock(&data_dir, DIR_LOCK_ACQUIRE_TIMEOUT)?;
+        let dir_lock = acquire_dir_lock(&data_dir, access, DIR_LOCK_ACQUIRE_TIMEOUT)?;
 
         let data_path = data_dir.join(DATA_FILENAME);
         let read_index_path = data_dir.join(READ_INDEX_FILENAME);
@@ -404,24 +465,10 @@ impl FileBlobStore {
             }
         };
         let index_flags = libc::O_CLOEXEC;
-        let data_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .custom_flags(data_flags)
-            .open(&data_path)?;
-        let read_index_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .custom_flags(index_flags)
-            .open(&read_index_path)?;
-        let value_segment_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .custom_flags(index_flags)
-            .open(&value_segment_path)?;
+        let data_file = open_store_file(&data_path, data_flags, access)?;
+        let read_index_file = open_read_accelerator_file(&read_index_path, index_flags, access)?;
+        let value_segment_file =
+            open_read_accelerator_file(&value_segment_path, index_flags, access)?;
 
         // macOS doesn't have O_DIRECT; F_NOCACHE on the fd is the
         // closest equivalent (tells the VFS not to populate the
@@ -431,7 +478,8 @@ impl FileBlobStore {
             let _ = libc::fcntl(data_file.as_raw_fd(), libc::F_NOCACHE, 1);
         }
 
-        let manifest = Manifest::load_or_create(&manifest_path, &manifest_log_path)?;
+        let manifest =
+            Manifest::load_or_create(&manifest_path, &manifest_log_path, !access.is_read_only())?;
         let file_slots = slots_for_len(data_file.metadata()?.len());
         let preallocated_slots = file_slots.max(manifest.next_slot);
 
@@ -450,6 +498,7 @@ impl FileBlobStore {
         Ok(Self {
             data_dir,
             _dir_lock: dir_lock,
+            access,
             data_file,
             read_index_file,
             value_segment_file,
@@ -471,13 +520,16 @@ impl FileBlobStore {
     fn open_with_registered_buffer_capacity<P: Into<PathBuf>>(
         data_dir: P,
         _registered_buffer_slots: usize,
+        access: FileAccess,
     ) -> Result<Self> {
         let data_dir = data_dir.into();
-        std::fs::create_dir_all(&data_dir)?;
+        if !access.is_read_only() {
+            std::fs::create_dir_all(&data_dir)?;
+        }
         // Take the lock before touching any store file: manifest
         // replay (including torn-tail truncation) must not run
         // while another instance can still append deltas.
-        let dir_lock = acquire_dir_lock(&data_dir, DIR_LOCK_ACQUIRE_TIMEOUT)?;
+        let dir_lock = acquire_dir_lock(&data_dir, access, DIR_LOCK_ACQUIRE_TIMEOUT)?;
 
         let data_path = data_dir.join(DATA_FILENAME);
         let read_index_path = data_dir.join(READ_INDEX_FILENAME);
@@ -496,37 +548,25 @@ impl FileBlobStore {
             }
         };
         let index_flags = libc::O_CLOEXEC;
-        let data_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .custom_flags(data_flags)
-            .open(&data_path)?;
-        let read_index_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .custom_flags(index_flags)
-            .open(&read_index_path)?;
-        let value_segment_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .custom_flags(index_flags)
-            .open(&value_segment_path)?;
+        let data_file = open_store_file(&data_path, data_flags, access)?;
+        let read_index_file = open_read_accelerator_file(&read_index_path, index_flags, access)?;
+        let value_segment_file =
+            open_read_accelerator_file(&value_segment_path, index_flags, access)?;
 
         #[cfg(target_os = "macos")]
         unsafe {
             let _ = libc::fcntl(data_file.as_raw_fd(), libc::F_NOCACHE, 1);
         }
 
-        let manifest = Manifest::load_or_create(&manifest_path, &manifest_log_path)?;
+        let manifest =
+            Manifest::load_or_create(&manifest_path, &manifest_log_path, !access.is_read_only())?;
         let file_slots = slots_for_len(data_file.metadata()?.len());
         let preallocated_slots = file_slots.max(manifest.next_slot);
 
         Ok(Self {
             data_dir,
             _dir_lock: dir_lock,
+            access,
             data_file,
             read_index_file,
             value_segment_file,
@@ -558,6 +598,14 @@ impl FileBlobStore {
         self.manifest.read().unwrap().entries.is_empty()
     }
 
+    fn ensure_writable(&self) -> Result<()> {
+        if self.access.is_read_only() {
+            Err(Error::ReadOnly)
+        } else {
+            Ok(())
+        }
+    }
+
     fn offset_of(&self, guid: BlobGuid) -> Result<u64> {
         Ok(self.entry_of(guid)?.slot * u64::from(PAGE_SIZE))
     }
@@ -585,6 +633,7 @@ impl FileBlobStore {
     }
 
     fn clear_read_accelerator_slots(&self, guid: BlobGuid) -> Result<()> {
+        self.ensure_writable()?;
         let Some(entry) = self.manifest.read().unwrap().entries.get(&guid).copied() else {
             return Ok(());
         };
@@ -1430,6 +1479,7 @@ impl BlobStore for FileBlobStore {
     }
 
     fn publish_read_index(&self, guid: BlobGuid, bytes: &[u8], value_bytes: &[u8]) -> Result<()> {
+        self.ensure_writable()?;
         let _io = self.data_io_lock.lock().unwrap();
         let Some(base_offset) = self.read_index_offset_of(guid) else {
             return Ok(());
@@ -1469,10 +1519,12 @@ impl BlobStore for FileBlobStore {
     }
 
     fn delete_read_index(&self, guid: BlobGuid) -> Result<()> {
+        self.ensure_writable()?;
         self.clear_read_accelerator_slots(guid)
     }
 
     fn write_blob(&self, guid: BlobGuid, src: &AlignedBlobBuf) -> Result<()> {
+        self.ensure_writable()?;
         let _io = self.data_io_lock.lock().unwrap();
         let writes = [(guid, src)];
         let prepared = self.prepare_blob_writes(&writes)?;
@@ -1487,6 +1539,7 @@ impl BlobStore for FileBlobStore {
     }
 
     fn write_blobs(&self, writes: &[(BlobGuid, &AlignedBlobBuf)]) -> Result<()> {
+        self.ensure_writable()?;
         let _io = self.data_io_lock.lock().unwrap();
         let prepared = self.prepare_blob_writes(writes)?;
         if prepared.is_empty() {
@@ -1503,6 +1556,7 @@ impl BlobStore for FileBlobStore {
     }
 
     fn write_blobs_with_data_sync(&self, writes: &[(BlobGuid, &AlignedBlobBuf)]) -> Result<()> {
+        self.ensure_writable()?;
         if writes.is_empty() {
             return Ok(());
         }
@@ -1537,6 +1591,7 @@ impl BlobStore for FileBlobStore {
     }
 
     fn delete_blob(&self, guid: BlobGuid) -> Result<()> {
+        self.ensure_writable()?;
         let _io = self.data_io_lock.lock().unwrap();
         let mut m = self.manifest.write().unwrap();
         if let Some(entry) = m.entries.remove(&guid) {
@@ -1610,15 +1665,18 @@ impl BlobStore for FileBlobStore {
     }
 
     fn flush(&self) -> Result<()> {
+        self.ensure_writable()?;
         let _io = self.data_io_lock.lock().unwrap();
         self.flush_locked()
     }
 
     fn needs_flush(&self) -> bool {
-        self.data_needs_sync().is_some() || self.manifest_dirty.load(Ordering::Acquire)
+        !self.access.is_read_only()
+            && (self.data_needs_sync().is_some() || self.manifest_dirty.load(Ordering::Acquire))
     }
 
     fn vacuum(&self) -> Result<VacuumStats> {
+        self.ensure_writable()?;
         let _io = self.data_io_lock.lock().unwrap();
         self.flush_locked()?;
         let _slot = self.enter_slot_write();
@@ -1689,7 +1747,7 @@ struct SlotMove {
 }
 
 impl Manifest {
-    fn load_or_create(path: &Path, log_path: &Path) -> Result<Self> {
+    fn load_or_create(path: &Path, log_path: &Path, repair_torn_tail: bool) -> Result<Self> {
         let (mut entries, mut next_slot) = match File::open(path) {
             Ok(mut f) => Self::parse_snapshot(&mut f)?,
             Err(e) if e.kind() == io::ErrorKind::NotFound => (HashMap::new(), 0),
@@ -1697,7 +1755,7 @@ impl Manifest {
         };
 
         let replay = Self::replay_log(log_path, &mut entries, &mut next_slot)?;
-        if replay.valid_bytes < replay.file_bytes {
+        if repair_torn_tail && replay.valid_bytes < replay.file_bytes {
             truncate_manifest_log(log_path, replay.valid_bytes)?;
         }
         let used_slots: Vec<_> = entries.values().map(|entry| entry.slot).collect();
@@ -2340,7 +2398,7 @@ mod tests {
         // 0.5.x a second instance replays the same manifest into
         // the same next_slot and corrupts it with duplicate-slot
         // set deltas.
-        let second = acquire_dir_lock(dir.path(), Duration::from_millis(50));
+        let second = acquire_dir_lock(dir.path(), FileAccess::ReadWrite, Duration::from_millis(50));
         match second {
             Err(Error::BlobStoreIo(e)) => {
                 assert_eq!(e.kind(), io::ErrorKind::WouldBlock, "unexpected error: {e}");

--- a/tests/read_only_open.rs
+++ b/tests/read_only_open.rs
@@ -1,0 +1,263 @@
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use holt::{Durability, Error, Tree, TreeBuilder, TreeConfig, DB};
+use tempfile::tempdir;
+
+const HELPER_PATH: &str = "HOLT_READ_ONLY_HELPER_PATH";
+const HELPER_MODE: &str = "HOLT_READ_ONLY_HELPER_MODE";
+const HELPER_EXPECT_SUCCESS: &str = "HOLT_READ_ONLY_HELPER_EXPECT_SUCCESS";
+
+fn writable_config(path: &Path) -> TreeConfig {
+    let mut cfg = TreeConfig::new(path);
+    cfg.durability = Durability::Wal { sync: true };
+    cfg.checkpoint.enabled = false;
+    cfg
+}
+
+fn snapshot_files(path: &Path) -> BTreeMap<OsString, Vec<u8>> {
+    fs::read_dir(path)
+        .unwrap()
+        .map(|entry| {
+            let entry = entry.unwrap();
+            (entry.file_name(), fs::read(entry.path()).unwrap())
+        })
+        .collect()
+}
+
+#[test]
+fn read_only_open_replays_wal_without_changing_files() {
+    let dir = tempdir().unwrap();
+    {
+        let tree = Tree::open(writable_config(dir.path())).unwrap();
+        tree.put(b"objects/a", b"etag-a").unwrap();
+    }
+
+    let before = snapshot_files(dir.path());
+    {
+        let tree = TreeBuilder::new(dir.path()).read_only().open().unwrap();
+        assert!(tree.config().is_read_only());
+        assert_eq!(
+            tree.get(b"objects/a").unwrap().as_deref(),
+            Some(&b"etag-a"[..])
+        );
+        tree.view(b"objects/", |view| {
+            assert_eq!(view.get(b"objects/a")?.as_deref(), Some(&b"etag-a"[..]));
+            Ok(())
+        })
+        .unwrap();
+        assert!(matches!(
+            tree.put(b"objects/b", b"etag-b"),
+            Err(Error::ReadOnly)
+        ));
+        assert!(matches!(tree.delete(b"objects/a"), Err(Error::ReadOnly)));
+        assert!(matches!(tree.atomic(|_| {}), Err(Error::ReadOnly)));
+        assert!(matches!(tree.checkpoint(), Err(Error::ReadOnly)));
+        assert!(matches!(tree.compact(), Err(Error::ReadOnly)));
+        assert!(matches!(tree.gc(), Err(Error::ReadOnly)));
+        assert!(matches!(tree.vacuum(), Err(Error::ReadOnly)));
+    }
+    assert_eq!(snapshot_files(dir.path()), before);
+}
+
+#[test]
+fn read_only_open_requires_existing_files() {
+    let dir = tempdir().unwrap();
+    let missing = dir.path().join("missing");
+    let error = TreeBuilder::new(&missing).read_only().open().unwrap_err();
+    assert!(matches!(error, Error::BlobStoreIo(_)));
+    assert!(!missing.exists());
+}
+
+#[test]
+fn read_only_open_allows_missing_optional_read_accelerators() {
+    let dir = tempdir().unwrap();
+    {
+        let tree = Tree::open(writable_config(dir.path())).unwrap();
+        tree.put(b"objects/a", b"etag-a").unwrap();
+        tree.checkpoint().unwrap();
+    }
+    fs::remove_file(dir.path().join("read.idx")).unwrap();
+    fs::remove_file(dir.path().join("value.seg")).unwrap();
+
+    let before = snapshot_files(dir.path());
+    {
+        let tree = TreeBuilder::new(dir.path()).read_only().open().unwrap();
+        assert_eq!(
+            tree.get(b"objects/a").unwrap().as_deref(),
+            Some(&b"etag-a"[..])
+        );
+    }
+    assert_eq!(snapshot_files(dir.path()), before);
+}
+
+#[test]
+fn read_only_database_replays_named_trees_and_rejects_mutations() {
+    let dir = tempdir().unwrap();
+    {
+        let db = DB::open(writable_config(dir.path())).unwrap();
+        let objects = db.create_tree("objects").unwrap();
+        objects.put(b"a", b"etag-a").unwrap();
+    }
+
+    let before = snapshot_files(dir.path());
+    let db = DB::open(writable_config(dir.path()).read_only()).unwrap();
+    assert_eq!(db.list_trees().unwrap(), vec!["objects"]);
+    let objects = db.open_tree("objects").unwrap();
+    assert_eq!(objects.get(b"a").unwrap().as_deref(), Some(&b"etag-a"[..]));
+    db.view(&[("objects", b"")], |view| {
+        assert_eq!(
+            view.tree("objects").unwrap().get(b"a")?.as_deref(),
+            Some(&b"etag-a"[..])
+        );
+        Ok(())
+    })
+    .unwrap();
+    let image = db.export_checkpoint().unwrap();
+
+    assert!(matches!(objects.put(b"b", b"etag-b"), Err(Error::ReadOnly)));
+    assert!(matches!(db.create_tree("new"), Err(Error::ReadOnly)));
+    assert!(matches!(db.drop_tree("objects"), Err(Error::ReadOnly)));
+    assert!(matches!(db.atomic(|_| {}), Err(Error::ReadOnly)));
+    assert!(matches!(
+        db.install_checkpoint(&image),
+        Err(Error::ReadOnly)
+    ));
+    assert!(matches!(db.checkpoint(), Err(Error::ReadOnly)));
+    assert!(matches!(db.compact(), Err(Error::ReadOnly)));
+    assert!(matches!(db.gc(), Err(Error::ReadOnly)));
+    assert!(matches!(db.vacuum(), Err(Error::ReadOnly)));
+    drop(objects);
+    drop(db);
+    assert_eq!(snapshot_files(dir.path()), before);
+}
+
+#[test]
+fn read_only_open_does_not_repair_a_torn_manifest_tail() {
+    let dir = tempdir().unwrap();
+    {
+        let tree = Tree::open(writable_config(dir.path())).unwrap();
+        tree.put(b"objects/a", b"etag-a").unwrap();
+        tree.checkpoint().unwrap();
+    }
+
+    let log_path = dir.path().join("manifest.log");
+    let valid_len = fs::metadata(&log_path).unwrap().len();
+    OpenOptions::new()
+        .append(true)
+        .open(&log_path)
+        .unwrap()
+        .write_all(b"torn")
+        .unwrap();
+    let torn = fs::read(&log_path).unwrap();
+
+    {
+        let tree = TreeBuilder::new(dir.path()).read_only().open().unwrap();
+        assert_eq!(
+            tree.get(b"objects/a").unwrap().as_deref(),
+            Some(&b"etag-a"[..])
+        );
+    }
+    assert_eq!(fs::read(&log_path).unwrap(), torn);
+
+    drop(Tree::open(writable_config(dir.path())).unwrap());
+    assert_eq!(fs::metadata(&log_path).unwrap().len(), valid_len);
+}
+
+#[test]
+fn read_only_open_does_not_repair_a_torn_wal_tail() {
+    let dir = tempdir().unwrap();
+    {
+        let tree = Tree::open(writable_config(dir.path())).unwrap();
+        tree.put(b"objects/a", b"etag-a").unwrap();
+    }
+
+    let wal_path = dir.path().join("journal.wal");
+    let valid_len = fs::metadata(&wal_path).unwrap().len();
+    OpenOptions::new()
+        .append(true)
+        .open(&wal_path)
+        .unwrap()
+        .write_all(b"torn")
+        .unwrap();
+    let torn = fs::read(&wal_path).unwrap();
+
+    {
+        let tree = TreeBuilder::new(dir.path()).read_only().open().unwrap();
+        assert_eq!(
+            tree.get(b"objects/a").unwrap().as_deref(),
+            Some(&b"etag-a"[..])
+        );
+    }
+    assert_eq!(fs::read(&wal_path).unwrap(), torn);
+
+    drop(Tree::open(writable_config(dir.path())).unwrap());
+    assert_eq!(fs::metadata(&wal_path).unwrap().len(), valid_len);
+}
+
+#[test]
+fn process_lock_allows_readers_and_excludes_writers() {
+    let dir = tempdir().unwrap();
+    {
+        let tree = Tree::open(writable_config(dir.path())).unwrap();
+        tree.put(b"ready", b"1").unwrap();
+        tree.checkpoint().unwrap();
+    }
+
+    let reader = TreeBuilder::new(dir.path()).read_only().open().unwrap();
+    run_lock_helper(dir.path(), "read", true);
+    run_lock_helper(dir.path(), "write", false);
+    drop(reader);
+
+    run_lock_helper(dir.path(), "write", true);
+
+    let writer = Tree::open(writable_config(dir.path())).unwrap();
+    run_lock_helper(dir.path(), "read", false);
+    drop(writer);
+}
+
+fn run_lock_helper(path: &Path, mode: &str, expect_success: bool) {
+    let output = Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("lock_open_helper")
+        .arg("--nocapture")
+        .env(HELPER_PATH, path)
+        .env(HELPER_MODE, mode)
+        .env(
+            HELPER_EXPECT_SUCCESS,
+            if expect_success { "1" } else { "0" },
+        )
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "lock helper failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lock_open_helper() {
+    let Some(path) = std::env::var_os(HELPER_PATH) else {
+        return;
+    };
+    let mode = std::env::var(HELPER_MODE).unwrap();
+    let expect_success = std::env::var(HELPER_EXPECT_SUCCESS).unwrap() == "1";
+    let result = match mode.as_str() {
+        "read" => TreeBuilder::new(&path).read_only().open(),
+        "write" => Tree::open(writable_config(Path::new(&path))),
+        other => panic!("unknown helper mode: {other}"),
+    };
+
+    if expect_success {
+        assert!(result.is_ok(), "open failed: {}", result.unwrap_err());
+    } else {
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("incompatible live access mode"), "{error}");
+    }
+}


### PR DESCRIPTION
DuckDB HoltFS needs one C ABI call for atomic put/delete batches and a non-mutating way to inspect an existing Holt store.

`holt_tree_atomic` validates the complete operation array before it calls `Tree::atomic`. `holt_tree_open_read_only` requires an existing file-backed tree, holds a shared process lock, replays the WAL in memory, and leaves torn manifest and WAL tails unchanged. Read-only handles reject mutations and maintenance. Writers retain exclusive locks.

This port starts from Holt 0.8.4 and preserves its `assert_absent` guards and oversized WAL preflight.

Validation:

- `cargo test --workspace --all-features --lib --tests --examples --locked` (675 passed, 7 ignored)
- `cargo test --workspace --all-features --doc --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- workspace and soak-tool format checks
- Rustdoc with warnings denied
- normal and DB-normal soak smoke tests
- release `holt-ffi` build and C ABI smoke test
