### PR TITLE
feat: attach recovery envelopes to atomic DB WAL batches

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -214,10 +214,13 @@ atomically. `put` / `delete` / `get` never take `rename_lock`.
 Mutations emit encoded `WalOp` records to an append-only
 `journal.wal` file via the journal worker. The durable variants
 are the logical API mutations: `Insert`, `Erase`, `RenameObject`,
-and `Batch`. Blob-shape changes (`splitBlob`, `mergeBlob`,
-`compactBlob`) are recovered either by replaying those logical
-records or by loading checkpointed blob images; they are not
-standalone WAL records. Each record is
+`Batch`, and `DbBatchWithEnvelope`. The last variant stores one
+application recovery envelope and its guarded multi-tree mutation in one
+CRC-covered WAL record. With `Durability::Wal { sync: true }`, Holt syncs that
+record as a unit. Blob-shape changes
+(`splitBlob`, `mergeBlob`, `compactBlob`) are recovered either by
+replaying those logical records or by loading checkpointed blob
+images; they are not standalone WAL records. Each record is
 
 ```text
 MAGIC | LEN | SEQ | TY | BODY | CRC32
@@ -233,6 +236,15 @@ variant tag on each record. Torn tails (mid-write power loss)
 are recovered gracefully — the scanner reports the offset where
 it stopped; real mid-file corruption surfaces as
 `Error::ReplaySanityFailed` with the bad record's offset.
+
+WAL format 4 reserves a 4096-byte header page with two checksummed
+application-anchor slots. `DB::atomic_with_journal_envelope` appends one
+`DbBatchWithEnvelope` record. After an application initializes the stream,
+Holt rejects ordinary logical writes before mutation. A clean checkpoint
+syncs both anchor slots before it truncates the retained WAL suffix.
+`DB::journal_envelopes_after` exposes only the local suffix after that
+checkpoint floor. The API does not provide a shared log or unbounded change
+feed.
 
 ### `BufferManager` — cache + dirty/pending tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-14
+
+### Added
+
+- Added `DB::initialize_journal_stream`,
+  `DB::atomic_with_journal_envelope`, `DB::journal_state`, and
+  `DB::journal_envelopes_after`. One opaque application recovery envelope and
+  its guarded multi-tree mutation now share one WAL record and one CRC.
+- Added `JournalAnchor`, `JournalEnvelope`, bounded paged scans, typed stale
+  cursor and anchor mismatch errors, and a 16 MiB encoded-record limit.
+- Added an explicit process-local stream for memory databases. It follows the
+  same ordering, fencing, paging, and checkpoint-floor rules but provides no
+  reopen or crash durability.
+
+### Changed
+
+- Advanced the WAL to format 4. Its 4096-byte header contains two
+  independently checksummed checkpoint-anchor slots. Checkpoint writes and
+  syncs both slots before it truncates the retained record suffix.
+- After callers initialize an attached recovery stream, Holt rejects ordinary
+  logical writes before mutation. Callers must route changes through
+  `DB::atomic_with_journal_envelope`; failed guards and stale anchors append no
+  envelope.
+- WAL scans stabilize and flush the committed async-ring prefix before reading
+  the retained suffix. Checkpoint and attached append use one lock order so
+  neither can cross the other's anchor boundary.
+
+### Fixed
+
+- Compaction now budgets the eight-byte routing node used by every reachable
+  `EmptyRoot`. Delete-heavy trees can retain empty child blobs, so treating the
+  sentinel as root-only undercounted the routing arena and could stop
+  compaction when the encoded layout crossed a page boundary.
+
+### Upgrade notes
+
+- Writable open upgrades a header-only format-3 WAL to format 4. Holt replays
+  a nonempty format-3 WAL only in read-only mode. It rejects writable open
+  before changing files or cached state.
+- Before upgrading a nonempty format-3 store, open it with Holt 0.8.5 and call
+  `DB::checkpoint()`. You can also export it through a read-only 0.9.0 open
+  and install the image into a fresh 0.9.0 store.
+- To downgrade from format 4, call `DB::export_checkpoint()`. Install the
+  image into a fresh 0.8.x store with `DB::install_checkpoint()`.
+
 ## [0.8.5] — 2026-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holt"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.82"
 autobenches = false

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ system built for that shape.
 
 ```toml
 [dependencies]
-holt = "0.8"
+holt = "0.9"
 ```
 
 File-backed trees are Unix-only. Linux uses the `io-uring` feature by
@@ -247,7 +247,7 @@ a minor release, but minor releases may still break source compatibility
 before 1.0. Pin exact versions for production evaluation:
 
 ```toml
