### PR TITLE
chore: prepare Holt 0.8.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+## [0.8.5] — 2026-08-11
+
 ### Added
 
 - `DB::atomic` now wraps failures in `Error::Atomic` with an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holt"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.82"
 autobenches = false

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ a minor release, but minor releases may still break source compatibility
 before 1.0. Pin exact versions for production evaluation:
 
 ```toml
-holt = "=0.8.4"
+holt = "=0.8.5"
 ```
 
 The engine is covered by unit, integration, property, fuzz, soak, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ minor release plus the previous minor.
 
 | Version | Supported |
 |---------|-----------|
-| `0.8.4` | Yes (current) |
-| `< 0.8.4` | No |
+| `0.8.5` | Yes (current) |
+| `< 0.8.5` | No |
 
 ## Reporting a vulnerability
 

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/tools/soak/Cargo.lock
+++ b/tools/soak/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "holt"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",


### PR DESCRIPTION
Holt 0.8.5 publishes the database atomic outcome classification from #49. It also includes the read-only, shared-reader, and FFI batch changes merged since 0.8.4.

This release moves the current changelog entries into 0.8.5. It updates the crate version, exact dependency example, support matrix, and standalone lockfiles.

Validation:

- `cargo test --workspace --lib --tests --examples --locked`
- `cargo publish --dry-run --locked --allow-dirty`
- `cargo metadata --locked` for the root, bench, and soak manifests
- `cargo fmt --all -- --check`
- `git diff --check`

After merge, tag the exact merged main commit as `v0.8.5`. The release workflow publishes the crate and creates the GitHub release.