-holt = "=0.8.5"
+holt = "=0.9.0"
 ```
 
 The engine is covered by unit, integration, property, fuzz, soak, and

--- a/README.md
+++ b/README.md
@@ -181,6 +181,46 @@ checkpointing:
 - `Durability::Wal { sync: false }` is the default throughput mode.
   Use `sync: true` when every committed mutation must force WAL sync.
 
+### Attached Recovery Stream
+
+Applications that need canonical recovery records can attach one opaque
+envelope to the same WAL record as a guarded `DB` batch:
+
+```rust
+use holt::{DB, Durability, JournalAnchor, JournalEnvelope, TreeConfig};
+
+let mut config = TreeConfig::new("/var/lib/app/db.holt");
+config.durability = Durability::Wal { sync: true };
+let db = DB::open(config)?;
+db.create_tree("metadata")?;
+db.checkpoint()?;
+
+let genesis = JournalAnchor::new(0, [0x10; 32]);
+let first = JournalAnchor::new(1, [0x11; 32]);
+db.initialize_journal_stream(genesis)?;
+db.atomic_with_journal_envelope(
+    JournalEnvelope::new(genesis, first, b"canonical command".to_vec())?,
+    |batch| batch.put("metadata", b"key", b"value"),
+)?;
+
+let page = db.journal_envelopes_after(genesis, 128, 1024 * 1024)?;
+assert_eq!(page.next(), first);
+```
+
+After stream initialization, Holt rejects ordinary logical writes. Route each
+mutation through `DB::atomic_with_journal_envelope`. File-backed databases
+persist the stream anchor and retained suffix in the local WAL. Memory
+databases provide the same ordering and paging contract only for the process
+lifetime.
+
+A checkpoint advances the local retention floor. Older cursors return
+`Error::JournalPositionExpired`. This API provides local recovery records. It
+does not provide a shared or remote log.
+
+The example uses `sync: true`, so a successful attached-batch acknowledgement
+survives a power loss. With `sync: false`, Holt preserves atomic ordering but
+does not force each acknowledgement to stable storage.
+
 ## Benchmarks
 
 Benchmark code lives in the separate non-published package under

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -391,6 +391,9 @@ single-node embedded library, no always-on MVCC version chains.
 
 ### P1 — WAL tail / change feed with explicit retention
 
+- Holt 0.9 exposes a local checkpoint-bounded recovery suffix through
+  `DB::journal_envelopes_after`. This is a crash-recovery primitive for
+  one file store, not a live subscription or shared change feed.
 - Expose a change-feed API only after WAL retention is designed.
   Today's checkpoint path truncates WAL, so `subscribe(from_seq)`
   cannot pretend old history is always available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ minor release plus the previous minor.
 
 | Version | Supported |
 |---------|-----------|
-| `0.8.5` | Yes (current) |
-| `< 0.8.5` | No |
+| `0.9.0` | Yes (current) |
+| `< 0.9.0` | No |
 
 ## Reporting a vulnerability
 

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -15,6 +15,9 @@ use super::atomic::{BatchOp, RecordVersion};
 use super::checkpoint::{self, CheckpointImage};
 use super::config::TreeConfig;
 use super::errors::{AtomicErrorKind, Error, Result};
+use super::journal::{
+    JournalAnchor, JournalEnvelope, JournalEnvelopePage, JournalState, VolatileJournal,
+};
 use super::snapshot::Snapshot;
 use super::stats::{CheckpointerStats, DBStats, JournalStats, OpenStats, VacuumStats};
 use super::tree::{
@@ -159,6 +162,7 @@ pub struct DB {
     next_seq: Arc<AtomicU64>,
     commit_gate: Arc<CommitGate>,
     journal: Option<Arc<Journal>>,
+    volatile_journal: Option<Arc<VolatileJournal>>,
     checkpointer: Option<Arc<crate::checkpoint::Checkpointer>>,
     open_stats: OpenStats,
     trees: Arc<Mutex<HashMap<u64, OpenTree>>>,
@@ -206,6 +210,9 @@ impl DB {
                         replay_wal(&path, &bm, !cfg.is_read_only(), |tree_id| {
                             Ok(root_guid_for_tree_id(tree_id))
                         })?;
+                    if cfg.is_read_only() {
+                        crate::journal::reader::validate_attached_journal(&path)?;
+                    }
                     open_stats.wal_replay_micros = start.elapsed().as_micros() as u64;
                     open_stats.wal_replay_records = replay_stats.records_seen;
                     open_stats.wal_torn_tail = replay_stats.torn_tail_at.is_some();
@@ -226,6 +233,8 @@ impl DB {
             _ => (None, 1),
         };
 
+        let volatile_journal =
+            (cfg.is_memory() && !cfg.is_read_only()).then(|| Arc::new(VolatileJournal::new()));
         let maintenance_gate = Arc::new(Gate::new());
         let commit_gate = Arc::new(CommitGate::new());
         let mut db = Self {
@@ -235,6 +244,7 @@ impl DB {
             next_seq: Arc::new(AtomicU64::new(next_seq)),
             commit_gate,
             journal,
+            volatile_journal,
             checkpointer: None,
             open_stats,
             trees: Arc::new(Mutex::new(HashMap::new())),
@@ -254,9 +264,10 @@ impl DB {
         db.checkpointer = if db.cfg.is_read_only() {
             None
         } else {
-            crate::checkpoint::Checkpointer::spawn(
+            crate::checkpoint::Checkpointer::spawn_with_volatile(
                 Arc::clone(&db.store),
                 db.journal.clone(),
+                db.volatile_journal.clone(),
                 Arc::clone(&db.maintenance_gate),
                 Arc::clone(&db.commit_gate),
                 db.cfg.checkpoint.clone(),
@@ -274,6 +285,16 @@ impl DB {
         }
     }
 
+    fn ensure_ordinary_writes_allowed(&self) -> Result<()> {
+        if let Some(journal) = &self.journal {
+            journal.ensure_ordinary_writes_allowed()?;
+        }
+        if let Some(journal) = &self.volatile_journal {
+            journal.ensure_ordinary_writes_allowed()?;
+        }
+        Ok(())
+    }
+
     /// Create a named tree inside this DB.
     ///
     /// Creation is recorded in the internal catalog before the
@@ -283,6 +304,7 @@ impl DB {
         self.ensure_writable()?;
         let name_bytes = validate_tree_name(name)?;
         let _maintenance = self.maintenance_gate.enter_exclusive();
+        self.ensure_ordinary_writes_allowed()?;
         if self.catalog_entry(name_bytes)?.is_some() {
             return Err(Error::TreeExists {
                 name: name.to_owned(),
@@ -399,6 +421,7 @@ impl DB {
         self.ensure_writable()?;
         let name_bytes = validate_tree_name(name)?;
         let _maintenance = self.maintenance_gate.enter_exclusive();
+        self.ensure_ordinary_writes_allowed()?;
         let entry = match self.catalog_entry(name_bytes)? {
             Some(entry) if entry.state == CatalogState::Live => entry,
             Some(_) | None => {
@@ -458,6 +481,155 @@ impl DB {
             return Ok(true);
         }
         self.apply_atomic(batch.pending)
+    }
+
+    /// Initialize the application recovery stream at one durable anchor.
+    ///
+    /// A file-backed DB stores the anchor in its WAL header. A memory DB keeps
+    /// the stream only for that DB's process lifetime. In both profiles the DB
+    /// must be writable and cleanly checkpointed before first initialization.
+    /// An exact retry with the same anchor succeeds; a different anchor fails
+    /// closed.
+    pub fn initialize_journal_stream(&self, genesis: JournalAnchor) -> Result<()> {
+        self.ensure_writable()?;
+        let _maintenance = self.maintenance_gate.enter_exclusive();
+        let _commit = self.commit_gate.enter_checkpoint();
+
+        if let Some(journal) = &self.journal {
+            if journal.state().is_some() {
+                return journal.initialize_anchor(genesis);
+            }
+        } else if let Some(journal) = &self.volatile_journal {
+            if journal.state().is_some() {
+                return journal.initialize(genesis);
+            }
+        } else {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "file-backed WAL or memory storage is required",
+            });
+        }
+
+        if self
+            .catalog_entries_unlocked()?
+            .iter()
+            .any(|(_, entry)| entry.state == CatalogState::Dropping)
+        {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "dropping trees must be finalized before stream initialization",
+            });
+        }
+
+        if self.store.dirty_count() != 0
+            || self.store.flushing_count() != 0
+            || self.store.pending_delete_count() != 0
+            || self.store.orphan_staging_count() != 0
+            || self.store.write_delta_count() != 0
+            || self.store.needs_flush()
+            || self
+                .journal
+                .as_ref()
+                .is_some_and(|journal| journal.needs_checkpoint())
+        {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "database must be cleanly checkpointed before stream initialization",
+            });
+        }
+        if let Some(journal) = &self.journal {
+            journal.initialize_anchor(genesis)
+        } else {
+            self.volatile_journal
+                .as_ref()
+                .expect("memory journal checked above")
+                .initialize(genesis)
+        }
+    }
+
+    /// Return the checkpoint floor and current attached-stream tail.
+    pub fn journal_state(&self) -> Result<JournalState> {
+        if self.cfg.is_read_only() {
+            let path = self.cfg.wal_path().ok_or(Error::JournalStreamUnavailable {
+                reason: "file-backed WAL or memory storage is required",
+            })?;
+            return crate::journal::reader::attached_journal_state(&path);
+        }
+        let _commit = self.commit_gate.enter_checkpoint();
+        let state = if let Some(journal) = &self.journal {
+            journal.state()
+        } else if let Some(journal) = &self.volatile_journal {
+            journal.state()
+        } else {
+            None
+        };
+        state.ok_or(Error::JournalStreamUnavailable {
+            reason: "stream has not been initialized",
+        })
+    }
+
+    /// Read a bounded page of retained recovery envelopes after `cursor`.
+    ///
+    /// A cursor before the local checkpoint floor returns
+    /// [`Error::JournalPositionExpired`]. This local API does not imply remote
+    /// or shared-log retention. `row_limit` must be non-zero.
+    /// `payload_byte_limit` is a soft boundary over payload bytes: the first
+    /// retained envelope is returned even when its payload exceeds the limit,
+    /// including a zero-byte limit.
+    pub fn journal_envelopes_after(
+        &self,
+        cursor: JournalAnchor,
+        row_limit: usize,
+        payload_byte_limit: usize,
+    ) -> Result<JournalEnvelopePage> {
+        if self.cfg.is_read_only() {
+            let path = self.cfg.wal_path().ok_or(Error::JournalStreamUnavailable {
+                reason: "file-backed WAL or memory storage is required",
+            })?;
+            return crate::journal::reader::scan_attached_envelope_page(
+                &path,
+                cursor,
+                row_limit,
+                payload_byte_limit,
+            );
+        }
+        // Stabilize both the committed ring prefix and checkpoint truncation
+        // for the complete scan. Journal then flushes that prefix before it
+        // opens the WAL file.
+        let _commit = self.commit_gate.enter_checkpoint();
+        if let Some(journal) = &self.journal {
+            journal.envelopes_after(cursor, row_limit, payload_byte_limit)
+        } else if let Some(journal) = &self.volatile_journal {
+            journal.envelopes_after(cursor, row_limit, payload_byte_limit)
+        } else {
+            Err(Error::JournalStreamUnavailable {
+                reason: "file-backed WAL or memory storage is required",
+            })
+        }
+    }
+
+    /// Apply one guarded DB batch and attach canonical application recovery
+    /// bytes to the same WAL record.
+    ///
+    /// Holt validates the caller's previous anchor before any mutation. A
+    /// failed batch guard returns `Ok(false)` without emitting an envelope.
+    /// Every error uses the same definitely-not-applied versus outcome-unknown
+    /// boundary as [`Self::atomic`].
+    pub fn atomic_with_journal_envelope<F>(
+        &self,
+        envelope: JournalEnvelope,
+        build: F,
+    ) -> Result<bool>
+    where
+        F: FnOnce(&mut DBAtomicBatch),
+    {
+        self.ensure_writable()
+            .map_err(atomic_definitely_not_applied)?;
+        let mut batch = DBAtomicBatch::default();
+        build(&mut batch);
+        if batch.pending.is_empty() {
+            return Err(atomic_definitely_not_applied(Error::Internal(
+                "attached journal batch must mutate database state",
+            )));
+        }
+        self.apply_atomic_with_journal_envelope(batch.pending, envelope)
     }
 
     /// Run a read-only transaction over explicit tree/prefix scopes.
@@ -622,6 +794,7 @@ impl DB {
     /// Holt does not yet provide online replacement of a live DB image.
     pub fn install_checkpoint(&self, image: &CheckpointImage) -> Result<()> {
         self.ensure_writable()?;
+        self.ensure_ordinary_writes_allowed()?;
         let decoded = checkpoint::decode(image.as_bytes())?;
         for (name, kv) in &decoded.families {
             let name = std::str::from_utf8(name)
@@ -661,6 +834,20 @@ impl DB {
                 &self.maintenance_gate,
                 &self.commit_gate,
             )?;
+        }
+        if let Some(journal) = &self.volatile_journal {
+            // Bind the volatile floor to an exact clean in-memory store image.
+            // The earlier DB maintenance passes release their gates between
+            // phases, so a writer could otherwise land after the last flush
+            // but before this floor advance.
+            let _maintenance = self.maintenance_gate.enter_exclusive();
+            Tree::checkpoint_shared_store_with_maintenance_held(
+                &self.store,
+                None,
+                &self.commit_gate,
+            )?;
+            let _commit = self.commit_gate.enter_checkpoint();
+            journal.checkpoint();
         }
         Ok(())
     }
@@ -1064,6 +1251,7 @@ impl DB {
             Arc::clone(&self.next_seq),
             Arc::clone(&self.commit_gate),
             self.journal.clone(),
+            self.volatile_journal.clone(),
             self.checkpointer.clone(),
             self.open_stats,
         )
@@ -1071,6 +1259,8 @@ impl DB {
 
     fn apply_atomic(&self, pending: Vec<DBBatchOp>) -> Result<bool> {
         let _maintenance = self.maintenance_gate.enter_shared();
+        self.ensure_ordinary_writes_allowed()
+            .map_err(atomic_definitely_not_applied)?;
         let groups = self
             .group_batch_ops(pending)
             .map_err(atomic_definitely_not_applied)?;
@@ -1116,6 +1306,107 @@ impl DB {
             self.apply_batch_groups_in_memory(&groups, base_seq)
         };
         apply.map_err(atomic_outcome_unknown)?;
+        Ok(true)
+    }
+
+    fn apply_atomic_with_journal_envelope(
+        &self,
+        pending: Vec<DBBatchOp>,
+        envelope: JournalEnvelope,
+    ) -> Result<bool> {
+        let _maintenance = self.maintenance_gate.enter_shared();
+        if self.journal.is_none() && self.volatile_journal.is_none() {
+            return Err(atomic_definitely_not_applied(
+                Error::JournalStreamUnavailable {
+                    reason: "file-backed WAL or memory storage is required",
+                },
+            ));
+        }
+        let groups = self
+            .group_batch_ops(pending)
+            .map_err(atomic_definitely_not_applied)?;
+        let count = count_wal_ops(&groups);
+        if count == 0 {
+            return Err(atomic_definitely_not_applied(Error::Internal(
+                "attached journal batch must contain a mutation",
+            )));
+        }
+        let record_len = encoded_db_batch_record_len(&groups)
+            .checked_add(encoded_journal_envelope_len(&envelope))
+            .ok_or_else(|| {
+                atomic_definitely_not_applied(Error::Internal(
+                    "attached journal record length overflow",
+                ))
+            })?;
+        let mut gates = groups
+            .iter()
+            .map(|group| (group.tree_id, group.tree.mutation_gate()))
+            .collect::<Vec<_>>();
+        gates.sort_by_key(|(tree_id, _)| *tree_id);
+        gates.dedup_by_key(|(tree_id, _)| *tree_id);
+        let _tree_guards = gates
+            .iter()
+            .map(|(_, gate)| gate.enter_batch())
+            .collect::<Vec<_>>();
+        {
+            let _commit = self.commit_gate.enter_writer();
+            for group in &groups {
+                self.store
+                    .flush_write_deltas_for_tree(group.tree_id)
+                    .map_err(atomic_definitely_not_applied)?;
+            }
+        }
+        let base_seq = self.next_seq.fetch_add(count, Ordering::Relaxed);
+        if !Self::preflight_batch_groups(&groups, base_seq)
+            .map_err(atomic_definitely_not_applied)?
+        {
+            return Ok(false);
+        }
+
+        if let Some(journal) = &self.journal {
+            // Lock order is commit gate -> attached-tail gate. Checkpoint takes
+            // the commit gate exclusively before it snapshots the tail, so the
+            // reverse order would deadlock a writer against WAL truncation.
+            let ack = {
+                let _commit = self.commit_gate.enter_writer();
+                let append = journal
+                    .begin_attached(envelope.previous(), record_len)
+                    .map_err(atomic_definitely_not_applied)?;
+                self.apply_batch_groups_with_attached_journal(
+                    &groups, base_seq, append, &envelope, record_len,
+                )
+                .map_err(atomic_outcome_unknown)?
+            };
+            if let Some(ack) = ack {
+                ack.wait().map_err(atomic_outcome_unknown)?;
+            }
+        } else {
+            let journal = self.volatile_journal.as_ref().ok_or_else(|| {
+                atomic_definitely_not_applied(Error::JournalStreamUnavailable {
+                    reason: "memory stream is unavailable",
+                })
+            })?;
+            {
+                let _commit = self.commit_gate.enter_writer();
+                let append = journal
+                    .begin_attached(envelope.previous(), record_len)
+                    .map_err(atomic_definitely_not_applied)?;
+                let mut group_base = base_seq;
+                for group in &groups {
+                    group
+                        .tree
+                        .apply_batch_walker_inline(&group.ops, group_base, None)
+                        .map_err(atomic_outcome_unknown)?;
+                    group_base += count_group_wal_ops(group);
+                }
+                append.submit(envelope).map_err(atomic_outcome_unknown)?;
+            }
+            if self.cfg.memory_flush_on_write {
+                if let Some(group) = groups.first() {
+                    group.tree.flush_inline().map_err(atomic_outcome_unknown)?;
+                }
+            }
+        }
         Ok(true)
     }
 
@@ -1185,6 +1476,27 @@ impl DB {
         Ok(())
     }
 
+    fn apply_batch_groups_with_attached_journal(
+        &self,
+        groups: &[DBBatchGroup],
+        base_seq: u64,
+        append: crate::journal::JournalAppendGuard<'_>,
+        envelope: &JournalEnvelope,
+        record_len: usize,
+    ) -> Result<Option<crate::journal::JournalAck>> {
+        let mut record = append.record_buffer(record_len);
+        let mut enc = BatchEncoder::begin_with_envelope(&mut record, base_seq, 0, envelope);
+        let mut group_base = base_seq;
+        for group in groups {
+            group
+                .tree
+                .apply_batch_walker_inline(&group.ops, group_base, Some(&mut enc))?;
+            group_base += count_group_wal_ops(group);
+        }
+        let _n = enc.finish();
+        append.submit(record, envelope, self.cfg.durability.wal_sync())
+    }
+
     fn apply_batch_groups_in_memory(&self, groups: &[DBBatchGroup], base_seq: u64) -> Result<()> {
         let commit = (self.store.fork_barrier() != 0).then(|| self.commit_gate.enter_writer());
         let mut group_base = base_seq;
@@ -1204,6 +1516,7 @@ impl DB {
     }
 
     fn apply_system_batch_unlocked(&self, tree_id: u64, ops: Vec<BatchOp>) -> Result<u64> {
+        self.ensure_ordinary_writes_allowed()?;
         let open = {
             let mut trees = self.trees.lock().unwrap();
             if let Some(open) = trees.get(&tree_id) {
@@ -1429,6 +1742,15 @@ fn encoded_db_batch_record_len(groups: &[DBBatchGroup]) -> usize {
     len + crate::journal::codec::RECORD_FOOTER_SIZE
 }
 
+fn encoded_journal_envelope_len(envelope: &JournalEnvelope) -> usize {
+    1 + 8
+        + super::journal::JOURNAL_DIGEST_BYTES
+        + 8
+        + super::journal::JOURNAL_DIGEST_BYTES
+        + 4
+        + envelope.payload().len()
+}
+
 fn count_wal_ops(groups: &[DBBatchGroup]) -> u64 {
     groups.iter().map(count_group_wal_ops).sum::<u64>()
 }
@@ -1528,7 +1850,7 @@ mod tests {
     use crate::store::blob_store::{AlignedBlobBuf, MemoryBlobStore};
     use std::collections::{BTreeMap, HashSet};
     use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
-    use std::sync::mpsc;
+    use std::sync::{mpsc, Condvar};
     use std::thread;
     use std::time::{Duration, Instant};
     use tempfile::tempdir;
@@ -1603,6 +1925,802 @@ mod tests {
         fn has_blob(&self, guid: BlobGuid) -> Result<bool> {
             self.inner.has_blob(guid)
         }
+    }
+
+    #[derive(Default)]
+    struct BlockingCheckpointState {
+        armed: bool,
+        entered: bool,
+        released: bool,
+    }
+
+    struct BlockingCheckpointStore {
+        inner: MemoryBlobStore,
+        state: Mutex<BlockingCheckpointState>,
+        wake: Condvar,
+    }
+
+    impl BlockingCheckpointStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryBlobStore::new(),
+                state: Mutex::new(BlockingCheckpointState::default()),
+                wake: Condvar::new(),
+            }
+        }
+
+        fn arm(&self) {
+            let mut state = self.state.lock().unwrap();
+            state.armed = true;
+            state.entered = false;
+            state.released = false;
+        }
+
+        fn wait_until_blocked(&self, timeout: Duration) -> bool {
+            let state = self.state.lock().unwrap();
+            let (state, _) = self
+                .wake
+                .wait_timeout_while(state, timeout, |state| !state.entered)
+                .unwrap();
+            state.entered
+        }
+
+        fn release(&self) {
+            let mut state = self.state.lock().unwrap();
+            state.released = true;
+            self.wake.notify_all();
+        }
+
+        fn block_if_armed(&self) {
+            let mut state = self.state.lock().unwrap();
+            if !state.armed {
+                return;
+            }
+            state.armed = false;
+            state.entered = true;
+            self.wake.notify_all();
+            while !state.released {
+                state = self.wake.wait(state).unwrap();
+            }
+        }
+    }
+
+    impl BlobStore for BlockingCheckpointStore {
+        fn read_blob(&self, guid: BlobGuid, dst: &mut AlignedBlobBuf) -> Result<()> {
+            self.inner.read_blob(guid, dst)
+        }
+
+        fn write_blob(&self, guid: BlobGuid, src: &AlignedBlobBuf) -> Result<()> {
+            self.block_if_armed();
+            self.inner.write_blob(guid, src)
+        }
+
+        fn write_blobs(&self, writes: &[(BlobGuid, &AlignedBlobBuf)]) -> Result<()> {
+            self.block_if_armed();
+            self.inner.write_blobs(writes)
+        }
+
+        fn delete_blob(&self, guid: BlobGuid) -> Result<()> {
+            self.inner.delete_blob(guid)
+        }
+
+        fn list_blobs(&self) -> Result<Vec<BlobGuid>> {
+            self.inner.list_blobs()
+        }
+
+        fn flush(&self) -> Result<()> {
+            self.inner.flush()
+        }
+
+        fn needs_flush(&self) -> bool {
+            self.inner.needs_flush()
+        }
+
+        fn has_blob(&self, guid: BlobGuid) -> Result<bool> {
+            self.inner.has_blob(guid)
+        }
+    }
+
+    fn background_memory_config() -> TreeConfig {
+        let mut cfg = TreeConfig::memory();
+        cfg.memory_flush_on_write = false;
+        cfg.checkpoint.enabled = true;
+        cfg.checkpoint.idle_interval = Duration::from_secs(10);
+        cfg.checkpoint.dirty_blob_threshold = 1;
+        cfg.checkpoint.auto_vacuum = false;
+        cfg
+    }
+
+    fn journal_anchor(sequence: u64, byte: u8) -> JournalAnchor {
+        JournalAnchor::new(
+            sequence,
+            [byte; super::super::journal::JOURNAL_DIGEST_BYTES],
+        )
+    }
+
+    fn assert_oversized_first_envelope_advances(db: &DB) {
+        db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0xc0);
+        let first = journal_anchor(1, 0xc1);
+        let second = journal_anchor(2, 0xc2);
+        let first_envelope = JournalEnvelope::new(genesis, first, vec![0x41; 64]).unwrap();
+        let second_envelope = JournalEnvelope::new(first, second, vec![0x42; 32]).unwrap();
+        db.initialize_journal_stream(genesis).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(first_envelope.clone(), |batch| {
+                batch.put("data", b"first", b"value");
+            })
+            .unwrap());
+        assert!(db
+            .atomic_with_journal_envelope(second_envelope.clone(), |batch| {
+                batch.put("data", b"second", b"value");
+            })
+            .unwrap());
+
+        for payload_byte_limit in [0, 1] {
+            let first_page = db
+                .journal_envelopes_after(genesis, 8, payload_byte_limit)
+                .unwrap();
+            assert_eq!(
+                first_page.envelopes(),
+                std::slice::from_ref(&first_envelope)
+            );
+            assert_eq!(first_page.next(), first);
+            assert!(first_page.has_more());
+
+            let second_page = db
+                .journal_envelopes_after(first, 8, payload_byte_limit)
+                .unwrap();
+            assert_eq!(
+                second_page.envelopes(),
+                std::slice::from_ref(&second_envelope)
+            );
+            assert_eq!(second_page.next(), second);
+            assert!(!second_page.has_more());
+        }
+
+        assert!(matches!(
+            db.journal_envelopes_after(genesis, 0, 1),
+            Err(Error::InvalidJournalScanLimit { .. })
+        ));
+    }
+
+    #[test]
+    fn file_journal_byte_limit_is_soft_for_first_envelope() {
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        cfg.durability = crate::Durability::Wal { sync: true };
+        let db = DB::open(cfg).unwrap();
+
+        assert_oversized_first_envelope_advances(&db);
+    }
+
+    #[test]
+    fn volatile_journal_byte_limit_is_soft_for_first_envelope() {
+        let db = DB::open(TreeConfig::memory()).unwrap();
+
+        assert_oversized_first_envelope_advances(&db);
+    }
+
+    #[test]
+    fn background_checkpoint_advances_volatile_floor_after_clean_image() {
+        let db = DB::open(background_memory_config()).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0xc0);
+        let first = journal_anchor(1, 0xc1);
+        db.initialize_journal_stream(genesis).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(
+                JournalEnvelope::new(genesis, first, b"first".to_vec()).unwrap(),
+                |batch| batch.put("data", b"key", b"value"),
+            )
+            .unwrap());
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, first)
+        );
+
+        db.checkpointer.as_ref().unwrap().wake();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while db.journal_state().unwrap().checkpoint() != first {
+            assert!(
+                Instant::now() < deadline,
+                "background checkpoint never advanced the volatile floor"
+            );
+            thread::sleep(Duration::from_millis(2));
+        }
+
+        assert_eq!(data.get(b"key").unwrap().as_deref(), Some(&b"value"[..]));
+        assert!(matches!(
+            db.journal_envelopes_after(genesis, 8, 4096),
+            Err(Error::JournalPositionExpired {
+                requested: 0,
+                checkpoint: 1,
+            })
+        ));
+    }
+
+    #[test]
+    fn concurrent_attached_write_does_not_outrun_volatile_checkpoint_image() {
+        let store = Arc::new(BlockingCheckpointStore::new());
+        let db = DB::open_with_blob_store(
+            background_memory_config(),
+            Arc::clone(&store) as Arc<dyn BlobStore>,
+        )
+        .unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0xd0);
+        let first = journal_anchor(1, 0xd1);
+        let second = journal_anchor(2, 0xd2);
+        db.initialize_journal_stream(genesis).unwrap();
+
+        store.arm();
+        assert!(db
+            .atomic_with_journal_envelope(
+                JournalEnvelope::new(genesis, first, b"first".to_vec()).unwrap(),
+                |batch| batch.put("data", b"first", b"one"),
+            )
+            .unwrap());
+        db.checkpointer.as_ref().unwrap().wake();
+        assert!(
+            store.wait_until_blocked(Duration::from_secs(2)),
+            "background checkpoint never reached the blocked store write"
+        );
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, first),
+            "floor advanced before the captured image reached the store"
+        );
+
+        let writer_db = db.clone();
+        let (writer_tx, writer_rx) = mpsc::channel();
+        let writer = thread::spawn(move || {
+            writer_tx
+                .send(writer_db.atomic_with_journal_envelope(
+                    JournalEnvelope::new(first, second, b"second".to_vec()).unwrap(),
+                    |batch| batch.put("data", b"second", b"two"),
+                ))
+                .unwrap();
+        });
+        writer_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("attached writer blocked behind checkpoint I/O")
+            .unwrap();
+        writer.join().unwrap();
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, second),
+            "floor advanced across a concurrent dirty write"
+        );
+
+        store.release();
+        db.checkpointer.as_ref().unwrap().wake();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while db.journal_state().unwrap().checkpoint() != second {
+            assert!(
+                Instant::now() < deadline,
+                "background checkpoint never caught up to the concurrent tail"
+            );
+            thread::sleep(Duration::from_millis(2));
+        }
+
+        assert_eq!(data.get(b"first").unwrap().as_deref(), Some(&b"one"[..]));
+        assert_eq!(data.get(b"second").unwrap().as_deref(), Some(&b"two"[..]));
+        assert!(matches!(
+            db.journal_envelopes_after(genesis, 8, 4096),
+            Err(Error::JournalPositionExpired {
+                requested: 0,
+                checkpoint: 2,
+            })
+        ));
+    }
+
+    #[test]
+    fn attached_journal_batch_advances_once_and_survives_checkpoint_reopen() {
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        cfg.durability = crate::Durability::Wal { sync: true };
+
+        let db = DB::open(cfg.clone()).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0x10);
+        let first = journal_anchor(1, 0x11);
+        db.initialize_journal_stream(genesis).unwrap();
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, genesis)
+        );
+
+        let first_envelope =
+            JournalEnvelope::new(genesis, first, b"first canonical command".to_vec()).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(first_envelope.clone(), |batch| {
+                batch.put_if_absent("data", b"key", b"value");
+            })
+            .unwrap());
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, first)
+        );
+        let page = db.journal_envelopes_after(genesis, 8, 4096).unwrap();
+        assert_eq!(page.envelopes(), &[first_envelope]);
+        assert_eq!(page.next(), first);
+        assert!(!page.has_more());
+
+        let second = journal_anchor(2, 0x12);
+        let rejected = JournalEnvelope::new(first, second, b"guarded command".to_vec()).unwrap();
+        assert!(!db
+            .atomic_with_journal_envelope(rejected.clone(), |batch| {
+                batch.put_if_absent("data", b"key", b"replacement");
+            })
+            .unwrap());
+        assert_eq!(db.journal_state().unwrap().tail(), first);
+        assert!(db
+            .journal_envelopes_after(first, 8, 4096)
+            .unwrap()
+            .envelopes()
+            .is_empty());
+
+        db.checkpoint().unwrap();
+        assert_eq!(db.journal_state().unwrap(), JournalState::new(first, first));
+        assert!(matches!(
+            db.journal_envelopes_after(genesis, 8, 4096),
+            Err(Error::JournalPositionExpired {
+                requested: 0,
+                checkpoint: 1,
+            })
+        ));
+        drop(data);
+        drop(db);
+
+        let reopened = DB::open(cfg).unwrap();
+        assert_eq!(
+            reopened.journal_state().unwrap(),
+            JournalState::new(first, first)
+        );
+        assert_eq!(
+            reopened.open_tree("data").unwrap().get(b"key").unwrap(),
+            Some(b"value".to_vec())
+        );
+        assert!(reopened
+            .atomic_with_journal_envelope(rejected, |batch| {
+                batch.put("data", b"next", b"value-2");
+            })
+            .unwrap());
+        assert_eq!(reopened.journal_state().unwrap().tail(), second);
+    }
+
+    #[test]
+    fn attached_journal_rejects_missing_or_stale_stream_before_mutation() {
+        let memory = DB::open(TreeConfig::memory()).unwrap();
+        memory.create_tree("data").unwrap();
+        let genesis = journal_anchor(0, 0x20);
+        let first = journal_anchor(1, 0x21);
+        let envelope = JournalEnvelope::new(genesis, first, b"command".to_vec()).unwrap();
+        assert!(matches!(
+            memory.atomic_with_journal_envelope(envelope.clone(), |batch| {
+                batch.put("data", b"key", b"value");
+            }),
+            Err(Error::Atomic {
+                kind: AtomicErrorKind::DefinitelyNotApplied,
+                source,
+            }) if matches!(source.as_ref(), Error::JournalStreamUnavailable { .. })
+        ));
+        assert!(memory
+            .open_tree("data")
+            .unwrap()
+            .get(b"key")
+            .unwrap()
+            .is_none());
+
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        let db = DB::open(cfg).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+        db.initialize_journal_stream(genesis).unwrap();
+        db.initialize_journal_stream(genesis).unwrap();
+        assert!(matches!(
+            db.initialize_journal_stream(journal_anchor(0, 0x22)),
+            Err(Error::JournalAnchorMismatch { .. })
+        ));
+
+        let wrong_previous = journal_anchor(0, 0x23);
+        let stale = JournalEnvelope::new(wrong_previous, first, b"stale".to_vec()).unwrap();
+        assert!(matches!(
+            db.atomic_with_journal_envelope(stale, |batch| {
+                batch.put("data", b"key", b"value");
+            }),
+            Err(Error::Atomic {
+                kind: AtomicErrorKind::DefinitelyNotApplied,
+                source,
+            }) if matches!(source.as_ref(), Error::JournalAnchorMismatch { .. })
+        ));
+        assert!(data.get(b"key").unwrap().is_none());
+        assert_eq!(db.journal_state().unwrap().tail(), genesis);
+
+        assert!(db
+            .atomic_with_journal_envelope(envelope, |batch| {
+                batch.put("data", b"key", b"value");
+            })
+            .unwrap());
+        assert_eq!(data.get(b"key").unwrap(), Some(b"value".to_vec()));
+    }
+
+    #[test]
+    fn initialized_journal_rejects_ordinary_writes_before_mutation() {
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        let db = DB::open(cfg).unwrap();
+        let data = db.create_tree("data").unwrap();
+        data.put(b"existing", b"old").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0x70);
+        db.initialize_journal_stream(genesis).unwrap();
+
+        assert!(matches!(
+            data.put(b"existing", b"new"),
+            Err(Error::JournalStreamUnavailable { .. })
+        ));
+        assert_eq!(data.get(b"existing").unwrap(), Some(b"old".to_vec()));
+        assert!(data.get(b"new-key").unwrap().is_none());
+        assert!(matches!(
+            data.put_many_if_absent(&[(b"bulk".as_slice(), b"value".as_slice())]),
+            Err(Error::JournalStreamUnavailable { .. })
+        ));
+        assert!(data.get(b"bulk").unwrap().is_none());
+        assert!(matches!(
+            db.create_tree("late"),
+            Err(Error::JournalStreamUnavailable { .. })
+        ));
+        assert!(matches!(
+            db.drop_tree("data"),
+            Err(Error::JournalStreamUnavailable { .. })
+        ));
+
+        assert!(matches!(
+            db.atomic(|batch| batch.put("data", b"new-key", b"new-value")),
+            Err(Error::Atomic {
+                kind: AtomicErrorKind::DefinitelyNotApplied,
+                source,
+            }) if matches!(source.as_ref(), Error::JournalStreamUnavailable { .. })
+        ));
+        assert!(data.get(b"new-key").unwrap().is_none());
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, genesis)
+        );
+
+        let first = journal_anchor(1, 0x71);
+        let envelope = JournalEnvelope::new(genesis, first, b"attached".to_vec()).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(envelope, |batch| {
+                batch.put("data", b"new-key", b"new-value");
+            })
+            .unwrap());
+        assert_eq!(data.get(b"new-key").unwrap(), Some(b"new-value".to_vec()));
+        assert_eq!(db.journal_state().unwrap().tail(), first);
+    }
+
+    #[test]
+    fn memory_db_uses_an_explicit_volatile_attached_stream() {
+        let db = DB::open(TreeConfig::memory()).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0x80);
+        let first = journal_anchor(1, 0x81);
+        let second = journal_anchor(2, 0x82);
+        let third = journal_anchor(3, 0x83);
+        db.initialize_journal_stream(genesis).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(
+                JournalEnvelope::new(genesis, first, b"volatile command".to_vec()).unwrap(),
+                |batch| batch.put("data", b"key", b"value"),
+            )
+            .unwrap());
+        assert_eq!(data.get(b"key").unwrap(), Some(b"value".to_vec()));
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, first)
+        );
+        assert_eq!(
+            db.journal_envelopes_after(genesis, 8, 4096)
+                .unwrap()
+                .envelopes()
+                .len(),
+            1
+        );
+        for (previous, current, key) in [
+            (first, second, b"second".as_slice()),
+            (second, third, b"third".as_slice()),
+        ] {
+            assert!(db
+                .atomic_with_journal_envelope(
+                    JournalEnvelope::new(previous, current, key.to_vec()).unwrap(),
+                    |batch| batch.put("data", key, b"value"),
+                )
+                .unwrap());
+        }
+        let first_page = db.journal_envelopes_after(genesis, 1, 4096).unwrap();
+        assert_eq!(first_page.envelopes().len(), 1);
+        assert_eq!(first_page.next(), first);
+        assert!(first_page.has_more());
+        let second_page = db.journal_envelopes_after(first, 8, 4096).unwrap();
+        assert_eq!(second_page.envelopes().len(), 2);
+        assert_eq!(second_page.next(), third);
+        assert!(!second_page.has_more());
+        assert!(matches!(
+            db.journal_envelopes_after(journal_anchor(1, 0xff), 8, 4096),
+            Err(Error::JournalAnchorMismatch {
+                requested: 1,
+                expected: 1,
+            })
+        ));
+        assert!(matches!(
+            data.put(b"ordinary", b"rejected"),
+            Err(Error::JournalStreamUnavailable { .. })
+        ));
+
+        data.checkpoint().unwrap();
+        assert_eq!(db.journal_state().unwrap(), JournalState::new(third, third));
+        assert!(matches!(
+            db.journal_envelopes_after(genesis, 8, 4096),
+            Err(Error::JournalPositionExpired {
+                requested: 0,
+                checkpoint: 3,
+            })
+        ));
+        assert_eq!(data.get(b"third").unwrap(), Some(b"value".to_vec()));
+    }
+
+    #[test]
+    fn stream_initialization_fences_a_tree_write_waiting_outside_maintenance() {
+        use crate::api::tree::{
+            set_ordinary_write_gate_barrier_for_current_thread, OrdinaryWriteGateBarrier,
+        };
+
+        let db = DB::open(TreeConfig::memory()).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let barrier = Arc::new(OrdinaryWriteGateBarrier::new());
+        let writer_barrier = Arc::clone(&barrier);
+        let writer = thread::spawn(move || {
+            set_ordinary_write_gate_barrier_for_current_thread(writer_barrier);
+            data.put(b"racing", b"value")
+        });
+
+        barrier.entered.wait();
+        let genesis = journal_anchor(0, 0x82);
+        db.initialize_journal_stream(genesis).unwrap();
+        barrier.release.wait();
+
+        assert!(matches!(
+            writer.join().unwrap(),
+            Err(Error::JournalStreamUnavailable { .. })
+        ));
+        assert!(db
+            .open_tree("data")
+            .unwrap()
+            .get(b"racing")
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            db.journal_state().unwrap(),
+            JournalState::new(genesis, genesis)
+        );
+    }
+
+    #[test]
+    fn concurrent_envelopes_with_same_previous_have_one_winner() {
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        let db = DB::open(cfg).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0x90);
+        db.initialize_journal_stream(genesis).unwrap();
+        let start = Arc::new(std::sync::Barrier::new(3));
+        let mut workers = Vec::new();
+        for (byte, key) in [(0x91, b"one".as_slice()), (0x92, b"two".as_slice())] {
+            let db = db.clone();
+            let start = Arc::clone(&start);
+            let key = key.to_vec();
+            workers.push(thread::spawn(move || {
+                let current = journal_anchor(1, byte);
+                let envelope = JournalEnvelope::new(genesis, current, vec![byte; 8]).unwrap();
+                start.wait();
+                (
+                    key.clone(),
+                    current,
+                    db.atomic_with_journal_envelope(envelope, |batch| {
+                        batch.put("data", &key, b"value");
+                    }),
+                )
+            }));
+        }
+        start.wait();
+
+        let results = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            results
+                .iter()
+                .filter(|(_, _, result)| result.as_ref().is_ok_and(|value| *value))
+                .count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|(_, _, result)| matches!(
+                    result,
+                    Err(Error::Atomic {
+                        kind: AtomicErrorKind::DefinitelyNotApplied,
+                        source,
+                    }) if matches!(source.as_ref(), Error::JournalAnchorMismatch { .. })
+                ))
+                .count(),
+            1
+        );
+        let page = db.journal_envelopes_after(genesis, 8, 4096).unwrap();
+        assert_eq!(page.envelopes().len(), 1);
+        let winner = page.envelopes()[0].current();
+        assert_eq!(db.journal_state().unwrap().tail(), winner);
+        for (key, current, _) in results {
+            assert_eq!(data.get(&key).unwrap().is_some(), current == winner);
+        }
+    }
+
+    #[test]
+    fn scan_flushes_an_async_attached_record_before_reading() {
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        cfg.durability = crate::Durability::Wal { sync: false };
+        let db = DB::open(cfg).unwrap();
+        db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+
+        let genesis = journal_anchor(0, 0xa0);
+        let first = journal_anchor(1, 0xa1);
+        db.initialize_journal_stream(genesis).unwrap();
+        let envelope = JournalEnvelope::new(genesis, first, b"async".to_vec()).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(envelope.clone(), |batch| {
+                batch.put("data", b"key", b"value");
+            })
+            .unwrap());
+
+        assert_eq!(
+            db.journal_envelopes_after(genesis, 8, 4096)
+                .unwrap()
+                .envelopes(),
+            &[envelope]
+        );
+    }
+
+    #[test]
+    fn checkpoint_and_attached_writes_complete_without_lock_inversion() {
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        let db = DB::open(cfg).unwrap();
+        db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+        let genesis = journal_anchor(0, 0xb0);
+        db.initialize_journal_stream(genesis).unwrap();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let writer_db = db.clone();
+        let writer_tx = done_tx.clone();
+        thread::spawn(move || {
+            let mut previous = genesis;
+            for sequence in 1..=12 {
+                let current = journal_anchor(sequence, 0xb0 + sequence as u8);
+                let envelope =
+                    JournalEnvelope::new(previous, current, vec![sequence as u8]).unwrap();
+                writer_db
+                    .atomic_with_journal_envelope(envelope, |batch| {
+                        batch.put("data", &sequence.to_le_bytes(), b"value");
+                    })
+                    .unwrap();
+                previous = current;
+                thread::yield_now();
+            }
+            writer_tx.send(()).unwrap();
+        });
+        let checkpoint_db = db.clone();
+        thread::spawn(move || {
+            for _ in 0..12 {
+                checkpoint_db.checkpoint().unwrap();
+                thread::yield_now();
+            }
+            done_tx.send(()).unwrap();
+        });
+
+        done_rx.recv_timeout(Duration::from_secs(20)).unwrap();
+        done_rx.recv_timeout(Duration::from_secs(20)).unwrap();
+        assert_eq!(db.journal_state().unwrap().tail().sequence(), 12);
+    }
+
+    #[test]
+    fn volatile_named_tree_checkpoint_and_attached_writes_do_not_deadlock() {
+        let db = DB::open(TreeConfig::memory()).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+        let genesis = journal_anchor(0, 0xc0);
+        db.initialize_journal_stream(genesis).unwrap();
+
+        let writer_db = db.clone();
+        let writer = thread::spawn(move || {
+            let mut previous = genesis;
+            for sequence in 1..=12 {
+                let current = journal_anchor(sequence, 0xc0 + sequence as u8);
+                writer_db
+                    .atomic_with_journal_envelope(
+                        JournalEnvelope::new(previous, current, vec![sequence as u8]).unwrap(),
+                        |batch| batch.put("data", &sequence.to_le_bytes(), b"value"),
+                    )
+                    .unwrap();
+                previous = current;
+                thread::yield_now();
+            }
+        });
+        let checkpointer = thread::spawn(move || {
+            for _ in 0..12 {
+                data.checkpoint().unwrap();
+                thread::yield_now();
+            }
+        });
+
+        writer.join().unwrap();
+        checkpointer.join().unwrap();
+        db.checkpoint().unwrap();
+        assert_eq!(db.journal_state().unwrap().tail().sequence(), 12);
+        assert_eq!(db.journal_state().unwrap().checkpoint().sequence(), 12);
+    }
+
+    #[test]
+    fn oversized_attached_record_is_definitely_not_applied() {
+        let db = DB::open(TreeConfig::memory()).unwrap();
+        let data = db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+        let genesis = journal_anchor(0, 0xc0);
+        let first = journal_anchor(1, 0xc1);
+        db.initialize_journal_stream(genesis).unwrap();
+        let payload = vec![0xc1; super::super::journal::MAX_JOURNAL_RECORD_BYTES];
+        let envelope = JournalEnvelope::new(genesis, first, payload).unwrap();
+
+        assert!(matches!(
+            db.atomic_with_journal_envelope(envelope, |batch| {
+                batch.put("data", b"key", b"value");
+            }),
+            Err(Error::Atomic {
+                kind: AtomicErrorKind::DefinitelyNotApplied,
+                source,
+            }) if matches!(source.as_ref(), Error::WalRecordTooLarge { .. })
+        ));
+        assert!(data.get(b"key").unwrap().is_none());
+        assert_eq!(db.journal_state().unwrap().tail(), genesis);
     }
 
     #[test]

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -113,6 +113,40 @@ pub enum Error {
         /// offset.
         record_offset: u64,
     },
+    /// An attached journal operation requires a supported DB profile whose
+    /// stream has been initialized with an application genesis anchor.
+    JournalStreamUnavailable {
+        /// Static reason the stream cannot serve the request.
+        reason: &'static str,
+    },
+    /// The caller's attached-journal cursor is older than the local
+    /// checkpoint floor and its envelopes are no longer retained.
+    JournalPositionExpired {
+        /// Sequence requested by the caller.
+        requested: u64,
+        /// Oldest sequence retained by the local journal.
+        checkpoint: u64,
+    },
+    /// The caller supplied an anchor that conflicts with Holt's anchor at the
+    /// same sequence or does not name the current stream tail.
+    JournalAnchorMismatch {
+        /// Sequence supplied by the caller.
+        requested: u64,
+        /// Sequence Holt expected at this boundary.
+        expected: u64,
+    },
+    /// One encoded WAL record cannot fit in Holt's bounded submit buffer.
+    WalRecordTooLarge {
+        /// Encoded record size requested by the caller.
+        bytes: usize,
+        /// Maximum encoded record size accepted by this Holt build.
+        maximum: usize,
+    },
+    /// An attached-journal page request used an invalid limit.
+    InvalidJournalScanLimit {
+        /// Static reason the limit is invalid.
+        reason: &'static str,
+    },
     /// `Tree::rename` (or similar) called with a `src` that has no
     /// leaf in the tree.
     NotFound,
@@ -243,6 +277,36 @@ impl std::fmt::Display for Error {
                     f,
                     "WAL replay sanity-check failed at offset {record_offset}: {context}"
                 )
+            }
+            Self::JournalStreamUnavailable { reason } => {
+                write!(f, "attached journal stream unavailable: {reason}")
+            }
+            Self::JournalPositionExpired {
+                requested,
+                checkpoint,
+            } => write!(
+                f,
+                "attached journal position {requested} expired at checkpoint {checkpoint}"
+            ),
+            Self::JournalAnchorMismatch {
+                requested,
+                expected,
+            } => {
+                if requested == expected {
+                    write!(f, "attached journal digest mismatch at position {requested}")
+                } else {
+                    write!(
+                        f,
+                        "attached journal anchor {requested} does not match expected position {expected}"
+                    )
+                }
+            }
+            Self::WalRecordTooLarge { bytes, maximum } => write!(
+                f,
+                "WAL record is too large ({bytes} bytes; maximum {maximum})"
+            ),
+            Self::InvalidJournalScanLimit { reason } => {
+                write!(f, "invalid attached journal scan limit: {reason}")
             }
             Self::NotFound => write!(f, "key not found"),
             Self::DstExists => write!(
@@ -394,6 +458,62 @@ mod tests {
             (
                 Error::SnapshotEpochExhausted.to_string(),
                 "snapshot epoch exhausted",
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn display_covers_attached_journal_errors() {
+        let cases = [
+            (
+                Error::JournalStreamUnavailable {
+                    reason: "stream has not been initialized",
+                }
+                .to_string(),
+                "attached journal stream unavailable: stream has not been initialized",
+            ),
+            (
+                Error::JournalPositionExpired {
+                    requested: 7,
+                    checkpoint: 9,
+                }
+                .to_string(),
+                "attached journal position 7 expired at checkpoint 9",
+            ),
+            (
+                Error::JournalAnchorMismatch {
+                    requested: 8,
+                    expected: 9,
+                }
+                .to_string(),
+                "attached journal anchor 8 does not match expected position 9",
+            ),
+            (
+                Error::JournalAnchorMismatch {
+                    requested: 9,
+                    expected: 9,
+                }
+                .to_string(),
+                "attached journal digest mismatch at position 9",
+            ),
+            (
+                Error::WalRecordTooLarge {
+                    bytes: 17,
+                    maximum: 16,
+                }
+                .to_string(),
+                "WAL record is too large (17 bytes; maximum 16)",
+            ),
+            (
+                Error::InvalidJournalScanLimit {
+                    reason: "row limit must be non-zero",
+                }
+                .to_string(),
+                "invalid attached journal scan limit: row limit must be non-zero",
             ),
         ];
 

--- a/src/api/journal.rs
+++ b/src/api/journal.rs
@@ -1,0 +1,464 @@
+//! Application-owned recovery material attached to one atomic WAL batch.
+//!
+//! Holt treats the payload as opaque bytes. The application owns its schema,
+//! canonical encoding, and digest calculation; Holt only keeps the envelope in
+//! the same checksummed WAL record as the batch that mutates the database.
+
+use std::fmt;
+use std::sync::{Mutex, MutexGuard};
+
+use super::errors::{Error, Result};
+
+/// Byte width of a journal anchor digest.
+pub const JOURNAL_DIGEST_BYTES: usize = 32;
+
+/// Maximum encoded size of one WAL record accepted by Holt.
+///
+/// Applications that attach canonical recovery material must keep the full
+/// envelope plus physical DB batch within this bound.
+pub const MAX_JOURNAL_RECORD_BYTES: usize = 16 * 1024 * 1024;
+
+/// One position in an application's hash-chained recovery stream.
+///
+/// The digest also binds the stream identity: applications should derive their
+/// genesis digest from the logical stream identity before constructing the
+/// first attached envelope.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct JournalAnchor {
+    sequence: u64,
+    digest: [u8; JOURNAL_DIGEST_BYTES],
+}
+
+impl JournalAnchor {
+    /// Construct an anchor from an application sequence and digest.
+    #[must_use]
+    pub const fn new(sequence: u64, digest: [u8; JOURNAL_DIGEST_BYTES]) -> Self {
+        Self { sequence, digest }
+    }
+
+    /// Return the application sequence represented by this anchor.
+    #[must_use]
+    pub const fn sequence(self) -> u64 {
+        self.sequence
+    }
+
+    /// Return the application-provided digest represented by this anchor.
+    #[must_use]
+    pub const fn digest(self) -> [u8; JOURNAL_DIGEST_BYTES] {
+        self.digest
+    }
+}
+
+/// Validation failure while constructing an attached journal envelope.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum JournalEnvelopeError {
+    /// The current anchor is not the immediate successor of the previous one.
+    NonContiguousSequence {
+        /// Sequence in the previous anchor.
+        previous: u64,
+        /// Sequence in the current anchor.
+        current: u64,
+    },
+    /// An attached envelope must carry canonical recovery bytes.
+    EmptyPayload,
+    /// The WAL envelope frame uses a 32-bit payload length.
+    PayloadTooLarge {
+        /// Caller-supplied payload length.
+        len: usize,
+    },
+}
+
+impl fmt::Display for JournalEnvelopeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonContiguousSequence { previous, current } => write!(
+                formatter,
+                "journal sequence {current} is not the immediate successor of {previous}"
+            ),
+            Self::EmptyPayload => formatter.write_str("journal envelope payload must not be empty"),
+            Self::PayloadTooLarge { len } => {
+                write!(
+                    formatter,
+                    "journal envelope payload is too large ({len} bytes)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for JournalEnvelopeError {}
+
+/// Opaque application recovery bytes anchored before and after one DB batch.
+///
+/// The current sequence must equal `previous.sequence() + 1`, and `payload`
+/// must not be empty. Holt does not recompute either digest; the enclosing WAL
+/// record CRC protects both anchors, the payload, and the database operations
+/// against torn writes and accidental corruption.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JournalEnvelope {
+    previous: JournalAnchor,
+    current: JournalAnchor,
+    payload: Vec<u8>,
+}
+
+/// Checkpointed and live positions of one attached recovery stream.
+///
+/// `checkpoint` is the oldest position retained by the local stream.
+/// Envelopes at or before it have already been folded into the checkpointed
+/// database image. `tail` includes every attached envelope accepted after
+/// that checkpoint. File-backed images are durable; memory images are not.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JournalState {
+    checkpoint: JournalAnchor,
+    tail: JournalAnchor,
+}
+
+impl JournalState {
+    pub(crate) const fn new(checkpoint: JournalAnchor, tail: JournalAnchor) -> Self {
+        Self { checkpoint, tail }
+    }
+
+    /// Return the oldest stream position retained by the local WAL.
+    #[must_use]
+    pub const fn checkpoint(self) -> JournalAnchor {
+        self.checkpoint
+    }
+
+    /// Return the latest attached stream position accepted by this database.
+    #[must_use]
+    pub const fn tail(self) -> JournalAnchor {
+        self.tail
+    }
+}
+
+/// One bounded page of attached recovery envelopes.
+///
+/// `next` is the cursor for the next call. It equals the input cursor when
+/// the page is empty. `has_more` reports whether another retained envelope
+/// follows `next`. The payload-byte limit is a soft page boundary: when at
+/// least one row is requested, an oversized first envelope is returned by
+/// itself so a caller can always advance its cursor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JournalEnvelopePage {
+    envelopes: Vec<JournalEnvelope>,
+    next: JournalAnchor,
+    has_more: bool,
+}
+
+impl JournalEnvelopePage {
+    pub(crate) fn new(
+        envelopes: Vec<JournalEnvelope>,
+        next: JournalAnchor,
+        has_more: bool,
+    ) -> Self {
+        Self {
+            envelopes,
+            next,
+            has_more,
+        }
+    }
+
+    /// Return the retained envelopes after the requested cursor.
+    #[must_use]
+    pub fn envelopes(&self) -> &[JournalEnvelope] {
+        &self.envelopes
+    }
+
+    /// Consume the page and return its retained envelopes.
+    #[must_use]
+    pub fn into_envelopes(self) -> Vec<JournalEnvelope> {
+        self.envelopes
+    }
+
+    /// Return the cursor to pass to the next scan call.
+    #[must_use]
+    pub const fn next(&self) -> JournalAnchor {
+        self.next
+    }
+
+    /// Return whether another retained envelope follows this page.
+    #[must_use]
+    pub const fn has_more(&self) -> bool {
+        self.has_more
+    }
+}
+
+pub(crate) fn bounded_envelope_page(
+    retained: &[JournalEnvelope],
+    start: usize,
+    cursor: JournalAnchor,
+    row_limit: usize,
+    payload_byte_limit: usize,
+) -> JournalEnvelopePage {
+    debug_assert!(row_limit > 0);
+    let mut envelopes = Vec::new();
+    let mut payload_bytes = 0usize;
+    for envelope in &retained[start..] {
+        if envelopes.len() == row_limit {
+            break;
+        }
+        let next_bytes = payload_bytes.saturating_add(envelope.payload().len());
+        if !envelopes.is_empty() && next_bytes > payload_byte_limit {
+            break;
+        }
+        payload_bytes = next_bytes;
+        envelopes.push(envelope.clone());
+    }
+    let consumed = envelopes.len();
+    let next = envelopes.last().map_or(cursor, JournalEnvelope::current);
+    let has_more = start + consumed < retained.len();
+    JournalEnvelopePage::new(envelopes, next, has_more)
+}
+
+impl JournalEnvelope {
+    /// Construct a validated owned envelope.
+    pub fn new(
+        previous: JournalAnchor,
+        current: JournalAnchor,
+        payload: Vec<u8>,
+    ) -> Result<Self, JournalEnvelopeError> {
+        if previous.sequence.checked_add(1) != Some(current.sequence) {
+            return Err(JournalEnvelopeError::NonContiguousSequence {
+                previous: previous.sequence,
+                current: current.sequence,
+            });
+        }
+        if payload.is_empty() {
+            return Err(JournalEnvelopeError::EmptyPayload);
+        }
+        if u32::try_from(payload.len()).is_err() {
+            return Err(JournalEnvelopeError::PayloadTooLarge { len: payload.len() });
+        }
+        Ok(Self {
+            previous,
+            current,
+            payload,
+        })
+    }
+
+    /// Return the durable anchor that must precede this envelope.
+    #[must_use]
+    pub const fn previous(&self) -> JournalAnchor {
+        self.previous
+    }
+
+    /// Return the anchor produced by this envelope.
+    #[must_use]
+    pub const fn current(&self) -> JournalAnchor {
+        self.current
+    }
+
+    /// Return the opaque canonical recovery bytes.
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    /// Consume the envelope and return its opaque canonical recovery bytes.
+    #[must_use]
+    pub fn into_payload(self) -> Vec<u8> {
+        self.payload
+    }
+}
+
+/// Process-local attached stream used by [`crate::DB`] in memory mode.
+///
+/// This profile preserves the same ordering, fencing, paging, and checkpoint
+/// semantics as the file-backed stream. It deliberately provides no reopen or
+/// crash durability: dropping the memory DB drops both its data and envelopes.
+pub(crate) struct VolatileJournal {
+    state: Mutex<VolatileJournalState>,
+}
+
+#[derive(Default)]
+struct VolatileJournalState {
+    checkpoint: Option<JournalAnchor>,
+    tail: Option<JournalAnchor>,
+    envelopes: Vec<JournalEnvelope>,
+}
+
+pub(crate) struct VolatileJournalAppendGuard<'a> {
+    state: MutexGuard<'a, VolatileJournalState>,
+}
+
+impl VolatileJournal {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(VolatileJournalState::default()),
+        }
+    }
+
+    pub(crate) fn initialize(&self, genesis: JournalAnchor) -> Result<()> {
+        let mut state = self.state.lock().unwrap();
+        match state.checkpoint {
+            Some(existing) if existing == genesis => Ok(()),
+            Some(existing) => Err(Error::JournalAnchorMismatch {
+                requested: genesis.sequence(),
+                expected: existing.sequence(),
+            }),
+            None => {
+                state.checkpoint = Some(genesis);
+                state.tail = Some(genesis);
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn state(&self) -> Option<JournalState> {
+        let state = self.state.lock().unwrap();
+        Some(JournalState::new(state.checkpoint?, state.tail?))
+    }
+
+    pub(crate) fn ensure_ordinary_writes_allowed(&self) -> Result<()> {
+        if self.state.lock().unwrap().checkpoint.is_some() {
+            Err(Error::JournalStreamUnavailable {
+                reason: "ordinary writes are disabled after attached stream initialization",
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn begin_attached(
+        &self,
+        expected_previous: JournalAnchor,
+        record_len: usize,
+    ) -> Result<VolatileJournalAppendGuard<'_>> {
+        if record_len == 0 {
+            return Err(Error::Internal("journal record must not be empty"));
+        }
+        if record_len > MAX_JOURNAL_RECORD_BYTES {
+            return Err(Error::WalRecordTooLarge {
+                bytes: record_len,
+                maximum: MAX_JOURNAL_RECORD_BYTES,
+            });
+        }
+        let state = self.state.lock().unwrap();
+        let expected = state.tail.ok_or(Error::JournalStreamUnavailable {
+            reason: "stream has not been initialized",
+        })?;
+        if expected_previous != expected {
+            return Err(Error::JournalAnchorMismatch {
+                requested: expected_previous.sequence(),
+                expected: expected.sequence(),
+            });
+        }
+        Ok(VolatileJournalAppendGuard { state })
+    }
+
+    pub(crate) fn checkpoint(&self) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(tail) = state.tail {
+            state.checkpoint = Some(tail);
+            state.envelopes.clear();
+        }
+    }
+
+    pub(crate) fn envelopes_after(
+        &self,
+        cursor: JournalAnchor,
+        row_limit: usize,
+        payload_byte_limit: usize,
+    ) -> Result<JournalEnvelopePage> {
+        if row_limit == 0 {
+            return Err(Error::InvalidJournalScanLimit {
+                reason: "row limit must be non-zero",
+            });
+        }
+        let state = self.state.lock().unwrap();
+        let checkpoint = state.checkpoint.ok_or(Error::JournalStreamUnavailable {
+            reason: "stream has not been initialized",
+        })?;
+        if cursor.sequence() < checkpoint.sequence() {
+            return Err(Error::JournalPositionExpired {
+                requested: cursor.sequence(),
+                checkpoint: checkpoint.sequence(),
+            });
+        }
+        let start = if cursor == checkpoint {
+            0
+        } else if cursor.sequence() == checkpoint.sequence() {
+            return Err(Error::JournalAnchorMismatch {
+                requested: cursor.sequence(),
+                expected: cursor.sequence(),
+            });
+        } else if let Some(index) = state
+            .envelopes
+            .iter()
+            .position(|envelope| envelope.current().sequence() == cursor.sequence())
+        {
+            if state.envelopes[index].current() != cursor {
+                return Err(Error::JournalAnchorMismatch {
+                    requested: cursor.sequence(),
+                    expected: cursor.sequence(),
+                });
+            }
+            index + 1
+        } else {
+            return Err(Error::JournalAnchorMismatch {
+                requested: cursor.sequence(),
+                expected: state.tail.unwrap_or(checkpoint).sequence(),
+            });
+        };
+        Ok(bounded_envelope_page(
+            &state.envelopes,
+            start,
+            cursor,
+            row_limit,
+            payload_byte_limit,
+        ))
+    }
+}
+
+impl VolatileJournalAppendGuard<'_> {
+    pub(crate) fn submit(mut self, envelope: JournalEnvelope) -> Result<()> {
+        let expected = self
+            .state
+            .tail
+            .expect("begin_attached initialized volatile tail");
+        if envelope.previous() != expected {
+            return Err(Error::JournalAnchorMismatch {
+                requested: envelope.previous().sequence(),
+                expected: expected.sequence(),
+            });
+        }
+        self.state.tail = Some(envelope.current());
+        self.state.envelopes.push(envelope);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_requires_one_sequence_step_and_payload() {
+        let previous = JournalAnchor::new(7, [0x11; JOURNAL_DIGEST_BYTES]);
+        let current = JournalAnchor::new(8, [0x22; JOURNAL_DIGEST_BYTES]);
+        let envelope = JournalEnvelope::new(previous, current, b"canonical".to_vec()).unwrap();
+        assert_eq!(envelope.previous(), previous);
+        assert_eq!(envelope.current(), current);
+        assert_eq!(envelope.payload(), b"canonical");
+
+        assert!(matches!(
+            JournalEnvelope::new(previous, JournalAnchor::new(9, [0x33; 32]), vec![1]),
+            Err(JournalEnvelopeError::NonContiguousSequence { .. })
+        ));
+        assert_eq!(
+            JournalEnvelope::new(previous, current, Vec::new()),
+            Err(JournalEnvelopeError::EmptyPayload)
+        );
+    }
+
+    #[test]
+    fn envelope_rejects_sequence_overflow() {
+        let previous = JournalAnchor::new(u64::MAX, [0x11; JOURNAL_DIGEST_BYTES]);
+        let current = JournalAnchor::new(0, [0x22; JOURNAL_DIGEST_BYTES]);
+        assert!(matches!(
+            JournalEnvelope::new(previous, current, vec![1]),
+            Err(JournalEnvelopeError::NonContiguousSequence { .. })
+        ));
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod checkpoint;
 pub mod config;
 pub mod db;
 pub mod errors;
+pub mod journal;
 pub mod key;
 pub mod snapshot;
 pub mod stats;

--- a/src/api/tree.rs
+++ b/src/api/tree.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use super::config::{Storage, TreeConfig};
 use super::errors::{Error, Result};
+use super::journal::VolatileJournal;
 use super::snapshot::Snapshot;
 use super::stats::OpenStats;
 use super::stats::{
@@ -53,6 +54,44 @@ const ONLINE_MERGE_PARENT_BUDGET: usize = 256;
 const SHAPE_UNDERFILLED_CHILD_FILL_PER_MILLE: u32 = 350;
 const SHAPE_OVERFULL_CHILD_FILL_PER_MILLE: u32 = 850;
 const WRITE_DELTA_FLUSH_THRESHOLD: usize = 262_144;
+
+#[cfg(test)]
+pub(crate) struct OrdinaryWriteGateBarrier {
+    pub(crate) entered: std::sync::Barrier,
+    pub(crate) release: std::sync::Barrier,
+}
+
+#[cfg(test)]
+impl OrdinaryWriteGateBarrier {
+    pub(crate) fn new() -> Self {
+        Self {
+            entered: std::sync::Barrier::new(2),
+            release: std::sync::Barrier::new(2),
+        }
+    }
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static ORDINARY_WRITE_GATE_BARRIER: std::cell::RefCell<Option<Arc<OrdinaryWriteGateBarrier>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn set_ordinary_write_gate_barrier_for_current_thread(
+    barrier: Arc<OrdinaryWriteGateBarrier>,
+) {
+    ORDINARY_WRITE_GATE_BARRIER.with(|slot| *slot.borrow_mut() = Some(barrier));
+}
+
+#[cfg(test)]
+fn pause_before_ordinary_write_gate() {
+    let barrier = ORDINARY_WRITE_GATE_BARRIER.with(|slot| slot.borrow_mut().take());
+    if let Some(barrier) = barrier {
+        barrier.entered.wait();
+        barrier.release.wait();
+    }
+}
 
 #[cfg(test)]
 struct FullGcSnapshotCaptureBarrier {
@@ -288,6 +327,9 @@ pub struct Tree {
     /// Group-commit WAL worker — `Some` for persistent trees,
     /// `None` for memory trees.
     journal: Option<Arc<Journal>>,
+    /// Process-local attached-stream fence shared by trees opened from a
+    /// memory-mode DB. Standalone trees do not expose attached envelopes.
+    volatile_journal: Option<Arc<VolatileJournal>>,
     /// Direct-mapped cache for short hot key-only prefix scans.
     /// Conservatively invalidated by `next_seq`, so every write
     /// makes old entries miss.
@@ -669,6 +711,7 @@ impl Tree {
             Arc::new(AtomicU64::new(next_seq)),
             commit_gate,
             journal,
+            None,
             checkpointer,
             open_stats,
         )
@@ -685,6 +728,7 @@ impl Tree {
         next_seq: Arc<AtomicU64>,
         commit_gate: Arc<CommitGate>,
         journal: Option<Arc<Journal>>,
+        volatile_journal: Option<Arc<VolatileJournal>>,
         checkpointer: Option<Arc<crate::checkpoint::Checkpointer>>,
         open_stats: OpenStats,
     ) -> Result<Self> {
@@ -701,6 +745,7 @@ impl Tree {
             next_seq,
             commit_gate,
             journal,
+            volatile_journal,
             prefix_list_cache: runtime.prefix_list_cache,
             mutation_gate: runtime.mutation_gate,
             dropped: runtime.dropped,
@@ -728,6 +773,16 @@ impl Tree {
         } else {
             Ok(())
         }
+    }
+
+    fn preflight_ordinary_record(&self, record_len: usize) -> Result<()> {
+        if let Some(journal) = &self.journal {
+            journal.preflight_submit(record_len)?;
+        }
+        if let Some(journal) = &self.volatile_journal {
+            journal.ensure_ordinary_writes_allowed()?;
+        }
+        Ok(())
     }
 
     /// Look up `key`. Returns the value bytes, or `None` if no leaf
@@ -871,6 +926,7 @@ impl Tree {
         }
 
         if !new_ops.is_empty() {
+            self.preflight_ordinary_record(encoded_batch_record_len(&new_ops))?;
             let base_seq = self
                 .next_seq
                 .fetch_add(new_ops.len() as u64, Ordering::Relaxed);
@@ -917,17 +973,18 @@ impl Tree {
 
     fn put_deferred(&self, key: &[u8], value: &[u8]) -> Result<()> {
         Self::validate_insert_shape(key, value)?;
+        let journal = self
+            .journal
+            .as_ref()
+            .expect("can_stage_deferred_write requires journal");
         let ack = {
             let _mutation = self.maintenance_gate.enter_shared();
             self.ensure_writable()?;
+            journal.preflight_submit(encoded_insert_record_len(key.len(), value.len()))?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             let creates_key = self.get_version(key)?.is_none();
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
-            let journal = self
-                .journal
-                .as_ref()
-                .expect("can_stage_deferred_write requires journal");
             let _commit = self.commit_gate.enter_writer();
             let mut record =
                 journal.record_buffer(encoded_insert_record_len(key.len(), value.len()));
@@ -959,8 +1016,11 @@ impl Tree {
         let search = engine::SearchKey::user(key);
 
         let (outcome, journal_ack) = {
+            #[cfg(test)]
+            pause_before_ordinary_write_gate();
             let _mutation = self.maintenance_gate.enter_shared();
             self.ensure_writable()?;
+            self.preflight_ordinary_record(encoded_insert_record_len(key.len(), value.len()))?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
@@ -1060,19 +1120,20 @@ impl Tree {
     }
 
     fn delete_deferred(&self, key: &[u8]) -> Result<bool> {
+        let journal = self
+            .journal
+            .as_ref()
+            .expect("can_stage_deferred_write requires journal");
         let ack = {
             let _mutation = self.maintenance_gate.enter_shared();
             self.ensure_writable()?;
+            journal.preflight_submit(encoded_erase_record_len(key.len()))?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             if self.get_version(key)?.is_none() {
                 return Ok(false);
             }
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
-            let journal = self
-                .journal
-                .as_ref()
-                .expect("can_stage_deferred_write requires journal");
             let _commit = self.commit_gate.enter_writer();
             let mut record = journal.record_buffer(encoded_erase_record_len(key.len()));
             encode_erase_record(&mut record, seq, self.tree_id, key);
@@ -1112,6 +1173,7 @@ impl Tree {
         let (outcome, journal_ack) = {
             let _mutation = self.maintenance_gate.enter_shared();
             self.ensure_writable()?;
+            self.preflight_ordinary_record(encoded_erase_record_len(key.len()))?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoint = self.endpoint_locks.lock_key(key);
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
@@ -1195,6 +1257,7 @@ impl Tree {
         let journal_ack = {
             let _mutation = self.maintenance_gate.enter_shared();
             self.ensure_writable()?;
+            self.preflight_ordinary_record(encoded_rename_object_record_len(src.len(), dst.len()))?;
             let _tree_mutation = self.mutation_gate.enter_shared();
             let _endpoints = self.endpoint_locks.lock_pair(src, dst);
             let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
@@ -1352,14 +1415,12 @@ impl Tree {
     pub(crate) fn apply_batch(&self, pending: Vec<BatchOp>) -> Result<bool> {
         self.ensure_writable()?;
         let count = pending.iter().filter(|op| op.emits_wal()).count() as u64;
-        if count != 0 {
-            if let Some(journal) = &self.journal {
-                journal.preflight_submit(encoded_batch_record_len(&pending))?;
-            }
-        }
         self.flush_write_delta_for_tree()?;
         let _maintenance = self.maintenance_gate.enter_shared();
         self.ensure_live()?;
+        if count != 0 {
+            self.preflight_ordinary_record(encoded_batch_record_len(&pending))?;
+        }
         let _tree_mutation = self.mutation_gate.enter_batch();
         // Reserve a contiguous seq range so each inner op's seq is
         // `base + mutating_index` and replay can derive it without
@@ -1382,6 +1443,7 @@ impl Tree {
     /// holds the maintenance + mutation gates and has reserved the
     /// `base_seq` range; every inner op applies via the run walker.
     fn commit_batch(&self, pending: &[BatchOp], base_seq: u64) -> Result<()> {
+        self.preflight_ordinary_record(encoded_batch_record_len(pending))?;
         // W2D-strict protocol: all inner ops' walker mutations +
         // `mark_dirty` calls, plus the single envelope WAL submit, happen
         // under `commit_gate` — see `Tree::put_inner_conditional`.
@@ -2347,12 +2409,23 @@ impl Tree {
     pub fn checkpoint(&self) -> Result<()> {
         self.ensure_writable()?;
         if self.tree_id != 0 {
-            return Self::checkpoint_shared_store(
+            Self::checkpoint_shared_store(
                 &self.store,
                 self.journal.as_ref(),
                 &self.maintenance_gate,
                 &self.commit_gate,
-            );
+            )?;
+            if let Some(journal) = &self.volatile_journal {
+                let _maintenance = self.maintenance_gate.enter_exclusive();
+                Self::checkpoint_shared_store_with_maintenance_held(
+                    &self.store,
+                    None,
+                    &self.commit_gate,
+                )?;
+                let _commit = self.commit_gate.enter_checkpoint();
+                journal.checkpoint();
+            }
+            return Ok(());
         }
 
         // Standalone checkpoints also make bounded progress on retired COW
@@ -3215,10 +3288,10 @@ where
                     engine::insert_multi(bm, &root_pin, None, dst_search, &value, seq)?;
                 erase_out.root_dirty || insert_out.root_dirty
             }
-            // `Batch` is unpacked into per-inner callbacks inside
+            // Batch records are unpacked into per-inner callbacks inside
             // `journal::reader::replay_bytes`, so it never reaches
             // this match — defensive arm only.
-            WalOp::Batch { ops: _ } => false,
+            WalOp::Batch { ops: _ } | WalOp::DbBatchWithEnvelope { .. } => false,
         };
         if root_dirty {
             // Honour the walker's caller-side `mark_dirty(root,

--- a/src/checkpoint/io.rs
+++ b/src/checkpoint/io.rs
@@ -752,6 +752,7 @@ mod tests {
         Arc::new(Shared {
             bm: Arc::new(BufferManager::new(store, 8)),
             journal: None,
+            volatile_journal: None,
             commit_gate: Arc::new(CommitGate::new()),
             maintenance_gate: Arc::new(Gate::new()),
             cfg: CheckpointConfig::default(),

--- a/src/checkpoint/mod.rs
+++ b/src/checkpoint/mod.rs
@@ -83,6 +83,7 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::api::journal::VolatileJournal;
 use crate::concurrency::{CommitGate, Gate};
 use crate::journal::Journal;
 use crate::store::BufferManager;
@@ -190,6 +191,10 @@ impl CheckpointConfig {
 pub(super) struct Shared {
     pub(super) bm: Arc<BufferManager>,
     pub(super) journal: Option<Arc<Journal>>,
+    /// Process-local attached stream for memory DBs. The planner advances
+    /// its floor only at the same clean store frontier used for file-WAL
+    /// truncation.
+    pub(super) volatile_journal: Option<Arc<VolatileJournal>>,
     /// Same writer-shared / checkpoint-exclusive publish barrier
     /// used by foreground persistent writers. Checkpoint rounds hold
     /// its exclusive side only while draining dirty intent and
@@ -250,6 +255,19 @@ impl Checkpointer {
         commit_gate: Arc<CommitGate>,
         cfg: CheckpointConfig,
     ) -> Option<Self> {
+        Self::spawn_with_volatile(bm, journal, None, maintenance_gate, commit_gate, cfg)
+    }
+
+    /// Spawn a DB checkpointer with its process-local attached stream.
+    #[must_use]
+    pub(crate) fn spawn_with_volatile(
+        bm: Arc<BufferManager>,
+        journal: Option<Arc<Journal>>,
+        volatile_journal: Option<Arc<VolatileJournal>>,
+        maintenance_gate: Arc<Gate>,
+        commit_gate: Arc<CommitGate>,
+        cfg: CheckpointConfig,
+    ) -> Option<Self> {
         if !cfg.enabled {
             return None;
         }
@@ -257,6 +275,7 @@ impl Checkpointer {
         let shared = Arc::new(Shared {
             bm,
             journal,
+            volatile_journal,
             commit_gate,
             maintenance_gate,
             cfg,

--- a/src/checkpoint/mod.rs
+++ b/src/checkpoint/mod.rs
@@ -890,7 +890,7 @@ mod tests {
             rounds_after_wait - rounds_before_wait <= 10,
             "all-pinned orphan backlog busy-spun: {rounds_before_wait} -> {rounds_after_wait}"
         );
-        assert_eq!(bm.gc_orphan_backlog_count(), 1);
+        assert!(inner.has_blob(pinned_guid).unwrap());
 
         retire(free_guid);
         let deadline = Instant::now() + Duration::from_secs(2);
@@ -902,7 +902,6 @@ mod tests {
             thread::sleep(Duration::from_millis(2));
         }
         assert!(inner.has_blob(pinned_guid).unwrap());
-        assert_eq!(bm.gc_orphan_backlog_count(), 1);
 
         drop(pinned);
         ck.wake();

--- a/src/checkpoint/round.rs
+++ b/src/checkpoint/round.rs
@@ -185,6 +185,13 @@ impl Pipeline {
                     shared.truncates.fetch_add(1, Ordering::Relaxed);
                 }
             }
+            if let Some(journal) = &shared.volatile_journal {
+                // `maintenance -> commit -> volatile journal` matches the
+                // attached-write lock order. At this point the complete
+                // in-memory store image is clean, so the stream can discard
+                // every envelope through its current tail.
+                journal.checkpoint();
+            }
             shared.bm.take_retired_orphans_bounded(256)
         };
         // A clean frontier durably publishes every current parent image.

--- a/src/engine/walker/migrate.rs
+++ b/src/engine/walker/migrate.rs
@@ -530,9 +530,13 @@ struct BudgetNode {
 /// Mirrors filter-mode `clone_subtree` arm-for-arm and
 /// `pack_inner_node`'s tier collapse, so the totals are EXACT. Returns
 /// `None` when the whole subtree filters away (matches `clone_subtree`
-/// returning `None`). `EmptyRoot` reports 0 routing bytes so the caller
-/// keeps the empty / bare-leaf-root degenerate cases in the legacy
-/// layout.
+/// returning `None`). An `EmptyRoot` is charged at its actual emitted
+/// size. Although it normally appears only as an empty blob's root,
+/// preserve-mode child-blob merge can leave a reachable `EmptyRoot`
+/// below an inner node in the parent. Filter-mode cloning preserves that
+/// sentinel, so pass 0 must count it like every other internal node.
+/// [`routing_geometry`] still keeps an entirely empty tree in the legacy
+/// layout because its surviving-leaf byte count is zero.
 ///
 /// **Keep in lockstep with `clone_subtree` (below) and
 /// `pack_inner_node`.**
@@ -548,10 +552,13 @@ fn routing_budget(src: BlobFrameRef<'_>, src_off: u32) -> Result<Option<BudgetNo
         NodeType::Invalid => Err(Error::node_corrupt(
             "routing_budget: NodeType::Invalid in source",
         )),
-        // EmptyRoot is only ever the root of an empty tree; report 0
-        // routing bytes so the caller steers it to the legacy layout.
+        // Preserve-mode merge of an empty child blob can make an EmptyRoot
+        // reachable below an inner node. `clone_subtree` allocates an
+        // 8-byte sentinel for every such node even in filter mode, so count
+        // it exactly. An entirely empty tree remains legacy because it has
+        // no surviving leaf bytes.
         NodeType::EmptyRoot => Ok(Some(BudgetNode {
-            routing_bytes: 0,
+            routing_bytes: size_of_node(NodeType::EmptyRoot),
             leaf_bytes: 0,
         })),
         NodeType::Leaf => {

--- a/src/engine/walker/tests.rs
+++ b/src/engine/walker/tests.rs
@@ -16,9 +16,13 @@ use super::types::LookupResult;
 use super::writers::write_struct_at;
 use super::SearchKey;
 use crate::api::errors::Error;
-use crate::layout::{BlobGuid, BlobNode, NodeType, DATA_AREA_START, PAGE_SIZE};
+use crate::layout::{
+    size_of_node, BlobGuid, BlobNode, Node256, NodeType, Prefix, DATA_AREA_START, PAGE_SIZE,
+};
 use crate::store::blob_store::{AlignedBlobBuf, BlobStore, MemoryBlobStore};
-use crate::store::{decode_child_off, page_align_up, BlobFrame, BlobFrameRef, BufferManager};
+use crate::store::{
+    decode_child_off, encode_child_off, page_align_up, BlobFrame, BlobFrameRef, BufferManager,
+};
 use proptest::prelude::*;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -1367,6 +1371,126 @@ fn compact_blob_preserves_guid_and_lets_inserts_continue() {
     }
 }
 
+/// Empty child blobs can be folded into a non-root edge by the preserve-mode
+/// merge path. The resulting reachable `EmptyRoot` sentinels are valid and
+/// filter-mode compaction preserves them. Pass-0 routing measurement must
+/// therefore charge every sentinel's emitted 8 bytes, not only the fresh
+/// destination frame's root sentinel.
+///
+/// The node counts are chosen so the old under-count put the measured arena
+/// 40 bytes below a page boundary while the 163 omitted sentinels put the
+/// actual arena 40 bytes past it. This is the smallest deterministic form of
+/// the History-prune/merge/compact failure seen with deep application keys.
+fn blob_with_reachable_empty_roots(empty_children: usize, prefix_wrapped: usize) -> AlignedBlobBuf {
+    assert!((1..200).contains(&empty_children));
+    assert!(prefix_wrapped <= empty_children);
+    let (buf_vec, _) = fresh_blob();
+    let mut buf = aligned_from_vec(&buf_vec);
+    {
+        let mut frame = BlobFrame::wrap(buf.as_mut_slice());
+
+        // One substantial live leaf makes the blob eligible for the routed
+        // layout. Its leading byte occupies a branch outside the synthetic
+        // empty-child range below.
+        let live_key = [200u8, b'l'];
+        put(&mut frame, &live_key, &vec![0xA5; 16 * 1024], 1);
+        let live_leaf_off = root_off(&frame);
+
+        let mut children = [0u16; 256];
+        for (branch, child) in children.iter_mut().enumerate().take(empty_children) {
+            let out = frame.alloc_node(NodeType::EmptyRoot).unwrap();
+            let empty_off = frame.offset_of_slot(out.slot).unwrap();
+            frame.bytes_at_mut(empty_off, 8).unwrap()[1] = NodeType::EmptyRoot.as_u8();
+
+            let child_off = if branch < prefix_wrapped {
+                let out = frame.alloc_node(NodeType::Prefix).unwrap();
+                let prefix_off = frame.offset_of_slot(out.slot).unwrap();
+                let prefix = Prefix::new(b"p", u32::from(encode_child_off(empty_off)));
+                write_struct_at(&mut frame, prefix_off, &prefix).unwrap();
+                prefix_off
+            } else {
+                empty_off
+            };
+            *child = encode_child_off(child_off);
+        }
+        children[live_key[0] as usize] = encode_child_off(live_leaf_off);
+
+        let out = frame.alloc_node(NodeType::Node256).unwrap();
+        let root = frame.offset_of_slot(out.slot).unwrap();
+        let mut node = Node256::empty();
+        node.count = (empty_children + 1) as u8;
+        node.children = children;
+        write_struct_at(&mut frame, root, &node).unwrap();
+        frame.header_mut().root_slot = encode_child_off(root);
+    }
+    buf
+}
+
+#[test]
+fn routed_compaction_counts_reachable_empty_roots_below_inner_nodes() {
+    const EMPTY_CHILDREN: usize = 163;
+    const PREFIX_WRAPPED: usize = 18;
+
+    let mut buf = blob_with_reachable_empty_roots(EMPTY_CHILDREN, PREFIX_WRAPPED);
+    compact_blob(&mut buf).unwrap();
+    let frame = BlobFrame::wrap(buf.as_mut_slice());
+    assert!(
+        frame.header().routing_len != 0,
+        "substantial live leaf should produce a routed compacted blob"
+    );
+    assert_routing_layout(&frame);
+    assert_eq!(get(&frame, &[200, b'l']), Some(vec![0xA5; 16 * 1024]));
+    for branch in 0..EMPTY_CHILDREN as u8 {
+        assert_eq!(get(&frame, &[branch, b'p']), None, "branch {branch}");
+    }
+}
+
+#[test]
+fn routed_compaction_handles_144_byte_binary_expanded_keys_after_churn() {
+    const ROWS: u128 = 320;
+    const ROOT_PREFIX: [u8; 16] = [0x52; 16];
+
+    let (buf_vec, _) = fresh_blob();
+    let mut buf = aligned_from_vec(&buf_vec);
+    let mut oracle = BTreeMap::new();
+    {
+        let mut frame = BlobFrame::wrap(buf.as_mut_slice());
+        for i in 0..ROWS {
+            // Multiplication by an odd constant is bijective modulo 2^128,
+            // so all expanded request-id suffixes remain distinct.
+            let bits = i
+                .wrapping_mul(0x9E37_79B9_7F4A_7C15_D1B5_4A32_D192_ED03)
+                .wrapping_add(0xA076_1D64_78BD_642F_E703_7ED1_A0B4_28DB);
+            let mut key = ROOT_PREFIX.to_vec();
+            key.extend((0..128).rev().map(|bit| b'0' + ((bits >> bit) & 1) as u8));
+            let value = vec![i as u8; 48];
+            put(&mut frame, &key, &value, i as u64 + 1);
+            oracle.insert(key, value);
+        }
+        for i in (0..ROWS).step_by(3) {
+            let bits = i
+                .wrapping_mul(0x9E37_79B9_7F4A_7C15_D1B5_4A32_D192_ED03)
+                .wrapping_add(0xA076_1D64_78BD_642F_E703_7ED1_A0B4_28DB);
+            let mut key = ROOT_PREFIX.to_vec();
+            key.extend((0..128).rev().map(|bit| b'0' + ((bits >> bit) & 1) as u8));
+            let root = frame.header().root_slot;
+            erase(&mut frame, root, &key).unwrap();
+            oracle.remove(&key);
+        }
+    }
+
+    compact_blob(&mut buf).unwrap();
+    let frame = BlobFrame::wrap(buf.as_mut_slice());
+    assert!(
+        frame.header().routing_len != 0,
+        "deep-key blob should route"
+    );
+    assert_routing_layout(&frame);
+    for (key, value) in oracle {
+        assert_eq!(get(&frame, &key).as_deref(), Some(value.as_slice()));
+    }
+}
+
 /// Walk every node reachable from the root and assert the routing
 /// invariant: a child classifies as internal-vs-leaf purely from
 /// `off < leaf_region_start`, and that classification agrees with the
@@ -1959,6 +2083,36 @@ proptest! {
                 prop_assert_eq!(got, oracle.get(&k).cloned());
             }
         }
+    }
+
+    /// Preserve-mode merge may leave any number of reachable empty child
+    /// sentinels, optionally below Prefix nodes. For every generated shape,
+    /// pass-0's byte budget must exactly match the arena emitted by the
+    /// filter-mode clone, including the fresh destination sentinel.
+    #[test]
+    fn routed_budget_is_exact_with_reachable_empty_roots(
+        empty_children in 1usize..190,
+        prefix_seed in 0usize..190,
+    ) {
+        let prefix_wrapped = prefix_seed % (empty_children + 1);
+        let mut buf = blob_with_reachable_empty_roots(empty_children, prefix_wrapped);
+        compact_blob(&mut buf).unwrap();
+        let frame = BlobFrame::wrap(buf.as_mut_slice());
+        assert_routing_layout(&frame);
+
+        let survivors = empty_children + 1; // empty branches + live leaf
+        let root_size = match survivors {
+            2..=4 => size_of_node(NodeType::Node4),
+            5..=16 => size_of_node(NodeType::Node16),
+            17..=48 => size_of_node(NodeType::Node48),
+            _ => size_of_node(NodeType::Node256),
+        };
+        let expected_routing_len = size_of_node(NodeType::EmptyRoot)
+            + root_size
+            + empty_children as u32 * size_of_node(NodeType::EmptyRoot)
+            + prefix_wrapped as u32 * size_of_node(NodeType::Prefix);
+        prop_assert_eq!(frame.header().routing_len, expected_routing_len);
+        prop_assert_eq!(get(&frame, &[200, b'l']), Some(vec![0xA5; 16 * 1024]));
     }
 }
 

--- a/src/journal/codec.rs
+++ b/src/journal/codec.rs
@@ -33,6 +33,7 @@
 
 use super::wal_op::WalOp;
 use crate::api::errors::{Error, Result};
+use crate::api::journal::{JournalAnchor, JournalEnvelope, JOURNAL_DIGEST_BYTES};
 
 /// Start-of-record magic — `"RECR"` little-endian.
 pub const RECORD_MAGIC: u32 = 0x5243_4552;
@@ -50,11 +51,16 @@ pub const RECORD_FOOTER_SIZE: usize = 4;
 /// one of our WAL files".
 pub const FILE_MAGIC: u32 = 0x414C_4157;
 
-/// Format version stored in the file header. New format revisions
-/// bump this and grow the header (in the reserved tail) rather
-/// than moving existing fields.
+/// Previous public format accepted by the replay reader.
 ///
-/// v0.3.0 ships format `3`: dropped the dead `prev_value` field
+/// Format 3 contains only the original logical redo tags. It is replay-only
+/// under a format-4 writer: callers must checkpoint it with a format-3 Holt
+/// binary before reopening for new writes.
+pub const LEGACY_FORMAT_VERSION: u32 = 3;
+
+/// Format version emitted by new WAL writers.
+///
+/// Format `3` dropped the dead `prev_value` field
 /// from `WalOp::Insert` and the dead `value` field from
 /// `WalOp::Erase`. Both were "for replay reversibility" but
 /// replay never undoes — it's an idempotent forward redo that
@@ -69,33 +75,61 @@ pub const FILE_MAGIC: u32 = 0x414C_4157;
 /// first so the WAL is truncated before opening it with v0.3.0.
 /// The v0.2 → v0.3.0 public upgrade follows the same
 /// "checkpoint before upgrade" rule.
-pub const FORMAT_VERSION: u32 = 3;
+///
+/// Format `4` adds `DbBatchWithEnvelope` (tag 13). Its application recovery
+/// bytes and logical DB operations are covered by one record CRC.
+pub const FORMAT_VERSION: u32 = 4;
 
-/// File-header byte size. The record stream starts at this offset.
-pub const FILE_HEADER_SIZE: usize = 32;
+/// Legacy format-3 header byte size and record-stream offset.
+pub const LEGACY_FILE_HEADER_SIZE: usize = 32;
 
-/// Top-of-file layout:
+/// Format-4 page header byte size and record-stream offset.
+///
+/// Keeping records page-aligned leaves room for two independently checksummed
+/// checkpoint-anchor slots without rewriting the append stream.
+pub const FILE_HEADER_SIZE: usize = 4096;
+
+const ANCHOR_SLOT_MAGIC: u32 = 0x5248_4341; // "ACHR" little-endian.
+const ANCHOR_SLOT_VERSION: u32 = 1;
+pub(crate) const ANCHOR_SLOT_SIZE: usize = 128;
+pub(crate) const ANCHOR_SLOT_OFFSETS: [usize; 2] = [64, 64 + ANCHOR_SLOT_SIZE];
+const ANCHOR_SLOT_CHECKSUM_OFFSET: usize = 64;
+const ANCHOR_SLOT_FLAG_INITIALIZED: u64 = 1;
+
+/// Format-4 top-of-file layout:
 ///
 /// ```text
-/// +------+------+------+--------+--------+
-/// | MAGIC|  VER | TREE | CREATED|  RSVD  |
-/// |  u32 |  u32 |  u64 |   u64  |  u64   |
-/// +------+------+------+--------+--------+
+/// base[32] | padding[32] | anchor_slot_a[128] | anchor_slot_b[128]
+///           |                         zero padding to 4096 bytes            |
+///
+/// base = MAGIC:u32 | VER:u32 | TREE:u64 | CREATED:u64 | HEADER_SIZE:u64
+/// slot = MAGIC:u32 | VER:u32 | GENERATION:u64 | FLAGS:u64
+///        | SEQUENCE:u64 | DIGEST:[u8;32] | CRC32:u32 | padding[60]
 /// ```
 ///
 /// - `MAGIC` = [`FILE_MAGIC`] (`"WALA"` LE).
-/// - `VER`   = [`FORMAT_VERSION`].
+/// - `VER`   = [`FORMAT_VERSION`] for new files; replay also accepts
+///   [`LEGACY_FORMAT_VERSION`].
 /// - `TREE`  = tree owner identifier; `0` for the single-tree API.
 /// - `CREATED` = unix epoch seconds; `0` when the writer chose
 ///   not to stamp a time (e.g. tests).
-/// - `RSVD`  = reserved for a future version bump, must be `0`.
+/// - `HEADER_SIZE` = [`FILE_HEADER_SIZE`].
+/// - Each initialized anchor slot has an independent generation and CRC.
+///   Decode selects the highest valid generation. Checkpoint updates write and
+///   sync both slots in sequence before they truncate the record stream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileHeader {
+    /// On-disk WAL format version.
+    pub version: u32,
     /// Tree owner identifier.
     pub tree_id: u64,
     /// Unix-epoch seconds when the file was created. `0` if the
     /// writer didn't stamp one.
     pub created_at: u64,
+    /// Latest checkpoint anchor recovered from the two format-4 slots.
+    pub checkpoint_anchor: Option<JournalAnchor>,
+    /// Generation of `checkpoint_anchor`; zero when uninitialized.
+    pub anchor_generation: u64,
 }
 
 impl FileHeader {
@@ -106,8 +140,21 @@ impl FileHeader {
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_secs());
         Self {
+            version: FORMAT_VERSION,
             tree_id,
             created_at,
+            checkpoint_anchor: None,
+            anchor_generation: 0,
+        }
+    }
+
+    /// Byte offset at which this format's record stream starts.
+    #[must_use]
+    pub const fn record_offset(self) -> usize {
+        if self.version == LEGACY_FORMAT_VERSION {
+            LEGACY_FILE_HEADER_SIZE
+        } else {
+            FILE_HEADER_SIZE
         }
     }
 }
@@ -115,19 +162,34 @@ impl FileHeader {
 /// Encode the file header into the first [`FILE_HEADER_SIZE`] bytes
 /// of `out` (the buffer is resized as needed).
 pub fn encode_file_header(h: &FileHeader, out: &mut Vec<u8>) {
+    let start = out.len();
     out.extend_from_slice(&FILE_MAGIC.to_le_bytes());
-    out.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+    out.extend_from_slice(&h.version.to_le_bytes());
     out.extend_from_slice(&h.tree_id.to_le_bytes());
     out.extend_from_slice(&h.created_at.to_le_bytes());
-    out.extend_from_slice(&0u64.to_le_bytes());
-    debug_assert_eq!(out.len(), FILE_HEADER_SIZE);
+    if h.version == LEGACY_FORMAT_VERSION {
+        out.extend_from_slice(&0u64.to_le_bytes());
+        debug_assert_eq!(out.len() - start, LEGACY_FILE_HEADER_SIZE);
+        return;
+    }
+
+    out.extend_from_slice(&(FILE_HEADER_SIZE as u64).to_le_bytes());
+    out.resize(start + FILE_HEADER_SIZE, 0);
+    if let Some(anchor) = h.checkpoint_anchor {
+        debug_assert_ne!(h.anchor_generation, 0);
+        let slot_index = ((h.anchor_generation - 1) & 1) as usize;
+        let slot = encode_anchor_slot(anchor, h.anchor_generation);
+        let offset = start + ANCHOR_SLOT_OFFSETS[slot_index];
+        out[offset..offset + ANCHOR_SLOT_SIZE].copy_from_slice(&slot);
+    }
+    debug_assert_eq!(out.len() - start, FILE_HEADER_SIZE);
 }
 
 /// Decode a file header from the first [`FILE_HEADER_SIZE`] bytes
 /// of `buf`. Returns the header on success and a sanity-failed
 /// error (with `record_offset = 0`) on mismatch.
 pub fn decode_file_header(buf: &[u8]) -> Result<FileHeader> {
-    if buf.len() < FILE_HEADER_SIZE {
+    if buf.len() < LEGACY_FILE_HEADER_SIZE {
         return Err(sanity("WAL file header truncated"));
     }
     let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
@@ -135,19 +197,128 @@ pub fn decode_file_header(buf: &[u8]) -> Result<FileHeader> {
         return Err(sanity("WAL file magic mismatch"));
     }
     let version = u32::from_le_bytes(buf[4..8].try_into().unwrap());
-    if version != FORMAT_VERSION {
+    if version != LEGACY_FORMAT_VERSION && version != FORMAT_VERSION {
         return Err(sanity("WAL file format version unsupported"));
+    }
+    let required = if version == LEGACY_FORMAT_VERSION {
+        LEGACY_FILE_HEADER_SIZE
+    } else {
+        FILE_HEADER_SIZE
+    };
+    if buf.len() < required {
+        return Err(sanity("WAL file header truncated"));
     }
     let tree_id = u64::from_le_bytes(buf[8..16].try_into().unwrap());
     let created_at = u64::from_le_bytes(buf[16..24].try_into().unwrap());
-    // bytes 24..32 reserved; ignore for forward-compatibility.
+    if version == FORMAT_VERSION {
+        let encoded_size = u64::from_le_bytes(buf[24..32].try_into().unwrap());
+        if encoded_size != FILE_HEADER_SIZE as u64 {
+            return Err(sanity("WAL format-4 header size mismatch"));
+        }
+    }
+    let (checkpoint_anchor, anchor_generation) = if version == FORMAT_VERSION {
+        decode_checkpoint_anchor(buf)?
+    } else {
+        (None, 0)
+    };
     Ok(FileHeader {
+        version,
         tree_id,
         created_at,
+        checkpoint_anchor,
+        anchor_generation,
     })
 }
 
-// On-disk variant tags. Stable for format v3; only ever add new
+/// Return the header size named by the prefix, without requiring the full
+/// format-4 page to be present yet.
+pub(crate) fn file_header_size_from_prefix(prefix: &[u8]) -> Result<usize> {
+    if prefix.len() < 8 {
+        return Err(sanity("WAL file header truncated"));
+    }
+    let magic = u32::from_le_bytes(prefix[0..4].try_into().unwrap());
+    if magic != FILE_MAGIC {
+        return Err(sanity("WAL file magic mismatch"));
+    }
+    match u32::from_le_bytes(prefix[4..8].try_into().unwrap()) {
+        LEGACY_FORMAT_VERSION => Ok(LEGACY_FILE_HEADER_SIZE),
+        FORMAT_VERSION => Ok(FILE_HEADER_SIZE),
+        _ => Err(sanity("WAL file format version unsupported")),
+    }
+}
+
+pub(crate) fn encode_anchor_slot(anchor: JournalAnchor, generation: u64) -> [u8; ANCHOR_SLOT_SIZE] {
+    debug_assert_ne!(generation, 0);
+    let mut slot = [0u8; ANCHOR_SLOT_SIZE];
+    slot[0..4].copy_from_slice(&ANCHOR_SLOT_MAGIC.to_le_bytes());
+    slot[4..8].copy_from_slice(&ANCHOR_SLOT_VERSION.to_le_bytes());
+    slot[8..16].copy_from_slice(&generation.to_le_bytes());
+    slot[16..24].copy_from_slice(&ANCHOR_SLOT_FLAG_INITIALIZED.to_le_bytes());
+    slot[24..32].copy_from_slice(&anchor.sequence().to_le_bytes());
+    slot[32..64].copy_from_slice(&anchor.digest());
+    let checksum = crc32(&slot[..ANCHOR_SLOT_CHECKSUM_OFFSET]);
+    slot[ANCHOR_SLOT_CHECKSUM_OFFSET..ANCHOR_SLOT_CHECKSUM_OFFSET + 4]
+        .copy_from_slice(&checksum.to_le_bytes());
+    slot
+}
+
+fn decode_checkpoint_anchor(buf: &[u8]) -> Result<(Option<JournalAnchor>, u64)> {
+    let mut valid = Vec::with_capacity(2);
+    let mut nonzero_slots = 0;
+    for &offset in &ANCHOR_SLOT_OFFSETS {
+        let slot = &buf[offset..offset + ANCHOR_SLOT_SIZE];
+        if slot.iter().any(|byte| *byte != 0) {
+            nonzero_slots += 1;
+        }
+        if let Some(decoded) = decode_anchor_slot(slot) {
+            valid.push(decoded);
+        }
+    }
+    if valid.is_empty() {
+        // One non-zero invalid slot can only be a torn first initialization;
+        // the all-zero sibling is still the authoritative uninitialized state.
+        if nonzero_slots > 1 {
+            return Err(sanity("WAL checkpoint anchor slots corrupt"));
+        }
+        return Ok((None, 0));
+    }
+    valid.sort_unstable_by_key(|(_, generation)| *generation);
+    if valid.len() == 2 && valid[0].1 == valid[1].1 && valid[0].0 != valid[1].0 {
+        return Err(sanity("WAL checkpoint anchor generations conflict"));
+    }
+    let (anchor, generation) = *valid.last().unwrap();
+    Ok((Some(anchor), generation))
+}
+
+fn decode_anchor_slot(slot: &[u8]) -> Option<(JournalAnchor, u64)> {
+    if slot.len() != ANCHOR_SLOT_SIZE {
+        return None;
+    }
+    let magic = u32::from_le_bytes(slot[0..4].try_into().ok()?);
+    let version = u32::from_le_bytes(slot[4..8].try_into().ok()?);
+    let generation = u64::from_le_bytes(slot[8..16].try_into().ok()?);
+    let flags = u64::from_le_bytes(slot[16..24].try_into().ok()?);
+    if magic != ANCHOR_SLOT_MAGIC
+        || version != ANCHOR_SLOT_VERSION
+        || generation == 0
+        || flags != ANCHOR_SLOT_FLAG_INITIALIZED
+    {
+        return None;
+    }
+    let expected = u32::from_le_bytes(
+        slot[ANCHOR_SLOT_CHECKSUM_OFFSET..ANCHOR_SLOT_CHECKSUM_OFFSET + 4]
+            .try_into()
+            .ok()?,
+    );
+    if crc32(&slot[..ANCHOR_SLOT_CHECKSUM_OFFSET]) != expected {
+        return None;
+    }
+    let sequence = u64::from_le_bytes(slot[24..32].try_into().ok()?);
+    let digest = slot[32..64].try_into().ok()?;
+    Some((JournalAnchor::new(sequence, digest), generation))
+}
+
+// On-disk variant tags. Stable through format v4; only ever add new
 // tags, never renumber existing ones. Tags 2..4 and 6..9 are
 // intentionally unassigned in production: an internal v0.3 draft
 // had non-emitted structural / multi-tree variants there, but
@@ -159,6 +330,10 @@ const TY_RENAME_OBJECT: u8 = 5;
 const TY_BATCH: u8 = 10;
 const TY_BATCH_INSERT_RUN: u8 = 11;
 const TY_BATCH_INSERT_PREFIX_RUN: u8 = 12;
+const TY_DB_BATCH_WITH_ENVELOPE: u8 = 13;
+
+/// Version of the envelope sub-frame carried by tag 13.
+const JOURNAL_ENVELOPE_WIRE_VERSION: u8 = 1;
 
 // ---------- CRC32 (IEEE 802.3) ----------
 
@@ -288,8 +463,10 @@ pub(crate) const fn encoded_rename_object_record_len(
 ///
 /// Lifecycle:
 ///
-/// 1. [`BatchEncoder::begin`] writes the record header and the
-///    batch body prefix (`tree_id` + zero-placeholder inner-count).
+/// 1. [`BatchEncoder::begin`] or [`BatchEncoder::begin_with_envelope`]
+///    writes the record header and batch body prefix (`tree_id` plus a
+///    zero-placeholder inner count). The attached form then writes its
+///    validated application envelope before the operation stream.
 /// 2. The caller interleaves walker mutations with
 ///    [`Self::push_insert`] / [`Self::push_insert_run`] /
 ///    [`Self::push_erase`] / [`Self::push_rename_object`] calls.
@@ -325,17 +502,57 @@ impl<'buf> BatchEncoder<'buf> {
     /// (tree_id, zero-placeholder count) are written immediately;
     /// subsequent `push_*` calls extend the body.
     pub fn begin(out: &'buf mut Vec<u8>, seq: u64, tree_id: u64) -> Self {
-        out.reserve(RECORD_HEADER_SIZE + 8 + 4 + RECORD_FOOTER_SIZE);
+        Self::begin_record(out, seq, tree_id, TY_BATCH, None)
+    }
+
+    /// Open a format-4 DB `Batch` record with one recovery envelope attached.
+    ///
+    /// The body layout is:
+    ///
+    /// ```text
+    /// tree_id:u64 | count:u32 | envelope_version:u8
+    /// previous_sequence:u64 | previous_digest:[u8;32]
+    /// current_sequence:u64  | current_digest:[u8;32]
+    /// payload_len:u32 | payload:[u8;payload_len] | inner_ops...
+    /// ```
+    ///
+    /// `finish` computes one CRC over the record header, the full envelope,
+    /// and all inner operations. The application payload remains opaque.
+    // This is the format-4 producer seam. The DB API calls it in the next
+    // integration slice; keeping the allow local avoids masking other dead code.
+    #[allow(dead_code)]
+    pub fn begin_with_envelope(
+        out: &'buf mut Vec<u8>,
+        seq: u64,
+        tree_id: u64,
+        envelope: &JournalEnvelope,
+    ) -> Self {
+        Self::begin_record(out, seq, tree_id, TY_DB_BATCH_WITH_ENVELOPE, Some(envelope))
+    }
+
+    fn begin_record(
+        out: &'buf mut Vec<u8>,
+        seq: u64,
+        tree_id: u64,
+        ty: u8,
+        envelope: Option<&JournalEnvelope>,
+    ) -> Self {
+        let envelope_len =
+            envelope.map_or(0, |value| encoded_journal_envelope_len(value.payload()));
+        out.reserve(RECORD_HEADER_SIZE + 8 + 4 + envelope_len + RECORD_FOOTER_SIZE);
         let start = out.len();
         out.extend_from_slice(&RECORD_MAGIC.to_le_bytes());
         let len_pos = out.len();
         out.extend_from_slice(&[0u8; 4]);
         out.extend_from_slice(&seq.to_le_bytes());
-        out.push(TY_BATCH);
+        out.push(ty);
         let body_start = out.len();
         out.extend_from_slice(&tree_id.to_le_bytes());
         let count_pos = out.len();
         out.extend_from_slice(&[0u8; 4]);
+        if let Some(envelope) = envelope {
+            encode_journal_envelope(envelope, out);
+        }
         Self {
             out,
             start,
@@ -504,6 +721,7 @@ fn variant_tag(op: &WalOp) -> u8 {
         WalOp::Erase { .. } => TY_ERASE,
         WalOp::RenameObject { .. } => TY_RENAME_OBJECT,
         WalOp::Batch { .. } => TY_BATCH,
+        WalOp::DbBatchWithEnvelope { .. } => TY_DB_BATCH_WITH_ENVELOPE,
     }
 }
 
@@ -541,14 +759,44 @@ fn encode_body(op: &WalOp, out: &mut Vec<u8>) {
             for inner in ops {
                 let inner_ty = variant_tag(inner);
                 assert!(
-                    inner_ty != TY_BATCH,
+                    inner_ty != TY_BATCH && inner_ty != TY_DB_BATCH_WITH_ENVELOPE,
                     "nested Batch is rejected — Tree::atomic must flatten",
                 );
                 out.push(inner_ty);
                 encode_body(inner, out);
             }
         }
+        WalOp::DbBatchWithEnvelope { envelope, ops } => {
+            out.extend_from_slice(&0u64.to_le_bytes());
+            let count = u32::try_from(ops.len()).expect("batch ops fit in u32");
+            out.extend_from_slice(&count.to_le_bytes());
+            encode_journal_envelope(envelope, out);
+            for inner in ops {
+                let inner_ty = variant_tag(inner);
+                assert!(
+                    inner_ty != TY_BATCH && inner_ty != TY_DB_BATCH_WITH_ENVELOPE,
+                    "nested Batch is rejected — DB::atomic must flatten",
+                );
+                out.push(inner_ty);
+                encode_body(inner, out);
+            }
+        }
     }
+}
+
+fn encoded_journal_envelope_len(payload: &[u8]) -> usize {
+    1 + 8 + JOURNAL_DIGEST_BYTES + 8 + JOURNAL_DIGEST_BYTES + 4 + payload.len()
+}
+
+fn encode_journal_envelope(envelope: &JournalEnvelope, out: &mut Vec<u8>) {
+    out.push(JOURNAL_ENVELOPE_WIRE_VERSION);
+    let previous = envelope.previous();
+    out.extend_from_slice(&previous.sequence().to_le_bytes());
+    out.extend_from_slice(&previous.digest());
+    let current = envelope.current();
+    out.extend_from_slice(&current.sequence().to_le_bytes());
+    out.extend_from_slice(&current.digest());
+    write_bytes(out, envelope.payload());
 }
 
 fn write_bytes(out: &mut Vec<u8>, b: &[u8]) {
@@ -653,13 +901,18 @@ fn decode_body_into(ty: u8, body: &mut &[u8]) -> Result<WalOp> {
                 force,
             }
         }
-        TY_BATCH => {
+        TY_BATCH | TY_DB_BATCH_WITH_ENVELOPE => {
             let _tree_id = read_u64(body)?;
             let count = read_u32(body)? as usize;
+            let envelope = if ty == TY_DB_BATCH_WITH_ENVELOPE {
+                Some(decode_journal_envelope(body)?)
+            } else {
+                None
+            };
             let mut ops = Vec::with_capacity(count);
             while ops.len() < count {
                 let inner_ty = read_u8(body)?;
-                if inner_ty == TY_BATCH {
+                if inner_ty == TY_BATCH || inner_ty == TY_DB_BATCH_WITH_ENVELOPE {
                     return Err(sanity("nested Batch is rejected"));
                 }
                 match inner_ty {
@@ -671,11 +924,42 @@ fn decode_body_into(ty: u8, body: &mut &[u8]) -> Result<WalOp> {
                     }
                 }
             }
-            WalOp::Batch { ops }
+            if let Some(envelope) = envelope {
+                WalOp::DbBatchWithEnvelope { envelope, ops }
+            } else {
+                WalOp::Batch { ops }
+            }
         }
         _ => return Err(sanity("unknown WalOp variant tag")),
     };
     Ok(op)
+}
+
+fn decode_journal_envelope(body: &mut &[u8]) -> Result<JournalEnvelope> {
+    let wire_version = read_u8(body)?;
+    if wire_version != JOURNAL_ENVELOPE_WIRE_VERSION {
+        return Err(sanity("journal envelope wire version unsupported"));
+    }
+
+    let previous_sequence = read_u64(body)?;
+    let previous_digest = read_digest(body)?;
+    let current_sequence = read_u64(body)?;
+    let current_digest = read_digest(body)?;
+    let payload = read_bytes(body)?;
+    JournalEnvelope::new(
+        JournalAnchor::new(previous_sequence, previous_digest),
+        JournalAnchor::new(current_sequence, current_digest),
+        payload,
+    )
+    .map_err(|error| match error {
+        crate::JournalEnvelopeError::NonContiguousSequence { .. } => {
+            sanity("journal envelope sequence is not contiguous")
+        }
+        crate::JournalEnvelopeError::EmptyPayload => sanity("journal envelope payload is empty"),
+        crate::JournalEnvelopeError::PayloadTooLarge { .. } => {
+            sanity("journal envelope payload is too large")
+        }
+    })
 }
 
 fn decode_insert_run(body: &mut &[u8], batch_count: usize, ops: &mut Vec<WalOp>) -> Result<()> {
@@ -750,6 +1034,12 @@ fn read_u64(body: &mut &[u8]) -> Result<u64> {
     Ok(u64::from_le_bytes(front.try_into().unwrap()))
 }
 
+fn read_digest(body: &mut &[u8]) -> Result<[u8; JOURNAL_DIGEST_BYTES]> {
+    let (front, rest) = take(body, JOURNAL_DIGEST_BYTES)?;
+    *body = rest;
+    Ok(front.try_into().unwrap())
+}
+
 fn read_bytes(body: &mut &[u8]) -> Result<Vec<u8>> {
     let len = read_u32(body)? as usize;
     let (front, rest) = take(body, len)?;
@@ -776,6 +1066,16 @@ fn sanity(context: &'static str) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Write;
+
+    fn sample_envelope() -> JournalEnvelope {
+        JournalEnvelope::new(
+            JournalAnchor::new(41, [0x11; JOURNAL_DIGEST_BYTES]),
+            JournalAnchor::new(42, [0x22; JOURNAL_DIGEST_BYTES]),
+            b"rv1".to_vec(),
+        )
+        .unwrap()
+    }
 
     fn roundtrip(op: WalOp, seq: u64) {
         let mut buf = Vec::new();
@@ -1077,6 +1377,155 @@ mod tests {
             WalOp::Batch { ops } => assert!(ops.is_empty()),
             other => panic!("expected Batch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn attached_batch_streaming_and_enum_encoders_match() {
+        let envelope = sample_envelope();
+        let mut streaming = Vec::new();
+        {
+            let mut encoder =
+                BatchEncoder::begin_with_envelope(&mut streaming, 1_000, 0, &envelope);
+            encoder.push_insert(7, b"k", b"v");
+            assert_eq!(encoder.finish(), 1);
+        }
+
+        let attached = WalOp::DbBatchWithEnvelope {
+            envelope: envelope.clone(),
+            ops: vec![WalOp::Insert {
+                tree_id: 7,
+                key: b"k".to_vec(),
+                value: b"v".to_vec(),
+            }],
+        };
+        let mut generic = Vec::new();
+        encode_record(&attached, 1_000, &mut generic);
+        assert_eq!(streaming, generic);
+
+        let decoded = decode_record(&streaming).unwrap();
+        assert_eq!(decoded.seq, 1_000);
+        assert_eq!(decoded.bytes_consumed, streaming.len());
+        match decoded.op {
+            WalOp::DbBatchWithEnvelope {
+                envelope: decoded_envelope,
+                ops,
+            } => {
+                assert_eq!(decoded_envelope, envelope);
+                assert!(matches!(
+                    ops.as_slice(),
+                    [WalOp::Insert {
+                        tree_id: 7,
+                        key,
+                        value,
+                    }] if key == b"k" && value == b"v"
+                ));
+            }
+            other => panic!("expected attached DB batch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn attached_batch_has_stable_format_4_golden_bytes() {
+        let envelope = sample_envelope();
+        let mut encoded = Vec::new();
+        {
+            let mut encoder = BatchEncoder::begin_with_envelope(&mut encoded, 1_000, 0, &envelope);
+            encoder.push_insert(7, b"k", b"v");
+            encoder.finish();
+        }
+
+        let actual = encoded.iter().fold(String::new(), |mut output, byte| {
+            write!(output, "{byte:02x}").unwrap();
+            output
+        });
+        assert_eq!(
+            actual,
+            concat!(
+                "5245435277000000e8030000000000000d0000000000000000010000000129",
+                "0000000000000011111111111111111111111111111111111111111111111111",
+                "111111111111112a000000000000002222222222222222222222222222222222",
+                "2222222222222222222222222222220300000072763100070000000000000001",
+                "0000006b0100000076ca022951"
+            )
+        );
+    }
+
+    #[test]
+    fn attached_batch_crc_covers_envelope_and_inner_ops() {
+        let mut encoded = Vec::new();
+        {
+            let mut encoder =
+                BatchEncoder::begin_with_envelope(&mut encoded, 1_000, 0, &sample_envelope());
+            encoder.push_insert(7, b"k", b"v");
+            encoder.finish();
+        }
+
+        let payload_offset = encoded
+            .windows(3)
+            .position(|window| window == b"rv1")
+            .unwrap();
+        let mut envelope_corrupt = encoded.clone();
+        envelope_corrupt[payload_offset] ^= 0x01;
+        assert!(matches!(
+            decode_record(&envelope_corrupt),
+            Err(Error::ReplaySanityFailed {
+                context: "record CRC mismatch",
+                ..
+            })
+        ));
+
+        let mut op_corrupt = encoded;
+        let value_offset = op_corrupt.len() - RECORD_FOOTER_SIZE - 1;
+        op_corrupt[value_offset] ^= 0x01;
+        assert!(matches!(
+            decode_record(&op_corrupt),
+            Err(Error::ReplaySanityFailed {
+                context: "record CRC mismatch",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn attached_batch_rejects_bad_envelope_version_and_sequence() {
+        let mut encoded = Vec::new();
+        {
+            let encoder =
+                BatchEncoder::begin_with_envelope(&mut encoded, 1_000, 0, &sample_envelope());
+            encoder.finish();
+        }
+
+        let envelope_version_offset = RECORD_HEADER_SIZE + 8 + 4;
+        let mut bad_version = encoded.clone();
+        bad_version[envelope_version_offset] = 2;
+        rewrite_record_crc(&mut bad_version);
+        assert!(matches!(
+            decode_record(&bad_version),
+            Err(Error::ReplaySanityFailed {
+                context: "journal envelope wire version unsupported",
+                ..
+            })
+        ));
+
+        let current_sequence_offset = envelope_version_offset + 1 + 8 + JOURNAL_DIGEST_BYTES;
+        let mut bad_sequence = encoded;
+        bad_sequence[current_sequence_offset..current_sequence_offset + 8]
+            .copy_from_slice(&43u64.to_le_bytes());
+        rewrite_record_crc(&mut bad_sequence);
+        assert!(matches!(
+            decode_record(&bad_sequence),
+            Err(Error::ReplaySanityFailed {
+                context: "journal envelope sequence is not contiguous",
+                ..
+            })
+        ));
+    }
+
+    fn rewrite_record_crc(encoded: &mut [u8]) {
+        let body_len = u32::from_le_bytes(encoded[4..8].try_into().unwrap()) as usize;
+        let body_end = RECORD_HEADER_SIZE + body_len;
+        let checksum = crc32(&encoded[..body_end]);
+        encoded[body_end..body_end + RECORD_FOOTER_SIZE].copy_from_slice(&checksum.to_le_bytes());
     }
 
     #[test]

--- a/src/journal/group_commit.rs
+++ b/src/journal/group_commit.rs
@@ -30,16 +30,25 @@
 //! fsync happens only when a sync target is outstanding (sync write or
 //! checkpoint barrier), exactly like legacy group commit.
 
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
 
 use crate::api::errors::{Error, Result};
+use crate::api::journal::{
+    JournalAnchor, JournalEnvelope, JournalEnvelopePage, JournalState, MAX_JOURNAL_RECORD_BYTES,
+};
 
+use super::codec::decode_record;
+use super::reader::{
+    scan_attached_envelope_page_from, validate_attached_journal, AttachedEnvelopeResume,
+};
 use super::ring::{ReserveTicket, WalRing};
+use super::wal_op::WalOp;
 use super::writer::WalWriter;
 
 /// Production journal counters surfaced through `Tree::stats`.
@@ -56,9 +65,9 @@ pub(crate) struct JournalStats {
     pub(crate) checkpoint_debt: u64,
 }
 
-/// In-RAM ring capacity. 16 MiB absorbs large metadata bursts between
-/// checkpoints; records are ≤ ~512 KB so a single record always fits.
-const RING_CAPACITY_BYTES: usize = 16 * 1024 * 1024;
+/// In-RAM ring capacity and public encoded-record ceiling. A maximum-size
+/// record fills the ring; smaller records share the remaining burst capacity.
+const RING_CAPACITY_BYTES: usize = MAX_JOURNAL_RECORD_BYTES;
 /// Flusher idle poll. Bounds the async RAM→page-cache window (process-crash
 /// durability) and the latency a sync waiter adds if a wake is ever missed.
 const FLUSH_POLL: Duration = Duration::from_micros(50);
@@ -104,6 +113,14 @@ struct Shared {
 
     control_tx: Sender<Control>,
     record_pool: Mutex<Vec<Vec<u8>>>,
+    path: PathBuf,
+    tail: Mutex<TailState>,
+}
+
+struct TailState {
+    checkpoint: Option<JournalAnchor>,
+    tail: Option<JournalAnchor>,
+    scan_resume: Option<AttachedEnvelopeResume>,
 }
 
 impl Shared {
@@ -270,9 +287,17 @@ pub(crate) struct Journal {
     handle: Mutex<Option<JoinHandle<()>>>,
 }
 
+/// Exclusive attached-stream append reservation held across DB preflight,
+/// walker mutation, record encoding, and ring publication.
+pub(crate) struct JournalAppendGuard<'a> {
+    journal: &'a Journal,
+    tail: MutexGuard<'a, TailState>,
+}
+
 impl Journal {
-    pub(crate) fn open_or_create(path: &std::path::Path, tree_id: u64) -> Result<Self> {
+    pub(crate) fn open_or_create(path: &Path, tree_id: u64) -> Result<Self> {
         let writer = WalWriter::open_or_create(path, tree_id)?;
+        let attached = validate_attached_journal(path)?;
         let record_base = u64::from(writer.has_records());
         // Mirror legacy reopen seeding: a reopened non-empty WAL is queued
         // and unflushed, so the first checkpoint flushes before making
@@ -299,6 +324,12 @@ impl Journal {
             space_cv: Condvar::new(),
             control_tx,
             record_pool: Mutex::new(Vec::new()),
+            path: path.to_path_buf(),
+            tail: Mutex::new(TailState {
+                checkpoint: attached.map(JournalState::checkpoint),
+                tail: attached.map(JournalState::tail),
+                scan_resume: None,
+            }),
         });
 
         let worker_shared = Arc::clone(&shared);
@@ -316,6 +347,21 @@ impl Journal {
     /// Validate that one encoded record can be accepted without reserving ring
     /// space or changing journal counters.
     pub(crate) fn preflight_submit(&self, record_len: usize) -> Result<()> {
+        self.ensure_ordinary_writes_allowed()?;
+        self.preflight_record_len(record_len)
+    }
+
+    pub(crate) fn ensure_ordinary_writes_allowed(&self) -> Result<()> {
+        if self.shared.tail.lock().unwrap().checkpoint.is_some() {
+            Err(Error::JournalStreamUnavailable {
+                reason: "ordinary WAL records are disabled after attached stream initialization",
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn preflight_record_len(&self, record_len: usize) -> Result<()> {
         if let Some(m) = self.shared.sticky_err() {
             return Err(Error::Internal(m));
         }
@@ -323,7 +369,10 @@ impl Journal {
             return Err(Error::Internal("journal record must not be empty"));
         }
         if record_len as u64 > self.shared.ring.capacity() {
-            return Err(Error::Internal("journal record exceeds WAL ring capacity"));
+            return Err(Error::WalRecordTooLarge {
+                bytes: record_len,
+                maximum: MAX_JOURNAL_RECORD_BYTES,
+            });
         }
         Ok(())
     }
@@ -332,6 +381,10 @@ impl Journal {
     /// (recycled here after the ring copies it). Sync appends return an ack.
     pub(crate) fn submit(&self, bytes: Vec<u8>, sync: bool) -> Result<Option<JournalAck>> {
         self.preflight_submit(bytes.len())?;
+        self.publish(bytes, sync)
+    }
+
+    fn publish(&self, bytes: Vec<u8>, sync: bool) -> Result<Option<JournalAck>> {
         // Reserve → backpressure wait → memcpy → publish. Backpressure parks on
         // the flusher advancing `flush_cursor`, so a full ring does not spin.
         let ticket = self.shared.ring.reserve(bytes.len() as u64);
@@ -360,6 +413,99 @@ impl Journal {
 
     pub(crate) fn record_buffer(&self, min_capacity: usize) -> Vec<u8> {
         self.shared.record_buffer(min_capacity)
+    }
+
+    pub(crate) fn initialize_anchor(&self, genesis: JournalAnchor) -> Result<()> {
+        let mut tail = self.shared.tail.lock().unwrap();
+        match tail.checkpoint {
+            Some(existing) if existing == genesis => {
+                // A prior initialization can fail after it syncs only one
+                // anchor generation. Repair the sibling before an exact retry
+                // reports success.
+                self.shared
+                    .writer
+                    .lock()
+                    .unwrap()
+                    .persist_checkpoint_anchor(genesis)?;
+                return Ok(());
+            }
+            Some(existing) => {
+                return Err(Error::JournalAnchorMismatch {
+                    requested: genesis.sequence(),
+                    expected: existing.sequence(),
+                });
+            }
+            None => {}
+        }
+        if self.needs_checkpoint() {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "WAL must be checkpoint-clean before stream initialization",
+            });
+        }
+        let mut writer = self.shared.writer.lock().unwrap();
+        writer.persist_checkpoint_anchor(genesis)?;
+        tail.checkpoint = Some(genesis);
+        tail.tail = Some(genesis);
+        tail.scan_resume = None;
+        Ok(())
+    }
+
+    pub(crate) fn state(&self) -> Option<JournalState> {
+        let tail = self.shared.tail.lock().unwrap();
+        Some(JournalState::new(tail.checkpoint?, tail.tail?))
+    }
+
+    pub(crate) fn begin_attached(
+        &self,
+        expected_previous: JournalAnchor,
+        record_len: usize,
+    ) -> Result<JournalAppendGuard<'_>> {
+        self.preflight_record_len(record_len)?;
+        let tail = self.shared.tail.lock().unwrap();
+        let Some(expected) = tail.tail else {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "stream has not been initialized",
+            });
+        };
+        if expected_previous != expected {
+            return Err(Error::JournalAnchorMismatch {
+                requested: expected_previous.sequence(),
+                expected: expected.sequence(),
+            });
+        }
+        Ok(JournalAppendGuard {
+            journal: self,
+            tail,
+        })
+    }
+
+    pub(crate) fn envelopes_after(
+        &self,
+        cursor: JournalAnchor,
+        row_limit: usize,
+        payload_byte_limit: usize,
+    ) -> Result<JournalEnvelopePage> {
+        // The DB caller holds the commit gate on its checkpoint side. Lock the
+        // attached tail before flushing so no attached writer can publish a
+        // new record between the durability barrier and the file scan.
+        let mut tail = self.shared.tail.lock().unwrap();
+        self.flush_up_to(self.queued_work())?;
+        match scan_attached_envelope_page_from(
+            &self.shared.path,
+            cursor,
+            row_limit,
+            payload_byte_limit,
+            tail.scan_resume,
+        ) {
+            Ok((page, resume)) => {
+                tail.scan_resume = Some(resume);
+                Ok(page)
+            }
+            Err(error) => {
+                tail.scan_resume = None;
+                Err(error)
+            }
+        }
     }
 
     pub(crate) fn queued_work(&self) -> u64 {
@@ -417,6 +563,42 @@ impl Journal {
     }
 }
 
+impl JournalAppendGuard<'_> {
+    pub(crate) fn record_buffer(&self, min_capacity: usize) -> Vec<u8> {
+        self.journal.shared.record_buffer(min_capacity)
+    }
+
+    pub(crate) fn submit(
+        mut self,
+        record: Vec<u8>,
+        envelope: &JournalEnvelope,
+        sync: bool,
+    ) -> Result<Option<JournalAck>> {
+        let decoded = decode_record(&record)?;
+        let WalOp::DbBatchWithEnvelope {
+            envelope: encoded, ..
+        } = decoded.op
+        else {
+            return Err(Error::Internal("attached submit requires WAL tag 13"));
+        };
+        if &encoded != envelope {
+            return Err(Error::Internal(
+                "attached submit envelope differs from encoded WAL record",
+            ));
+        }
+        let expected = self.tail.tail.expect("begin_attached initialized tail");
+        if envelope.previous() != expected {
+            return Err(Error::JournalAnchorMismatch {
+                requested: envelope.previous().sequence(),
+                expected: expected.sequence(),
+            });
+        }
+        let ack = self.journal.publish(record, sync)?;
+        self.tail.tail = Some(envelope.current());
+        Ok(ack)
+    }
+}
+
 impl Drop for Journal {
     fn drop(&mut self) {
         let _ = self.shared.control_tx.send(Control::Stop);
@@ -454,13 +636,20 @@ fn do_truncate(shared: &Shared) -> Result<()> {
     if let Some(m) = shared.sticky_err() {
         return Err(Error::Internal(m));
     }
+    // The caller holds the external commit gate on its checkpoint side, so no
+    // ordinary submit can race this point. Attached writers additionally take
+    // this tail gate while still under their commit writer guard.
+    let mut tail = shared.tail.lock().unwrap();
+    let anchor = tail.tail;
     let mut w = shared.writer.lock().unwrap();
-    w.truncate()?;
+    w.checkpoint_and_truncate(anchor)?;
     drop(w);
     // The ring is fully drained (the drain above caught up; no concurrent
     // writer under the checkpoint gate). Reset byte cursors; record count is
     // preserved as the stable cross-truncation order.
     shared.ring.reset_after_drain();
+    tail.checkpoint = anchor;
+    tail.scan_resume = None;
     Ok(())
 }
 
@@ -554,9 +743,13 @@ mod tests {
         let journal = Journal::open_or_create(&dir.path().join("journal.wal"), 0).unwrap();
 
         assert!(journal.submit(Vec::new(), false).is_err());
-        assert!(journal
-            .submit(vec![0; RING_CAPACITY_BYTES + 1], false)
-            .is_err());
+        assert!(matches!(
+            journal.submit(vec![0; RING_CAPACITY_BYTES + 1], false),
+            Err(Error::WalRecordTooLarge {
+                bytes,
+                maximum: MAX_JOURNAL_RECORD_BYTES,
+            }) if bytes == MAX_JOURNAL_RECORD_BYTES + 1
+        ));
 
         journal.submit(vec![1, 2, 3, 4], false).unwrap();
         journal.flush_up_to(journal.queued_work()).unwrap();

--- a/src/journal/mod.rs
+++ b/src/journal/mod.rs
@@ -3,7 +3,8 @@
 //! Layered design:
 //!
 //! - [`wal_op`] — the `WalOp` variant union for durable logical
-//!   mutations (`Insert`, `Erase`, `RenameObject`, `Batch`).
+//!   mutations (`Insert`, `Erase`, `RenameObject`, `Batch`, and attached DB
+//!   batches).
 //! - [`codec`] — binary record codec + file header. Pure
 //!   in-memory bytes ↔ `WalOp`.
 //! - [`writer`] — append-only WAL file with
@@ -14,8 +15,9 @@
 //!   committed prefix and runs `sync_data` for `wal_sync = true`
 //!   barriers.
 //! - [`reader`] — forward replay scanner with graceful
-//!   torn-tail handling. Unpacks `Batch` records into per-inner
-//!   callbacks so consumers don't need a `Batch` arm.
+//!   torn-tail handling. Unpacks batch records into per-inner callbacks for
+//!   ordinary replay and validates the retained attached-envelope suffix for
+//!   the public DB recovery API.
 //!
 //! Checkpoint (flush WAL → drain dirty → fdatasync → truncate
 //! WAL) lives in [`crate::Tree::checkpoint`] and the background
@@ -31,7 +33,7 @@ pub(crate) mod ring;
 pub mod wal_op;
 pub mod writer;
 
-pub(crate) use group_commit::Journal;
+pub(crate) use group_commit::{Journal, JournalAck, JournalAppendGuard};
 
 #[cfg(test)]
 mod tests;

--- a/src/journal/reader.rs
+++ b/src/journal/reader.rs
@@ -14,13 +14,25 @@
 //! and should not continue replay.
 
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use crate::api::errors::{Error, Result};
+use crate::api::journal::{
+    JournalAnchor, JournalEnvelope, JournalEnvelopePage, JournalState, MAX_JOURNAL_RECORD_BYTES,
+};
 
-use super::codec::{decode_file_header, decode_record, FileHeader, FILE_HEADER_SIZE};
+use super::codec::{
+    decode_file_header, decode_record, file_header_size_from_prefix, FileHeader,
+    LEGACY_FILE_HEADER_SIZE, LEGACY_FORMAT_VERSION, RECORD_FOOTER_SIZE, RECORD_HEADER_SIZE,
+    RECORD_MAGIC,
+};
 use super::wal_op::WalOp;
+
+#[cfg(test)]
+thread_local! {
+    static STREAMING_RECORDS_DECODED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 /// Outcome of a successful scan.
 ///
@@ -37,6 +49,26 @@ pub struct ReplayStats {
     /// Byte offset where the scan stopped due to a torn tail, or
     /// `None` if the file ended cleanly on a record boundary.
     pub torn_tail_at: Option<u64>,
+}
+
+/// Validated attached-envelope suffix retained after the checkpoint anchor.
+#[cfg(test)]
+pub(crate) struct AttachedEnvelopeScan {
+    pub(crate) checkpoint: Option<JournalAnchor>,
+    pub(crate) tail: Option<JournalAnchor>,
+    pub(crate) envelopes: Vec<JournalEnvelope>,
+}
+
+/// A validated place from which a sequential caller can continue scanning.
+///
+/// This is process-local only. The checkpoint is re-read and compared before
+/// the offset is trusted, and checkpoint/truncate clears the coordinator's
+/// cached value.
+#[derive(Clone, Copy)]
+pub(crate) struct AttachedEnvelopeResume {
+    checkpoint: JournalAnchor,
+    cursor: JournalAnchor,
+    record_offset: u64,
 }
 
 /// Open `path`, validate its file header, and yield every record
@@ -57,6 +89,22 @@ where
     replay_bytes(&bytes, &mut callback)
 }
 
+/// Reject a nonempty format-3 WAL before a writable open mutates database
+/// state. A header-only format-3 file remains eligible for the writer's
+/// in-place format-4 header upgrade.
+pub(crate) fn preflight_writable_wal(path: &Path) -> Result<()> {
+    let records = StreamingRecords::open(path)?;
+    if records.header.version == LEGACY_FORMAT_VERSION
+        && records.file_len != LEGACY_FILE_HEADER_SIZE as u64
+    {
+        return Err(Error::ReplaySanityFailed {
+            context: "nonempty WAL format 3 is replay-only; checkpoint it with a format-3 Holt binary before v4 writes",
+            record_offset: 0,
+        });
+    }
+    Ok(())
+}
+
 /// Same as [`replay`] but reads from an in-memory buffer. Splitting
 /// the I/O out makes unit tests trivially exercise both paths
 /// (file vs. raw buffer) with the same logic.
@@ -64,15 +112,15 @@ pub fn replay_bytes<F>(bytes: &[u8], callback: &mut F) -> Result<(FileHeader, Re
 where
     F: FnMut(&WalOp, u64, u64) -> Result<()>,
 {
-    if bytes.len() < FILE_HEADER_SIZE {
+    if bytes.len() < LEGACY_FILE_HEADER_SIZE {
         return Err(Error::ReplaySanityFailed {
             context: "WAL too short — missing file header",
             record_offset: 0,
         });
     }
-    let header = decode_file_header(&bytes[..FILE_HEADER_SIZE])?;
+    let header = decode_file_header(bytes)?;
 
-    let mut offset = FILE_HEADER_SIZE;
+    let mut offset = header.record_offset();
     let mut records_seen = 0u64;
     let mut highest_seq: Option<u64> = None;
     let mut torn_tail_at: Option<u64> = None;
@@ -80,11 +128,28 @@ where
     while offset < bytes.len() {
         match decode_record(&bytes[offset..]) {
             Ok(r) => {
-                // Flatten Batch transparently: the callback never
-                // sees a `WalOp::Batch`, just the inner primitive
-                // ops with derived seqs (`base + i`, mirroring the
-                // encoder's contiguous seq reservation).
-                if let WalOp::Batch { ops } = &r.op {
+                if header.version == LEGACY_FORMAT_VERSION
+                    && matches!(&r.op, WalOp::DbBatchWithEnvelope { .. })
+                {
+                    return Err(Error::ReplaySanityFailed {
+                        context: "attached batch requires WAL format version 4",
+                        record_offset: offset as u64,
+                    });
+                }
+
+                // Flatten both batch variants transparently: the callback sees
+                // the inner primitive ops with derived seqs (`base + i`). The
+                // direct record decoder retains an attached envelope for the
+                // record-level recovery scanner added by the DB API layer.
+                let batch_ops = match &r.op {
+                    WalOp::Batch { ops } => Some(ops),
+                    WalOp::DbBatchWithEnvelope { envelope, ops } => {
+                        debug_assert!(!envelope.payload().is_empty());
+                        Some(ops)
+                    }
+                    _ => None,
+                };
+                if let Some(ops) = batch_ops {
                     for (i, inner) in ops.iter().enumerate() {
                         let inner_seq = r.seq.wrapping_add(i as u64);
                         callback(inner, inner_seq, offset as u64)
@@ -126,6 +191,412 @@ where
     ))
 }
 
+/// Validate an attached journal and return its durable and live anchors.
+///
+/// The scanner retains at most one encoded WAL record. It validates every
+/// record CRC and the full attached-envelope chain, but does not retain the
+/// application payload suffix.
+pub(crate) fn validate_attached_journal(path: &Path) -> Result<Option<JournalState>> {
+    let mut records = StreamingRecords::open(path)?;
+    let mut chain = AttachedChain::new(records.header.checkpoint_anchor);
+    while let Some(record) = records.next_record()? {
+        if let WalOp::DbBatchWithEnvelope { envelope, .. } = record.op {
+            chain.observe(records.header.version, &envelope, record.offset)?;
+        }
+    }
+    Ok(chain.state())
+}
+
+/// Return the initialized attached-stream state for a read-only caller.
+pub(crate) fn attached_journal_state(path: &Path) -> Result<JournalState> {
+    validate_attached_journal(path)?.ok_or(Error::JournalStreamUnavailable {
+        reason: "stream has not been initialized",
+    })
+}
+
+/// Read one bounded page after `cursor` without materializing the retained WAL
+/// suffix. This stateless entry point is also used by read-only databases.
+pub(crate) fn scan_attached_envelope_page(
+    path: &Path,
+    cursor: JournalAnchor,
+    row_limit: usize,
+    payload_byte_limit: usize,
+) -> Result<JournalEnvelopePage> {
+    scan_attached_envelope_page_from(path, cursor, row_limit, payload_byte_limit, None)
+        .map(|(page, _)| page)
+}
+
+/// Stateful form used by the writable journal coordinator. A matching resume
+/// avoids rescanning an already validated prefix during sequential paging.
+/// The scan validates through the first envelope after the page so `has_more`
+/// never names an unvalidated record. Corruption farther into the suffix is
+/// reported by the page that reaches it; open/state validation still scans the
+/// complete file. Validating the entire suffix on every page would restore the
+/// quadratic I/O this path is designed to avoid.
+pub(crate) fn scan_attached_envelope_page_from(
+    path: &Path,
+    cursor: JournalAnchor,
+    row_limit: usize,
+    payload_byte_limit: usize,
+    resume: Option<AttachedEnvelopeResume>,
+) -> Result<(JournalEnvelopePage, AttachedEnvelopeResume)> {
+    if row_limit == 0 {
+        return Err(Error::InvalidJournalScanLimit {
+            reason: "row limit must be non-zero",
+        });
+    }
+
+    let mut records = StreamingRecords::open(path)?;
+    let Some(checkpoint) = records.header.checkpoint_anchor else {
+        // Preserve open-time validation for ordinary/uninitialized WALs. An
+        // attached record without a durable genesis is rejected by observe.
+        let mut chain = AttachedChain::new(None);
+        while let Some(record) = records.next_record()? {
+            if let WalOp::DbBatchWithEnvelope { envelope, .. } = record.op {
+                chain.observe(records.header.version, &envelope, record.offset)?;
+            }
+        }
+        return Err(Error::JournalStreamUnavailable {
+            reason: "stream has not been initialized",
+        });
+    };
+    if cursor.sequence() < checkpoint.sequence() {
+        return Err(Error::JournalPositionExpired {
+            requested: cursor.sequence(),
+            checkpoint: checkpoint.sequence(),
+        });
+    }
+    if cursor.sequence() == checkpoint.sequence() && cursor != checkpoint {
+        return Err(Error::JournalAnchorMismatch {
+            requested: cursor.sequence(),
+            expected: checkpoint.sequence(),
+        });
+    }
+
+    scan_initialized_envelope_page(
+        records,
+        checkpoint,
+        cursor,
+        row_limit,
+        payload_byte_limit,
+        resume,
+    )
+}
+
+fn scan_initialized_envelope_page(
+    mut records: StreamingRecords,
+    checkpoint: JournalAnchor,
+    cursor: JournalAnchor,
+    row_limit: usize,
+    payload_byte_limit: usize,
+    resume: Option<AttachedEnvelopeResume>,
+) -> Result<(JournalEnvelopePage, AttachedEnvelopeResume)> {
+    let usable_resume = resume.filter(|value| {
+        value.checkpoint == checkpoint
+            && value.cursor == cursor
+            && value.record_offset >= records.header.record_offset() as u64
+            && value.record_offset <= records.file_len
+    });
+    let mut chain = if let Some(value) = usable_resume {
+        records.seek_to(value.record_offset)?;
+        AttachedChain::resume(checkpoint, cursor)
+    } else {
+        AttachedChain::new(Some(checkpoint))
+    };
+    let mut cursor_found = usable_resume.is_some() || cursor == checkpoint;
+    let mut envelopes = Vec::new();
+    let mut payload_bytes = 0usize;
+
+    while let Some(record) = records.next_record()? {
+        let record_offset = record.offset;
+        let WalOp::DbBatchWithEnvelope { envelope, .. } = record.op else {
+            continue;
+        };
+        let retained = chain.observe(records.header.version, &envelope, record_offset)?;
+        if !retained {
+            continue;
+        }
+
+        if !cursor_found {
+            match envelope.current().sequence().cmp(&cursor.sequence()) {
+                std::cmp::Ordering::Less => continue,
+                std::cmp::Ordering::Equal => {
+                    if envelope.current() != cursor {
+                        return Err(Error::JournalAnchorMismatch {
+                            requested: cursor.sequence(),
+                            expected: envelope.current().sequence(),
+                        });
+                    }
+                    cursor_found = true;
+                    continue;
+                }
+                std::cmp::Ordering::Greater => {
+                    return Err(Error::JournalAnchorMismatch {
+                        requested: cursor.sequence(),
+                        expected: envelope.current().sequence(),
+                    });
+                }
+            }
+        }
+
+        let next_bytes = payload_bytes.saturating_add(envelope.payload().len());
+        let page_full = envelopes.len() == row_limit
+            || (!envelopes.is_empty() && next_bytes > payload_byte_limit);
+        if page_full {
+            let next = envelopes.last().map_or(cursor, JournalEnvelope::current);
+            return Ok((
+                JournalEnvelopePage::new(envelopes, next, true),
+                AttachedEnvelopeResume {
+                    checkpoint,
+                    cursor: next,
+                    record_offset,
+                },
+            ));
+        }
+        payload_bytes = next_bytes;
+        envelopes.push(envelope);
+    }
+
+    if !cursor_found {
+        return Err(Error::JournalAnchorMismatch {
+            requested: cursor.sequence(),
+            expected: chain.tail.expect("initialized chain has a tail").sequence(),
+        });
+    }
+    let next = envelopes.last().map_or(cursor, JournalEnvelope::current);
+    Ok((
+        JournalEnvelopePage::new(envelopes, next, false),
+        AttachedEnvelopeResume {
+            checkpoint,
+            cursor: next,
+            record_offset: records.offset,
+        },
+    ))
+}
+
+/// Read and retain the suffix for focused legacy tests only. Production open,
+/// state, and page paths use the bounded scanners above.
+#[cfg(test)]
+pub(crate) fn scan_attached_envelopes(path: &Path) -> Result<AttachedEnvelopeScan> {
+    let mut records = StreamingRecords::open(path)?;
+    let checkpoint = records.header.checkpoint_anchor;
+    let mut chain = AttachedChain::new(checkpoint);
+    let mut envelopes = Vec::new();
+    while let Some(record) = records.next_record()? {
+        if let WalOp::DbBatchWithEnvelope { envelope, .. } = record.op {
+            if chain.observe(records.header.version, &envelope, record.offset)? {
+                envelopes.push(envelope);
+            }
+        }
+    }
+    Ok(AttachedEnvelopeScan {
+        checkpoint,
+        tail: chain.tail,
+        envelopes,
+    })
+}
+
+struct AttachedChain {
+    checkpoint: Option<JournalAnchor>,
+    tail: Option<JournalAnchor>,
+    previous_record: Option<JournalAnchor>,
+}
+
+impl AttachedChain {
+    fn new(checkpoint: Option<JournalAnchor>) -> Self {
+        Self {
+            checkpoint,
+            tail: checkpoint,
+            previous_record: None,
+        }
+    }
+
+    fn resume(checkpoint: JournalAnchor, cursor: JournalAnchor) -> Self {
+        Self {
+            checkpoint: Some(checkpoint),
+            tail: Some(cursor),
+            previous_record: Some(cursor),
+        }
+    }
+
+    /// Validate one envelope and return whether it is retained after the
+    /// checkpoint.
+    fn observe(
+        &mut self,
+        format_version: u32,
+        envelope: &JournalEnvelope,
+        record_offset: u64,
+    ) -> Result<bool> {
+        if format_version == LEGACY_FORMAT_VERSION {
+            return Err(Error::ReplaySanityFailed {
+                context: "attached batch requires WAL format version 4",
+                record_offset,
+            });
+        }
+        let Some(checkpoint) = self.checkpoint else {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "WAL contains attached envelopes but its stream anchor is uninitialized",
+            });
+        };
+        if let Some(previous) = self.previous_record {
+            if envelope.previous() != previous {
+                return Err(Error::ReplaySanityFailed {
+                    context: "attached journal records do not form a contiguous chain",
+                    record_offset,
+                });
+            }
+        }
+        self.previous_record = Some(envelope.current());
+
+        match envelope.current().sequence().cmp(&checkpoint.sequence()) {
+            std::cmp::Ordering::Less => Ok(false),
+            std::cmp::Ordering::Equal => {
+                if envelope.current() != checkpoint {
+                    return Err(Error::ReplaySanityFailed {
+                        context: "attached journal record conflicts with checkpoint anchor",
+                        record_offset,
+                    });
+                }
+                Ok(false)
+            }
+            std::cmp::Ordering::Greater => {
+                let expected = self.tail.expect("checkpoint exists");
+                if envelope.previous() != expected {
+                    return Err(Error::ReplaySanityFailed {
+                        context: "attached journal suffix does not continue checkpoint anchor",
+                        record_offset,
+                    });
+                }
+                self.tail = Some(envelope.current());
+                Ok(true)
+            }
+        }
+    }
+
+    fn state(&self) -> Option<JournalState> {
+        Some(JournalState::new(self.checkpoint?, self.tail?))
+    }
+}
+
+struct RecordAt {
+    op: WalOp,
+    offset: u64,
+}
+
+/// Forward record reader with memory bounded by one accepted WAL record.
+struct StreamingRecords {
+    reader: BufReader<File>,
+    header: FileHeader,
+    file_len: u64,
+    offset: u64,
+}
+
+impl StreamingRecords {
+    fn open(path: &Path) -> Result<Self> {
+        let mut file = File::open(path)?;
+        let file_len = file.metadata()?.len();
+        let mut prefix = [0u8; LEGACY_FILE_HEADER_SIZE];
+        file.read_exact(&mut prefix).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::UnexpectedEof {
+                Error::ReplaySanityFailed {
+                    context: "WAL too short — missing file header",
+                    record_offset: 0,
+                }
+            } else {
+                Error::BlobStoreIo(error)
+            }
+        })?;
+        let header_size = file_header_size_from_prefix(&prefix)?;
+        let mut header_bytes = Vec::with_capacity(header_size);
+        header_bytes.extend_from_slice(&prefix);
+        if header_size > LEGACY_FILE_HEADER_SIZE {
+            header_bytes.resize(header_size, 0);
+            file.read_exact(&mut header_bytes[LEGACY_FILE_HEADER_SIZE..])
+                .map_err(|error| {
+                    if error.kind() == std::io::ErrorKind::UnexpectedEof {
+                        Error::ReplaySanityFailed {
+                            context: "WAL file header truncated",
+                            record_offset: 0,
+                        }
+                    } else {
+                        Error::BlobStoreIo(error)
+                    }
+                })?;
+        }
+        let header = decode_file_header(&header_bytes)?;
+        Ok(Self {
+            reader: BufReader::new(file),
+            header,
+            file_len,
+            offset: header_size as u64,
+        })
+    }
+
+    fn seek_to(&mut self, offset: u64) -> Result<()> {
+        self.reader.seek(SeekFrom::Start(offset))?;
+        self.offset = offset;
+        Ok(())
+    }
+
+    fn next_record(&mut self) -> Result<Option<RecordAt>> {
+        if self.offset >= self.file_len {
+            return Ok(None);
+        }
+        let record_offset = self.offset;
+        let remaining = self.file_len - record_offset;
+        if remaining < RECORD_HEADER_SIZE as u64 {
+            // A partial header at EOF is a tolerated torn tail.
+            return Ok(None);
+        }
+
+        let mut header = [0u8; RECORD_HEADER_SIZE];
+        self.reader.read_exact(&mut header)?;
+        let magic = u32::from_le_bytes(header[0..4].try_into().unwrap());
+        if magic != RECORD_MAGIC {
+            return Err(Error::ReplaySanityFailed {
+                context: "record magic mismatch",
+                record_offset,
+            });
+        }
+        let body_len = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
+        let total = RECORD_HEADER_SIZE
+            .checked_add(body_len)
+            .and_then(|value| value.checked_add(RECORD_FOOTER_SIZE))
+            .ok_or(Error::ReplaySanityFailed {
+                context: "record size overflow",
+                record_offset,
+            })?;
+        if total as u64 > remaining {
+            // A valid record header followed by an incomplete body/footer at
+            // EOF has the same torn-tail semantics as replay_bytes.
+            return Ok(None);
+        }
+        if total > MAX_JOURNAL_RECORD_BYTES {
+            return Err(Error::ReplaySanityFailed {
+                context: "record exceeds journal size limit",
+                record_offset,
+            });
+        }
+
+        let mut bytes = Vec::with_capacity(total);
+        bytes.extend_from_slice(&header);
+        bytes.resize(total, 0);
+        self.reader.read_exact(&mut bytes[RECORD_HEADER_SIZE..])?;
+        let decoded =
+            decode_record(&bytes).map_err(|error| patch_offset(error, record_offset as usize))?;
+        #[cfg(test)]
+        STREAMING_RECORDS_DECODED.with(|count| count.set(count.get() + 1));
+        self.offset = self
+            .offset
+            .checked_add(decoded.bytes_consumed as u64)
+            .expect("WAL offset fits in u64");
+        Ok(Some(RecordAt {
+            op: decoded.op,
+            offset: record_offset,
+        }))
+    }
+}
+
 fn is_torn_tail(context: &'static str) -> bool {
     // Two codec sanity-failure cases are consistent with a torn
     // tail at EOF and not a corrupted middle: header / body
@@ -142,5 +613,159 @@ fn patch_offset(e: Error, offset: usize) -> Error {
             record_offset: offset as u64,
         },
         other => other,
+    }
+}
+
+#[cfg(test)]
+mod attached_streaming_tests {
+    use std::fs;
+    use std::fs::OpenOptions;
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::journal::codec::{
+        encode_file_header, BatchEncoder, FileHeader, FILE_HEADER_SIZE, LEGACY_FORMAT_VERSION,
+    };
+    use crate::journal::writer::WalWriter;
+
+    fn anchor(sequence: u64) -> JournalAnchor {
+        let mut digest = [0u8; 32];
+        digest[..8].copy_from_slice(&sequence.to_le_bytes());
+        JournalAnchor::new(sequence, digest)
+    }
+
+    fn write_envelopes(
+        count: u64,
+        payload_len: usize,
+    ) -> (tempfile::TempDir, std::path::PathBuf, Vec<u64>) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("journal.wal");
+        let mut writer = WalWriter::create(&path, 0).unwrap();
+        writer.persist_checkpoint_anchor(anchor(0)).unwrap();
+        let mut offsets = Vec::new();
+        let mut offset = FILE_HEADER_SIZE as u64;
+        for sequence in 1..=count {
+            let envelope = JournalEnvelope::new(
+                anchor(sequence - 1),
+                anchor(sequence),
+                vec![sequence as u8; payload_len],
+            )
+            .unwrap();
+            let mut record = Vec::new();
+            BatchEncoder::begin_with_envelope(&mut record, sequence, 0, &envelope).finish();
+            offsets.push(offset);
+            offset += record.len() as u64;
+            writer.append_encoded(&record).unwrap();
+        }
+        writer.flush().unwrap();
+        (dir, path, offsets)
+    }
+
+    #[test]
+    fn resumed_pages_decode_only_one_lookahead_per_page() {
+        const RECORDS: u64 = 96;
+        const PAYLOAD_BYTES: usize = 64 * 1024;
+        let (_dir, path, _offsets) = write_envelopes(RECORDS, PAYLOAD_BYTES);
+        STREAMING_RECORDS_DECODED.with(|count| count.set(0));
+
+        let mut cursor = anchor(0);
+        let mut resume = None;
+        let mut seen = 0u64;
+        let mut pages = 0usize;
+        loop {
+            let (page, next_resume) =
+                scan_attached_envelope_page_from(&path, cursor, 16, PAYLOAD_BYTES * 2, resume)
+                    .unwrap();
+            assert!(!page.envelopes().is_empty());
+            assert!(page.envelopes().len() <= 2);
+            seen += page.envelopes().len() as u64;
+            pages += 1;
+            cursor = page.next();
+            resume = Some(next_resume);
+            if !page.has_more() {
+                break;
+            }
+        }
+
+        assert_eq!(seen, RECORDS);
+        assert_eq!(cursor, anchor(RECORDS));
+        assert_eq!(pages, RECORDS as usize / 2);
+        let decoded = STREAMING_RECORDS_DECODED.with(std::cell::Cell::get);
+        assert_eq!(decoded, RECORDS as usize + pages - 1);
+    }
+
+    #[test]
+    fn page_validates_one_lookahead_and_defers_later_corruption() {
+        let (_dir, path, offsets) = write_envelopes(3, 32);
+        let corrupt_at = offsets[2] + RECORD_HEADER_SIZE as u64 + 1;
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.seek(SeekFrom::Start(corrupt_at)).unwrap();
+        let mut byte = [0u8; 1];
+        file.read_exact(&mut byte).unwrap();
+        byte[0] ^= 0x80;
+        file.seek(SeekFrom::Start(corrupt_at)).unwrap();
+        file.write_all(&byte).unwrap();
+        file.sync_data().unwrap();
+
+        let (first, resume) =
+            scan_attached_envelope_page_from(&path, anchor(0), 1, usize::MAX, None).unwrap();
+        assert_eq!(first.envelopes()[0].current(), anchor(1));
+        assert!(first.has_more());
+
+        assert!(matches!(
+            scan_attached_envelope_page_from(
+                &path,
+                first.next(),
+                1,
+                usize::MAX,
+                Some(resume),
+            ),
+            Err(Error::ReplaySanityFailed {
+                context: "record CRC mismatch",
+                record_offset,
+            }) if record_offset == offsets[2]
+        ));
+        assert!(matches!(
+            validate_attached_journal(&path),
+            Err(Error::ReplaySanityFailed {
+                context: "record CRC mismatch",
+                record_offset,
+            }) if record_offset == offsets[2]
+        ));
+    }
+
+    #[test]
+    fn writable_preflight_accepts_header_only_v3_but_rejects_records() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("legacy.wal");
+        let mut bytes = Vec::new();
+        encode_file_header(
+            &FileHeader {
+                version: LEGACY_FORMAT_VERSION,
+                tree_id: 0,
+                created_at: 0,
+                checkpoint_anchor: None,
+                anchor_generation: 0,
+            },
+            &mut bytes,
+        );
+        fs::write(&path, &bytes).unwrap();
+        preflight_writable_wal(&path).unwrap();
+
+        bytes.push(0);
+        fs::write(&path, bytes).unwrap();
+        assert!(matches!(
+            preflight_writable_wal(&path),
+            Err(Error::ReplaySanityFailed {
+                context: "nonempty WAL format 3 is replay-only; checkpoint it with a format-3 Holt binary before v4 writes",
+                record_offset: 0,
+            })
+        ));
     }
 }

--- a/src/journal/tests.rs
+++ b/src/journal/tests.rs
@@ -9,12 +9,14 @@ use std::path::PathBuf;
 use tempfile::tempdir;
 
 use super::codec::{
-    crc32, encode_file_header, FileHeader, FILE_HEADER_SIZE, FORMAT_VERSION, RECORD_MAGIC,
+    crc32, decode_file_header, encode_file_header, BatchEncoder, FileHeader, FILE_HEADER_SIZE,
+    FORMAT_VERSION, LEGACY_FILE_HEADER_SIZE, LEGACY_FORMAT_VERSION, RECORD_MAGIC,
 };
 use super::reader::replay;
 use super::wal_op::WalOp;
 use super::writer::{WalWriter, AUTO_FLUSH_THRESHOLD};
 use crate::api::errors::Error;
+use crate::{JournalAnchor, JournalEnvelope};
 
 fn wal_path(dir: &tempfile::TempDir) -> PathBuf {
     dir.path().join("test.wal")
@@ -56,6 +58,333 @@ fn sample_ops() -> Vec<WalOp> {
     ]
 }
 
+fn sample_envelope() -> JournalEnvelope {
+    JournalEnvelope::new(
+        JournalAnchor::new(6, [0x66; 32]),
+        JournalAnchor::new(7, [0x77; 32]),
+        b"canonical-recovery-v1".to_vec(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn v3_and_v4_file_headers_have_stable_golden_bytes() {
+    let mut expected_prefix = [
+        0x57, 0x41, 0x4c, 0x41, 0x04, 0x00, 0x00, 0x00, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02,
+        0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00,
+    ];
+    let header_v4 = FileHeader {
+        version: FORMAT_VERSION,
+        tree_id: 0x0102_0304_0506_0708,
+        created_at: 0x1112_1314_1516_1718,
+        checkpoint_anchor: None,
+        anchor_generation: 0,
+    };
+    let mut encoded = Vec::new();
+    encode_file_header(&header_v4, &mut encoded);
+    assert_eq!(encoded.len(), FILE_HEADER_SIZE);
+    assert_eq!(&encoded[..LEGACY_FILE_HEADER_SIZE], expected_prefix);
+    assert!(encoded[LEGACY_FILE_HEADER_SIZE..]
+        .iter()
+        .all(|byte| *byte == 0));
+    assert_eq!(decode_file_header(&encoded).unwrap(), header_v4);
+
+    expected_prefix[4] = 0x03;
+    expected_prefix[24..32].fill(0);
+    let header_v3 = FileHeader {
+        version: LEGACY_FORMAT_VERSION,
+        checkpoint_anchor: None,
+        anchor_generation: 0,
+        ..header_v4
+    };
+    encoded.clear();
+    encode_file_header(&header_v3, &mut encoded);
+    assert_eq!(encoded, expected_prefix);
+    assert_eq!(decode_file_header(&encoded).unwrap(), header_v3);
+}
+
+#[test]
+fn nonempty_format_3_is_replayable_but_rejected_for_append() {
+    let dir = tempdir().unwrap();
+    let path = wal_path(&dir);
+    let mut bytes = Vec::new();
+    encode_file_header(
+        &FileHeader {
+            version: LEGACY_FORMAT_VERSION,
+            tree_id: 9,
+            created_at: 0,
+            checkpoint_anchor: None,
+            anchor_generation: 0,
+        },
+        &mut bytes,
+    );
+    let mut body = Vec::new();
+    body.extend_from_slice(&9u64.to_le_bytes());
+    body.extend_from_slice(&1u32.to_le_bytes());
+    body.extend_from_slice(b"k");
+    body.extend_from_slice(&1u32.to_le_bytes());
+    body.extend_from_slice(b"v");
+    append_raw_record(&mut bytes, 11, 0, &body);
+    fs::write(&path, &bytes).unwrap();
+
+    let mut seen = Vec::new();
+    let (header, stats) = replay(&path, |op, seq, _| {
+        seen.push((op.clone(), seq));
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(header.version, LEGACY_FORMAT_VERSION);
+    assert_eq!(header.tree_id, 9);
+    assert_eq!(stats.records_seen, 1);
+    assert_eq!(stats.highest_seq, Some(11));
+    assert!(matches!(
+        seen.as_slice(),
+        [(WalOp::Insert {
+            tree_id: 9,
+            key,
+            value,
+        }, 11)] if key == b"k" && value == b"v"
+    ));
+
+    let before = fs::read(&path).unwrap();
+    assert!(matches!(
+        WalWriter::open_existing(&path),
+        Err(Error::ReplaySanityFailed {
+            context: "nonempty WAL format 3 is replay-only; checkpoint it with a format-3 Holt binary before v4 writes",
+            record_offset: 0,
+        })
+    ));
+    assert_eq!(fs::read(&path).unwrap(), before);
+}
+
+#[test]
+fn header_only_format_3_is_upgraded_before_append() {
+    let dir = tempdir().unwrap();
+    let path = wal_path(&dir);
+    let legacy = FileHeader {
+        version: LEGACY_FORMAT_VERSION,
+        tree_id: 17,
+        created_at: 23,
+        checkpoint_anchor: None,
+        anchor_generation: 0,
+    };
+    let mut bytes = Vec::new();
+    encode_file_header(&legacy, &mut bytes);
+    fs::write(&path, &bytes).unwrap();
+
+    let writer = WalWriter::open_existing(&path).unwrap();
+    assert_eq!(writer.header().version, FORMAT_VERSION);
+    assert_eq!(writer.header().tree_id, legacy.tree_id);
+    assert_eq!(writer.header().created_at, legacy.created_at);
+    drop(writer);
+
+    let upgraded = fs::read(&path).unwrap();
+    assert_eq!(upgraded.len(), FILE_HEADER_SIZE);
+    let header = decode_file_header(&upgraded).unwrap();
+    assert_eq!(header.version, FORMAT_VERSION);
+    assert_eq!(header.tree_id, legacy.tree_id);
+    assert_eq!(header.created_at, legacy.created_at);
+}
+
+#[test]
+fn format_4_attached_batch_flattens_for_replay_and_is_rejected_under_v3_header() {
+    let envelope = sample_envelope();
+    let mut attached_record = Vec::new();
+    {
+        let mut encoder = BatchEncoder::begin_with_envelope(&mut attached_record, 20, 0, &envelope);
+        encoder.push_insert(3, b"a", b"one");
+        encoder.push_erase(3, b"b");
+        assert_eq!(encoder.finish(), 2);
+    }
+
+    let dir = tempdir().unwrap();
+    let v4_path = dir.path().join("v4.wal");
+    let mut v4 = Vec::new();
+    encode_file_header(
+        &FileHeader {
+            version: FORMAT_VERSION,
+            tree_id: 0,
+            created_at: 0,
+            checkpoint_anchor: None,
+            anchor_generation: 0,
+        },
+        &mut v4,
+    );
+    v4.extend_from_slice(&attached_record);
+    fs::write(&v4_path, &v4).unwrap();
+
+    let mut seen = Vec::new();
+    let (header, stats) = replay(&v4_path, |op, seq, _| {
+        seen.push((op.clone(), seq));
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(header.version, FORMAT_VERSION);
+    assert_eq!(stats.records_seen, 1);
+    assert_eq!(stats.highest_seq, Some(21));
+    assert_eq!(seen.len(), 2);
+    assert!(matches!(seen[0], (WalOp::Insert { .. }, 20)));
+    assert!(matches!(seen[1], (WalOp::Erase { .. }, 21)));
+
+    let v3_path = dir.path().join("v3-with-tag-13.wal");
+    let mut v3 = Vec::new();
+    encode_file_header(
+        &FileHeader {
+            version: LEGACY_FORMAT_VERSION,
+            tree_id: 0,
+            created_at: 0,
+            checkpoint_anchor: None,
+            anchor_generation: 0,
+        },
+        &mut v3,
+    );
+    v3.extend_from_slice(&attached_record);
+    fs::write(&v3_path, &v3).unwrap();
+    assert!(matches!(
+        replay(&v3_path, |_, _, _| Ok(())),
+        Err(Error::ReplaySanityFailed {
+            context: "attached batch requires WAL format version 4",
+            record_offset,
+        }) if record_offset == LEGACY_FILE_HEADER_SIZE as u64
+    ));
+}
+
+#[test]
+fn checkpoint_anchor_slots_fall_back_to_mirrored_anchor() {
+    let dir = tempdir().unwrap();
+    let path = wal_path(&dir);
+    let first = JournalAnchor::new(1, [0x31; 32]);
+    let second = JournalAnchor::new(2, [0x32; 32]);
+    {
+        let mut writer = WalWriter::create(&path, 0).unwrap();
+        writer.persist_checkpoint_anchor(first).unwrap();
+        writer.persist_checkpoint_anchor(second).unwrap();
+    }
+
+    let bytes = fs::read(&path).unwrap();
+    let header = decode_file_header(&bytes).unwrap();
+    assert_eq!(header.checkpoint_anchor, Some(second));
+    assert_eq!(header.anchor_generation, 4);
+
+    // Generation 4 lives in slot B. If it is lost, generation 3 in slot A
+    // still names the same checkpoint anchor.
+    let mut torn = bytes;
+    let slot_b_crc_byte = super::codec::ANCHOR_SLOT_OFFSETS[1] + 64;
+    torn[slot_b_crc_byte] ^= 0x80;
+    fs::write(&path, &torn).unwrap();
+    let recovered = decode_file_header(&fs::read(&path).unwrap()).unwrap();
+    assert_eq!(recovered.checkpoint_anchor, Some(second));
+    assert_eq!(recovered.anchor_generation, 3);
+}
+
+#[test]
+fn first_checkpoint_anchor_is_mirrored_before_initialization_returns() {
+    let dir = tempdir().unwrap();
+    let path = wal_path(&dir);
+    let genesis = JournalAnchor::new(0, [0x39; 32]);
+    {
+        let mut writer = WalWriter::create(&path, 0).unwrap();
+        writer.persist_checkpoint_anchor(genesis).unwrap();
+    }
+
+    let bytes = fs::read(&path).unwrap();
+    let header = decode_file_header(&bytes).unwrap();
+    assert_eq!(header.checkpoint_anchor, Some(genesis));
+    assert_eq!(header.anchor_generation, 2);
+
+    for slot in 0..2 {
+        let mut damaged = bytes.clone();
+        damaged[super::codec::ANCHOR_SLOT_OFFSETS[slot] + 64] ^= 0x80;
+        let recovered = decode_file_header(&damaged).unwrap();
+        assert_eq!(recovered.checkpoint_anchor, Some(genesis));
+    }
+}
+
+#[test]
+fn advanced_checkpoint_anchor_survives_either_slot_corruption_after_truncate() {
+    let dir = tempdir().unwrap();
+    let path = wal_path(&dir);
+    let genesis = JournalAnchor::new(0, [0x3a; 32]);
+    let advanced = JournalAnchor::new(7, [0x3b; 32]);
+    {
+        let mut writer = WalWriter::create(&path, 0).unwrap();
+        writer.persist_checkpoint_anchor(genesis).unwrap();
+        writer.checkpoint_and_truncate(Some(advanced)).unwrap();
+    }
+
+    let bytes = fs::read(&path).unwrap();
+    assert_eq!(bytes.len(), FILE_HEADER_SIZE);
+    let header = decode_file_header(&bytes).unwrap();
+    assert_eq!(header.checkpoint_anchor, Some(advanced));
+    assert_eq!(header.anchor_generation, 4);
+
+    for slot in 0..2 {
+        let mut damaged = bytes.clone();
+        damaged[super::codec::ANCHOR_SLOT_OFFSETS[slot] + 64] ^= 0x80;
+        let recovered = decode_file_header(&damaged).unwrap();
+        assert_eq!(recovered.checkpoint_anchor, Some(advanced));
+    }
+}
+
+#[test]
+fn interrupted_checkpoint_keeps_wal_and_retry_repairs_anchor_mirror() {
+    let dir = tempdir().unwrap();
+    let path = wal_path(&dir);
+    let genesis = JournalAnchor::new(0, [0x40; 32]);
+    let first = JournalAnchor::new(1, [0x41; 32]);
+    let second = JournalAnchor::new(2, [0x42; 32]);
+    let first_envelope = JournalEnvelope::new(genesis, first, b"first".to_vec()).unwrap();
+    let second_envelope = JournalEnvelope::new(first, second, b"second".to_vec()).unwrap();
+
+    let mut writer = WalWriter::create(&path, 0).unwrap();
+    writer.persist_checkpoint_anchor(genesis).unwrap();
+    for (seq, envelope) in [(10, &first_envelope), (11, &second_envelope)] {
+        let mut record = Vec::new();
+        BatchEncoder::begin_with_envelope(&mut record, seq, 0, envelope).finish();
+        writer.append_encoded(&record).unwrap();
+    }
+    writer.flush().unwrap();
+    let wal_len = fs::metadata(&path).unwrap().len();
+
+    // Fail after the first new generation reaches disk. Checkpoint must leave
+    // the old record stream intact so recovery can validate the new floor and
+    // retain the suffix after it.
+    WalWriter::fail_anchor_generation_after_for_test(1);
+    assert!(matches!(
+        writer.checkpoint_and_truncate(Some(first)),
+        Err(Error::Internal("checkpoint anchor generation test failure"))
+    ));
+    assert_eq!(fs::metadata(&path).unwrap().len(), wal_len);
+    drop(writer);
+
+    let scan = super::reader::scan_attached_envelopes(&path).unwrap();
+    assert_eq!(scan.checkpoint, Some(first));
+    assert_eq!(scan.tail, Some(second));
+    assert_eq!(scan.envelopes, vec![second_envelope]);
+
+    // Reopen sees the first new generation. Retrying the same checkpoint must
+    // write its sibling before truncation; either slot can then be lost.
+    {
+        let mut writer = WalWriter::open_existing(&path).unwrap();
+        assert_eq!(writer.header().checkpoint_anchor, Some(first));
+        assert_eq!(writer.header().anchor_generation, 3);
+        writer.checkpoint_and_truncate(Some(first)).unwrap();
+    }
+
+    let bytes = fs::read(&path).unwrap();
+    assert_eq!(bytes.len(), FILE_HEADER_SIZE);
+    let header = decode_file_header(&bytes).unwrap();
+    assert_eq!(header.checkpoint_anchor, Some(first));
+    assert_eq!(header.anchor_generation, 4);
+    for slot in 0..2 {
+        let mut damaged = bytes.clone();
+        damaged[super::codec::ANCHOR_SLOT_OFFSETS[slot] + 64] ^= 0x80;
+        let recovered = decode_file_header(&damaged).unwrap();
+        assert_eq!(recovered.checkpoint_anchor, Some(first));
+    }
+}
+
 #[test]
 fn create_open_round_trip_all_variants() {
     let dir = tempdir().unwrap();
@@ -63,6 +392,7 @@ fn create_open_round_trip_all_variants() {
     let ops = sample_ops();
 
     let mut w = WalWriter::create(&path, 42).unwrap();
+    assert_eq!(w.header().version, FORMAT_VERSION);
     assert_eq!(w.header().tree_id, 42);
     assert_eq!(w.bytes_written(), FILE_HEADER_SIZE as u64);
 
@@ -97,8 +427,11 @@ fn replay_rejects_removed_structural_tag() {
     let mut bytes = Vec::new();
     encode_file_header(
         &FileHeader {
+            version: FORMAT_VERSION,
             tree_id: 0,
             created_at: 0,
+            checkpoint_anchor: None,
+            anchor_generation: 0,
         },
         &mut bytes,
     );

--- a/src/journal/wal_op.rs
+++ b/src/journal/wal_op.rs
@@ -3,6 +3,8 @@
 //! Each variant carries the minimal info needed to replay the
 //! operation deterministically during WAL recovery.
 
+use crate::api::journal::JournalEnvelope;
+
 /// Logical WAL operation variants emitted by the public tree API.
 ///
 /// Variant tags are stable on-disk constants — see the `TY_*`
@@ -13,8 +15,8 @@ pub enum WalOp {
     ///
     /// Replay only redoes from `(key, value)`; there is no
     /// `prev_value` field because replay never undoes (it's an
-    /// idempotent forward redo) and holt does not provide a
-    /// journal-scan audit surface.
+    /// idempotent forward redo). Ordinary primitive records are not exposed
+    /// through the attached recovery scan.
     Insert {
         /// Logical tree owner.
         tree_id: u64,
@@ -56,6 +58,17 @@ pub enum WalOp {
         /// Inner ops, applied in order.
         ops: Vec<WalOp>,
     },
+    /// DB batch with application-owned canonical recovery bytes attached.
+    ///
+    /// The envelope and inner operations share one record CRC and therefore
+    /// one torn-write boundary. Replay still expands `ops` through the ordinary
+    /// primitive-op path; record-level recovery scanning retains `envelope`.
+    DbBatchWithEnvelope {
+        /// Validated recovery envelope preserved by the WAL codec.
+        envelope: JournalEnvelope,
+        /// Inner DB operations, applied in order.
+        ops: Vec<WalOp>,
+    },
 }
 
 impl WalOp {
@@ -70,7 +83,7 @@ impl WalOp {
             Self::Insert { tree_id, .. }
             | Self::Erase { tree_id, .. }
             | Self::RenameObject { tree_id, .. } => Some(*tree_id),
-            Self::Batch { .. } => None,
+            Self::Batch { .. } | Self::DbBatchWithEnvelope { .. } => None,
         }
     }
 }

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -22,16 +22,29 @@
 //! blob image.
 
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use crate::api::errors::{Error, Result};
 
 #[cfg(test)]
 use super::codec::encode_record;
-use super::codec::{decode_file_header, encode_file_header, FileHeader, FILE_HEADER_SIZE};
+use super::codec::{
+    decode_file_header, encode_anchor_slot, encode_file_header, file_header_size_from_prefix,
+    FileHeader, ANCHOR_SLOT_OFFSETS, ANCHOR_SLOT_SIZE, FILE_HEADER_SIZE, FORMAT_VERSION,
+    LEGACY_FILE_HEADER_SIZE,
+};
 #[cfg(test)]
 use super::wal_op::WalOp;
+use crate::api::journal::JournalAnchor;
+
+#[cfg(test)]
+thread_local! {
+    /// Fail one checkpoint-anchor generation after this many successful
+    /// generation writes on the current test thread.
+    static FAIL_ANCHOR_GENERATION_AFTER: std::cell::Cell<Option<usize>> =
+        const { std::cell::Cell::new(None) };
+}
 
 /// Append's in-memory buffer is auto-drained to the OS page
 /// cache once it crosses this many bytes. Drops user-space
@@ -48,6 +61,8 @@ pub const AUTO_FLUSH_THRESHOLD: usize = 64 * 1024;
 pub struct WalWriter {
     /// Underlying file handle, opened in append mode.
     file: File,
+    /// Independent non-append handle for checkpoint-anchor slot updates.
+    header_file: File,
     /// Buffered bytes not yet handed to the OS.
     pending: Vec<u8>,
     /// Sum of `pending.len()` over the lifetime of this writer
@@ -63,17 +78,22 @@ impl WalWriter {
     /// Returns an error if `path` already exists — use
     /// [`WalWriter::open_existing`] to append to an existing log.
     pub fn create(path: &Path, tree_id: u64) -> Result<Self> {
-        let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+        let mut header_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(path)?;
         let header = FileHeader::now(tree_id);
         let mut buf = Vec::with_capacity(FILE_HEADER_SIZE);
         encode_file_header(&header, &mut buf);
-        file.write_all(&buf)?;
-        file.sync_data()?;
+        header_file.write_all(&buf)?;
+        header_file.sync_data()?;
         // Reopen in append mode so subsequent writes go to the end
         // even if other code seeks around.
         let file = OpenOptions::new().append(true).open(path)?;
         Ok(Self {
             file,
+            header_file,
             pending: Vec::with_capacity(4096),
             bytes_written: FILE_HEADER_SIZE as u64,
             header,
@@ -84,17 +104,43 @@ impl WalWriter {
     /// header and returns the parsed `FileHeader` via
     /// [`WalWriter::header`].
     pub fn open_existing(path: &Path) -> Result<Self> {
-        let mut header_bytes = [0u8; FILE_HEADER_SIZE];
-        {
-            let mut f = File::open(path)?;
-            use std::io::Read;
-            f.read_exact(&mut header_bytes)?;
+        let mut header_file = OpenOptions::new().read(true).write(true).open(path)?;
+        let mut prefix = [0u8; LEGACY_FILE_HEADER_SIZE];
+        header_file.read_exact(&mut prefix)?;
+        let encoded_header_size = file_header_size_from_prefix(&prefix)?;
+        let mut header_bytes = Vec::with_capacity(encoded_header_size);
+        header_bytes.extend_from_slice(&prefix);
+        if encoded_header_size > LEGACY_FILE_HEADER_SIZE {
+            header_bytes.resize(encoded_header_size, 0);
+            header_file.read_exact(&mut header_bytes[LEGACY_FILE_HEADER_SIZE..])?;
         }
-        let header = decode_file_header(&header_bytes)?;
+        let mut header = decode_file_header(&header_bytes)?;
+        if header.version != FORMAT_VERSION {
+            if header_file.metadata()?.len() != LEGACY_FILE_HEADER_SIZE as u64 {
+                return Err(Error::ReplaySanityFailed {
+                    context: "nonempty WAL format 3 is replay-only; checkpoint it with a format-3 Holt binary before v4 writes",
+                    record_offset: 0,
+                });
+            }
+
+            // A header-only legacy WAL has no recovery records to lose. Rewrite
+            // its fixed-size header before opening O_APPEND; a crash during the
+            // rewrite can at worst leave an unsupported header over an empty
+            // log, which fails closed on the next open.
+            header.version = FORMAT_VERSION;
+            header.checkpoint_anchor = None;
+            header.anchor_generation = 0;
+            let mut upgraded = Vec::with_capacity(FILE_HEADER_SIZE);
+            encode_file_header(&header, &mut upgraded);
+            header_file.seek(SeekFrom::Start(0))?;
+            header_file.write_all(&upgraded)?;
+            header_file.sync_data()?;
+        }
         let file = OpenOptions::new().append(true).open(path)?;
         let bytes_written = file.metadata()?.len();
         Ok(Self {
             file,
+            header_file,
             pending: Vec::with_capacity(4096),
             bytes_written,
             header,
@@ -233,13 +279,92 @@ impl WalWriter {
     /// dropped — call `flush()` first if they matter.
     pub fn truncate(&mut self) -> Result<()> {
         self.pending.clear();
-        self.file.set_len(FILE_HEADER_SIZE as u64)?;
-        self.file.sync_data()?;
-        self.bytes_written = FILE_HEADER_SIZE as u64;
+        let record_offset = self.header.record_offset() as u64;
+        self.header_file.set_len(record_offset)?;
+        self.header_file.sync_data()?;
+        self.bytes_written = record_offset;
 
         #[cfg(feature = "tracing")]
         tracing::info!(target: "holt::wal", "wal truncated to header-only");
 
+        Ok(())
+    }
+
+    /// Persist `anchor` in both format-4 slots and sync each update before
+    /// truncating the record stream back to the header page.
+    pub(crate) fn checkpoint_and_truncate(&mut self, anchor: Option<JournalAnchor>) -> Result<()> {
+        // The checkpoint path already requested a flush barrier. Repeat the
+        // drain defensively so no buffered append can survive past truncation.
+        self.flush()?;
+        if let Some(anchor) = anchor {
+            self.persist_checkpoint_anchor(anchor)?;
+        }
+        self.truncate()
+    }
+
+    /// Durably initialize or advance the checkpoint anchor without touching
+    /// the record stream.
+    pub(crate) fn persist_checkpoint_anchor(&mut self, anchor: JournalAnchor) -> Result<()> {
+        if self.header.version != FORMAT_VERSION {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "checkpoint anchors require WAL format 4",
+            });
+        }
+
+        // A newly advanced anchor must reach both slots before checkpoint can
+        // truncate its covered WAL suffix. If recovery sees the same anchor,
+        // the previous process may have crashed after only the first slot was
+        // synced, so write one more generation to repair the sibling.
+        let generations = if self.header.checkpoint_anchor == Some(anchor) {
+            1
+        } else {
+            2
+        };
+        self.header
+            .anchor_generation
+            .checked_add(generations)
+            .ok_or(Error::JournalStreamUnavailable {
+                reason: "checkpoint anchor generation exhausted",
+            })?;
+        for _ in 0..generations {
+            self.persist_anchor_generation(anchor)?;
+        }
+        Ok(())
+    }
+
+    /// Arm a one-shot test failure for checkpoint-anchor generation writes.
+    #[cfg(test)]
+    pub(crate) fn fail_anchor_generation_after_for_test(successful_writes: usize) {
+        FAIL_ANCHOR_GENERATION_AFTER.with(|remaining| remaining.set(Some(successful_writes)));
+    }
+
+    fn persist_anchor_generation(&mut self, anchor: JournalAnchor) -> Result<()> {
+        #[cfg(test)]
+        FAIL_ANCHOR_GENERATION_AFTER.with(|remaining| match remaining.get() {
+            Some(0) => {
+                remaining.set(None);
+                Err(Error::Internal("checkpoint anchor generation test failure"))
+            }
+            Some(count) => {
+                remaining.set(Some(count - 1));
+                Ok(())
+            }
+            None => Ok(()),
+        })?;
+
+        let generation = self.header.anchor_generation.checked_add(1).ok_or(
+            Error::JournalStreamUnavailable {
+                reason: "checkpoint anchor generation exhausted",
+            },
+        )?;
+        let slot_index = ((generation - 1) & 1) as usize;
+        let slot = encode_anchor_slot(anchor, generation);
+        self.header_file
+            .seek(SeekFrom::Start(ANCHOR_SLOT_OFFSETS[slot_index] as u64))?;
+        self.header_file.write_all(&slot[..ANCHOR_SLOT_SIZE])?;
+        self.header_file.sync_data()?;
+        self.header.checkpoint_anchor = Some(anchor);
+        self.header.anchor_generation = generation;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,10 @@ pub use api::checkpoint::CheckpointImage;
 pub use api::config::{AccessMode, Durability, Storage, TreeConfig};
 pub use api::db::{DBAtomicBatch, DBView, DB};
 pub use api::errors::{AtomicErrorKind, Error, Result};
+pub use api::journal::{
+    JournalAnchor, JournalEnvelope, JournalEnvelopeError, JournalEnvelopePage, JournalState,
+    JOURNAL_DIGEST_BYTES, MAX_JOURNAL_RECORD_BYTES,
+};
 pub use api::key::{KeyPathBuf, KeyPathError, KeyPrefixBuf};
 pub use api::snapshot::Snapshot;
 pub use api::tree::{PutOutcome, Tree};

--- a/src/store/blob_store/file/mod.rs
+++ b/src/store/blob_store/file/mod.rs
@@ -112,6 +112,8 @@ const DATA_FILENAME: &str = "blobs.dat";
 /// Advisory lock file inside `data_dir`, flock'd for the lifetime of
 /// an open instance. Readers hold shared locks; writers hold exclusive locks.
 const LOCK_FILENAME: &str = "store.lock";
+/// WAL file checked under the store lock before a writable open touches data.
+const JOURNAL_FILENAME: &str = "journal.wal";
 /// How long `open` waits for a previous instance to release the
 /// directory lock before failing. Covers the handover pattern where
 /// a caller opens a new instance while the previous one is still
@@ -384,6 +386,17 @@ fn open_read_accelerator_file(
     }
 }
 
+fn preflight_writable_journal(data_dir: &Path, access: FileAccess) -> Result<()> {
+    if access.is_read_only() {
+        return Ok(());
+    }
+    let path = data_dir.join(JOURNAL_FILENAME);
+    if path.exists() {
+        crate::journal::reader::preflight_writable_wal(&path)?;
+    }
+    Ok(())
+}
+
 impl FileBlobStore {
     /// Open or create a persistent store at `data_dir`.
     ///
@@ -447,6 +460,7 @@ impl FileBlobStore {
         // replay (including torn-tail truncation) must not run
         // while another instance can still append deltas.
         let dir_lock = acquire_dir_lock(&data_dir, access, DIR_LOCK_ACQUIRE_TIMEOUT)?;
+        preflight_writable_journal(&data_dir, access)?;
 
         let data_path = data_dir.join(DATA_FILENAME);
         let read_index_path = data_dir.join(READ_INDEX_FILENAME);
@@ -530,6 +544,7 @@ impl FileBlobStore {
         // replay (including torn-tail truncation) must not run
         // while another instance can still append deltas.
         let dir_lock = acquire_dir_lock(&data_dir, access, DIR_LOCK_ACQUIRE_TIMEOUT)?;
+        preflight_writable_journal(&data_dir, access)?;
 
         let data_path = data_dir.join(DATA_FILENAME);
         let read_index_path = data_dir.join(READ_INDEX_FILENAME);

--- a/tests/read_only_open.rs
+++ b/tests/read_only_open.rs
@@ -12,6 +12,15 @@ const HELPER_PATH: &str = "HOLT_READ_ONLY_HELPER_PATH";
 const HELPER_MODE: &str = "HOLT_READ_ONLY_HELPER_MODE";
 const HELPER_EXPECT_SUCCESS: &str = "HOLT_READ_ONLY_HELPER_EXPECT_SUCCESS";
 
+const WAL_FILE_MAGIC: u32 = 0x414C_4157;
+const WAL_RECORD_MAGIC: u32 = 0x5243_4552;
+const LEGACY_WAL_FORMAT_VERSION: u32 = 3;
+const CURRENT_WAL_FORMAT_VERSION: u32 = 4;
+const LEGACY_WAL_HEADER_SIZE: usize = 32;
+const CURRENT_WAL_HEADER_SIZE: usize = 4096;
+const INSERT_RECORD_TAG: u8 = 0;
+const FIRST_DB_USER_TREE_ID: u64 = 1;
+
 fn writable_config(path: &Path) -> TreeConfig {
     let mut cfg = TreeConfig::new(path);
     cfg.durability = Durability::Wal { sync: true };
@@ -27,6 +36,45 @@ fn snapshot_files(path: &Path) -> BTreeMap<OsString, Vec<u8>> {
             (entry.file_name(), fs::read(entry.path()).unwrap())
         })
         .collect()
+}
+
+fn legacy_wal_header(tree_id: u64, created_at: u64) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(LEGACY_WAL_HEADER_SIZE);
+    bytes.extend_from_slice(&WAL_FILE_MAGIC.to_le_bytes());
+    bytes.extend_from_slice(&LEGACY_WAL_FORMAT_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&tree_id.to_le_bytes());
+    bytes.extend_from_slice(&created_at.to_le_bytes());
+    bytes.extend_from_slice(&0u64.to_le_bytes());
+    assert_eq!(bytes.len(), LEGACY_WAL_HEADER_SIZE);
+    bytes
+}
+
+fn legacy_wal_with_insert(tree_id: u64, key: &[u8], value: &[u8]) -> Vec<u8> {
+    let mut bytes = legacy_wal_header(0, 0x0102_0304_0506_0708);
+    let record_start = bytes.len();
+    let body_len = 8 + 4 + key.len() + 4 + value.len();
+    bytes.extend_from_slice(&WAL_RECORD_MAGIC.to_le_bytes());
+    bytes.extend_from_slice(&(body_len as u32).to_le_bytes());
+    bytes.extend_from_slice(&1_000u64.to_le_bytes());
+    bytes.push(INSERT_RECORD_TAG);
+    bytes.extend_from_slice(&tree_id.to_le_bytes());
+    bytes.extend_from_slice(&(key.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(key);
+    bytes.extend_from_slice(&(value.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(value);
+    let checksum = crc32fast::hash(&bytes[record_start..]);
+    bytes.extend_from_slice(&checksum.to_le_bytes());
+    bytes
+}
+
+fn assert_nonempty_v3_error(error: &Error) {
+    assert!(matches!(
+        error,
+        Error::ReplaySanityFailed {
+            context: "nonempty WAL format 3 is replay-only; checkpoint it with a format-3 Holt binary before v4 writes",
+            record_offset: 0,
+        }
+    ));
 }
 
 #[test]
@@ -140,6 +188,203 @@ fn read_only_database_replays_named_trees_and_rejects_mutations() {
     drop(objects);
     drop(db);
     assert_eq!(snapshot_files(dir.path()), before);
+}
+
+#[test]
+fn read_only_database_validates_and_scans_attached_journal() {
+    let dir = tempdir().unwrap();
+    let genesis = holt::JournalAnchor::new(0, [0x50; 32]);
+    let first = holt::JournalAnchor::new(1, [0x51; 32]);
+    let envelope =
+        holt::JournalEnvelope::new(genesis, first, b"read-only recovery command".to_vec()).unwrap();
+
+    {
+        let db = DB::open(writable_config(dir.path())).unwrap();
+        db.create_tree("metadata").unwrap();
+        db.checkpoint().unwrap();
+        db.initialize_journal_stream(genesis).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(envelope.clone(), |batch| {
+                batch.put("metadata", b"key", b"value");
+            })
+            .unwrap());
+    }
+
+    let before = snapshot_files(dir.path());
+    let db = DB::open(writable_config(dir.path()).read_only()).unwrap();
+    assert_eq!(db.journal_state().unwrap().checkpoint(), genesis);
+    assert_eq!(db.journal_state().unwrap().tail(), first);
+    let page = db.journal_envelopes_after(genesis, 8, 4096).unwrap();
+    assert_eq!(page.envelopes(), &[envelope]);
+    assert_eq!(page.next(), first);
+    assert!(!page.has_more());
+    drop(db);
+    assert_eq!(snapshot_files(dir.path()), before);
+}
+
+#[test]
+fn nonempty_v3_tree_is_replay_only_and_writable_open_changes_nothing() {
+    let dir = tempdir().unwrap();
+    {
+        let tree = Tree::open(writable_config(dir.path())).unwrap();
+        tree.put(b"checkpointed", b"tree-value").unwrap();
+        tree.checkpoint().unwrap();
+    }
+
+    fs::write(
+        dir.path().join("journal.wal"),
+        legacy_wal_with_insert(0, b"from-v3", b"tree-replay"),
+    )
+    .unwrap();
+    let before = snapshot_files(dir.path());
+
+    let error = Tree::open(writable_config(dir.path())).unwrap_err();
+    assert_nonempty_v3_error(&error);
+    assert_eq!(snapshot_files(dir.path()), before);
+
+    let tree = TreeBuilder::new(dir.path()).read_only().open().unwrap();
+    assert_eq!(
+        tree.get(b"checkpointed").unwrap().as_deref(),
+        Some(&b"tree-value"[..])
+    );
+    assert_eq!(
+        tree.get(b"from-v3").unwrap().as_deref(),
+        Some(&b"tree-replay"[..])
+    );
+    drop(tree);
+    assert_eq!(snapshot_files(dir.path()), before);
+}
+
+#[test]
+fn nonempty_v3_database_is_replay_only_and_read_only_export_includes_replay() {
+    let dir = tempdir().unwrap();
+    {
+        let db = DB::open(writable_config(dir.path())).unwrap();
+        let objects = db.create_tree("objects").unwrap();
+        objects.put(b"checkpointed", b"db-value").unwrap();
+        db.checkpoint().unwrap();
+    }
+
+    // A fresh DB assigns tree id 1 to its first named tree. That id is part
+    // of this legacy wire fixture, not a public API assumption by callers.
+    fs::write(
+        dir.path().join("journal.wal"),
+        legacy_wal_with_insert(FIRST_DB_USER_TREE_ID, b"from-v3", b"db-replay"),
+    )
+    .unwrap();
+    let before = snapshot_files(dir.path());
+
+    let error = DB::open(writable_config(dir.path())).unwrap_err();
+    assert_nonempty_v3_error(&error);
+    assert_eq!(snapshot_files(dir.path()), before);
+
+    let db = DB::open(writable_config(dir.path()).read_only()).unwrap();
+    let objects = db.open_tree("objects").unwrap();
+    assert_eq!(
+        objects.get(b"checkpointed").unwrap().as_deref(),
+        Some(&b"db-value"[..])
+    );
+    assert_eq!(
+        objects.get(b"from-v3").unwrap().as_deref(),
+        Some(&b"db-replay"[..])
+    );
+    let image = db.export_checkpoint().unwrap();
+    drop(objects);
+    drop(db);
+    assert_eq!(snapshot_files(dir.path()), before);
+
+    let restored_dir = tempdir().unwrap();
+    let restored = DB::open(writable_config(restored_dir.path())).unwrap();
+    restored.install_checkpoint(&image).unwrap();
+    let restored_objects = restored.open_tree("objects").unwrap();
+    assert_eq!(
+        restored_objects.get(b"checkpointed").unwrap().as_deref(),
+        Some(&b"db-value"[..])
+    );
+    assert_eq!(
+        restored_objects.get(b"from-v3").unwrap().as_deref(),
+        Some(&b"db-replay"[..])
+    );
+}
+
+#[test]
+fn header_only_v3_tree_and_database_upgrade_to_v4_on_writable_open() {
+    let tree_dir = tempdir().unwrap();
+    {
+        let tree = Tree::open(writable_config(tree_dir.path())).unwrap();
+        tree.put(b"checkpointed", b"tree-value").unwrap();
+        tree.checkpoint().unwrap();
+    }
+    let tree_wal = tree_dir.path().join("journal.wal");
+    fs::write(&tree_wal, legacy_wal_header(0, 41)).unwrap();
+    let tree_before = snapshot_files(tree_dir.path());
+
+    let tree = Tree::open(writable_config(tree_dir.path())).unwrap();
+    assert_eq!(
+        tree.get(b"checkpointed").unwrap().as_deref(),
+        Some(&b"tree-value"[..])
+    );
+    drop(tree);
+    assert_v4_header_only_upgrade(&tree_wal, 41);
+    assert_non_wal_files_unchanged(tree_dir.path(), &tree_before);
+
+    let db_dir = tempdir().unwrap();
+    {
+        let db = DB::open(writable_config(db_dir.path())).unwrap();
+        let objects = db.create_tree("objects").unwrap();
+        objects.put(b"checkpointed", b"db-value").unwrap();
+        db.checkpoint().unwrap();
+    }
+    let db_wal = db_dir.path().join("journal.wal");
+    fs::write(&db_wal, legacy_wal_header(0, 43)).unwrap();
+    let db_before = snapshot_files(db_dir.path());
+
+    let db = DB::open(writable_config(db_dir.path())).unwrap();
+    let objects = db.open_tree("objects").unwrap();
+    assert_eq!(
+        objects.get(b"checkpointed").unwrap().as_deref(),
+        Some(&b"db-value"[..])
+    );
+    drop(objects);
+    drop(db);
+    assert_v4_header_only_upgrade(&db_wal, 43);
+    assert_non_wal_files_unchanged(db_dir.path(), &db_before);
+}
+
+fn assert_v4_header_only_upgrade(wal_path: &Path, created_at: u64) {
+    let bytes = fs::read(wal_path).unwrap();
+    assert_eq!(bytes.len(), CURRENT_WAL_HEADER_SIZE);
+    assert_eq!(
+        u32::from_le_bytes(bytes[0..4].try_into().unwrap()),
+        WAL_FILE_MAGIC
+    );
+    assert_eq!(
+        u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+        CURRENT_WAL_FORMAT_VERSION
+    );
+    assert_eq!(u64::from_le_bytes(bytes[8..16].try_into().unwrap()), 0);
+    assert_eq!(
+        u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+        created_at
+    );
+    assert_eq!(
+        u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+        CURRENT_WAL_HEADER_SIZE as u64
+    );
+}
+
+fn assert_non_wal_files_unchanged(path: &Path, before: &BTreeMap<OsString, Vec<u8>>) {
+    let after = snapshot_files(path);
+    for (name, bytes) in before {
+        if name != "journal.wal" {
+            assert_eq!(
+                after.get(name),
+                Some(bytes),
+                "{} changed",
+                name.to_string_lossy()
+            );
+        }
+    }
 }
 
 #[test]

--- a/tests/wal_tree_integration.rs
+++ b/tests/wal_tree_integration.rs
@@ -17,7 +17,7 @@ use std::thread;
 
 use tempfile::tempdir;
 
-use holt::{Durability, Tree, TreeConfig, DB};
+use holt::{Durability, JournalAnchor, JournalEnvelope, Tree, TreeConfig, DB};
 
 fn wal_path(dir: &Path) -> PathBuf {
     dir.join("journal.wal")
@@ -39,6 +39,45 @@ fn durable_cfg(dir: &std::path::Path) -> TreeConfig {
 }
 
 const OVERSIZED_ATOMIC_OPS: u32 = 257;
+const WAL_HEADER_SIZE: u64 = 4096;
+
+fn journal_anchor(sequence: u64, byte: u8) -> JournalAnchor {
+    JournalAnchor::new(sequence, [byte; 32])
+}
+
+#[test]
+fn attached_batch_replays_state_tail_and_envelope_without_checkpoint() {
+    let dir = tempdir().unwrap();
+    let genesis = journal_anchor(0, 0x40);
+    let first = journal_anchor(1, 0x41);
+    let envelope =
+        JournalEnvelope::new(genesis, first, b"canonical recovery command".to_vec()).unwrap();
+
+    {
+        let db = DB::open(durable_cfg(dir.path())).unwrap();
+        db.create_tree("metadata").unwrap();
+        db.checkpoint().unwrap();
+        db.initialize_journal_stream(genesis).unwrap();
+        assert!(db
+            .atomic_with_journal_envelope(envelope.clone(), |batch| {
+                batch.put("metadata", b"key", b"value");
+            })
+            .unwrap());
+        assert!(fs::metadata(wal_path(dir.path())).unwrap().len() > WAL_HEADER_SIZE);
+    }
+
+    let db = DB::open(durable_cfg(dir.path())).unwrap();
+    assert_eq!(
+        db.open_tree("metadata").unwrap().get(b"key").unwrap(),
+        Some(b"value".to_vec())
+    );
+    assert_eq!(db.journal_state().unwrap().checkpoint(), genesis);
+    assert_eq!(db.journal_state().unwrap().tail(), first);
+    let page = db.journal_envelopes_after(genesis, 8, 4096).unwrap();
+    assert_eq!(page.envelopes(), &[envelope]);
+    assert_eq!(page.next(), first);
+    assert!(!page.has_more());
+}
 
 #[test]
 fn db_named_trees_replay_from_one_wal() {
@@ -250,7 +289,10 @@ fn clean_checkpoint_skips_empty_wal_flush() {
 
     tree.put(b"wal-clean/k", b"v").unwrap();
     tree.checkpoint().unwrap();
-    assert_eq!(fs::metadata(wal_path(dir.path())).unwrap().len(), 32);
+    assert_eq!(
+        fs::metadata(wal_path(dir.path())).unwrap().len(),
+        WAL_HEADER_SIZE
+    );
 
     let after_truncate = tree.stats().unwrap().journal.unwrap();
     tree.checkpoint().unwrap();
@@ -276,7 +318,10 @@ fn checkpoint_reuses_durable_group_commit_wal_sync() {
         after_checkpoint.syncs, after_put.syncs,
         "checkpoint must not fsync WAL records already made durable by group commit",
     );
-    assert_eq!(fs::metadata(wal_path(dir.path())).unwrap().len(), 32);
+    assert_eq!(
+        fs::metadata(wal_path(dir.path())).unwrap().len(),
+        WAL_HEADER_SIZE
+    );
 }
 
 #[test]
@@ -298,7 +343,10 @@ fn persistent_put_then_reopen_via_wal_replay() {
 
     // The WAL file exists and has bytes past the header.
     let wal_size_after_drop = fs::metadata(wal_path(dir.path())).unwrap().len();
-    assert!(wal_size_after_drop > 32, "WAL should hold records");
+    assert!(
+        wal_size_after_drop > WAL_HEADER_SIZE,
+        "WAL should hold records"
+    );
 
     // Round 2: reopen. Replay rebuilds every key from the log.
     {
@@ -350,7 +398,10 @@ fn checkpoint_merges_deferred_put_before_truncating_wal() {
         let tree = Tree::open(cfg.clone()).unwrap();
         tree.put(b"checkpoint/deferred", b"value").unwrap();
         tree.checkpoint().unwrap();
-        assert_eq!(fs::metadata(wal_path(dir.path())).unwrap().len(), 32);
+        assert_eq!(
+            fs::metadata(wal_path(dir.path())).unwrap().len(),
+            WAL_HEADER_SIZE
+        );
     }
 
     let tree = Tree::open(cfg).unwrap();
@@ -425,7 +476,10 @@ fn replay_then_checkpoint_then_reopen_preserves_data() {
         // to store before truncating the WAL.**
         tree.checkpoint().unwrap();
         let wal_size_after = fs::metadata(wal_path(dir.path())).unwrap().len();
-        assert_eq!(wal_size_after, 32, "WAL truncated to header-only");
+        assert_eq!(
+            wal_size_after, WAL_HEADER_SIZE,
+            "WAL truncated to header-only"
+        );
     }
 
     // Round 3: store is the source of truth (WAL empty). If
@@ -459,11 +513,11 @@ fn checkpoint_truncates_wal_and_keys_survive_reopen() {
                 .unwrap();
         }
         let wal_size_before = fs::metadata(wal_path(dir.path())).unwrap().len();
-        assert!(wal_size_before > 32);
+        assert!(wal_size_before > WAL_HEADER_SIZE);
         tree.checkpoint().unwrap();
         let wal_size_after = fs::metadata(wal_path(dir.path())).unwrap().len();
         assert_eq!(
-            wal_size_after, 32,
+            wal_size_after, WAL_HEADER_SIZE,
             "checkpoint should truncate WAL to header-only",
         );
     }
@@ -585,7 +639,7 @@ fn enqueue_mode_loses_writes_without_checkpoint_or_fsync() {
         // file on disk is still header-only.
     }
     let wal_size = fs::metadata(wal_path(dir.path())).unwrap().len();
-    assert_eq!(wal_size, 32);
+    assert_eq!(wal_size, WAL_HEADER_SIZE);
 
     let tree = Tree::open(cfg).unwrap();
     for i in 0..50u32 {
@@ -998,10 +1052,7 @@ fn oversized_tree_atomic_record_fails_before_publish_or_seq_reservation() {
         .unwrap_err();
 
     assert!(
-        matches!(
-            err,
-            holt::Error::Internal("journal record exceeds WAL ring capacity")
-        ),
+        matches!(err, holt::Error::WalRecordTooLarge { .. }),
         "expected the WAL record limit, got {err:?}",
     );
     assert_eq!(fs::metadata(wal_path(dir.path())).unwrap().len(), wal_len);
@@ -1051,7 +1102,7 @@ fn oversized_db_atomic_record_fails_before_publish_or_seq_reservation() {
                 ref source,
             } if matches!(
                 source.as_ref(),
-                holt::Error::Internal("journal record exceeds WAL ring capacity")
+                holt::Error::WalRecordTooLarge { .. }
             )
         ),
         "expected the WAL record limit, got {err:?}",
@@ -1177,7 +1228,7 @@ fn background_checkpointer_truncates_wal_and_keeps_data_durable() {
         // waiting: repeated tick writes can keep slow machines in a
         // permanently dirty state and make this test self-defeating.
         // The background checkpointer wakes on its idle interval.
-        let header_size_after_truncate = 32u64; // FILE_HEADER_SIZE
+        let header_size_after_truncate = WAL_HEADER_SIZE;
         let deadline = Instant::now() + Duration::from_secs(15);
         loop {
             let wal_len = fs::metadata(wal_path(dir.path())).unwrap().len();

--- a/tools/soak/Cargo.lock
+++ b/tools/soak/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "holt"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",


### PR DESCRIPTION
## What changed

NoKV needs each canonical recovery record to share the commit boundary of the metadata mutation it describes. This PR adds an attached recovery stream to `DB`. One opaque envelope and its guarded multi-tree batch share one CRC-covered WAL record.

The file-backed stream stores its checkpoint floor in the format-4 WAL header. Retained WAL records define the current tail. A checkpoint mirrors the anchor before truncating the retained suffix. Memory databases provide the same ordering and paging only during the current process. After stream initialization, Holt rejects ordinary logical writes and requires attached batches.

The branch also fixes routed-compaction accounting for reachable `EmptyRoot` nodes and prepares Holt 0.9.0.

### Compatibility

- `Durability::Wal { sync: true }` puts each acknowledged attached batch on a forced sync boundary. `sync: false` does not provide per-acknowledgement power-loss durability.
- A checkpoint advances the local retention floor. Scans from an older cursor return `Error::JournalPositionExpired`.
- Writable open upgrades a header-only format-3 WAL. Holt replays a nonempty format-3 WAL only in read-only mode and rejects writable open before changing store files.
- Downgrade from format 4 requires `DB::export_checkpoint()` and `DB::install_checkpoint()` into a fresh 0.8.x store.
- The attached recovery stream is local. It is not a shared log, replication stream, or unbounded change feed.

## Test plan

- `cargo build --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-features --lib --tests --examples --locked`
- `cargo test --workspace --all-features --doc --locked`
- workspace and soak-tool format and clippy checks
- rustdoc with warnings denied
- all four documented examples
- normal and DB-normal soak smoke runs
- 512-case property tests
- `cargo publish --dry-run --locked --allow-dirty`

Regression tests cover crash replay without a checkpoint, dual anchor-slot corruption, interrupted checkpoint retry, legacy WAL migration, and read-only export. They also cover stream fencing, concurrent anchors, checkpoint lock ordering, bounded paging, oversized records, and reachable-empty-root compaction.

The local host lacks rustup/nightly and `cargo-llvm-cov`. GitHub Actions runs the fuzz smoke and 88% coverage gates.

A downstream NoKV capacity oracle ran two 500-publish batches against the attached stream. The second batch did not raise Holt's slot high-water mark. Its logical store growth was 0.055 MiB per publish.

## Related

This implements the checkpoint-bounded recovery suffix under ROADMAP P1. Live subscription and shared retention remain separate work.

NoKV adoption and existing-store migration remain downstream work.

This maintainer-directed Holt 0.9.0 storage work has no linked issue.

After merge, tag the exact merged `main` commit as `v0.9.0`. The release workflow publishes the crate and creates the GitHub release.
