### PR TITLE
fix: make journal stream initialization fail closed

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -246,6 +246,13 @@ syncs both anchor slots before it truncates the retained WAL suffix.
 checkpoint floor. The API does not provide a shared log or unbounded change
 feed.
 
+Initialization fences ordinary records before writing either anchor slot. If
+an anchor write fails, the in-process stream remains incomplete and accepts
+only an exact retry with the same genesis. State reads, scans, and attached
+writes remain unavailable until the retry repairs the anchor mirror. On open,
+an initialized header followed by an ordinary logical WAL record is rejected
+as a recovery-chain gap.
+
 ### `BufferManager` — cache + dirty/pending tracking
 
 `BufferManager` wraps any `BlobStore` and itself implements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-08-14
+
+### Fixed
+
+- Journal stream initialization now fences ordinary writes before either
+  persistent anchor slot can become durable. An interrupted initialization
+  keeps the fence active and accepts only an exact retry with the same genesis
+  anchor.
+- Open, replay, and recovery scans now reject an ordinary logical WAL record
+  after an attached-stream checkpoint anchor. This detects a surviving Holt
+  0.9.0 interrupted-initialization gap instead of accepting it as part of the
+  recovery stream.
+
+### Changed
+
+- Ordinary writes now use an atomic stream fence instead of locking the
+  journal tail while no attached stream is active.
+- Attached submissions now use encoder-sealed record metadata. They no longer
+  decode and copy a record before queueing it. Replay and recovery scans still
+  decode records and validate their CRCs.
+
+### Upgrade notes
+
+- Holt 0.9.1 uses the same format-4 WAL as 0.9.0. Existing stores do not need a
+  format migration.
+- If Holt 0.9.0 returned an error from `initialize_journal_stream` and the
+  process then accepted ordinary writes or ran a checkpoint, rebuild from
+  authoritative application state before using the attached stream. Holt
+  0.9.1 rejects mixed records that remain in the WAL, but it cannot reconstruct
+  or detect a recovery gap already folded into a checkpoint.
+
 ## [0.9.0] — 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holt"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.82"
 autobenches = false

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ a minor release, but minor releases may still break source compatibility
 before 1.0. Pin exact versions for production evaluation:
 
 ```toml
-holt = "=0.9.0"
+holt = "=0.9.1"
 ```
 
 The engine is covered by unit, integration, property, fuzz, soak, and

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ persist the stream anchor and retained suffix in the local WAL. Memory
 databases provide the same ordering and paging contract only for the process
 lifetime.
 
+If file-backed initialization returns an I/O error, do not resume ordinary
+writes. Holt keeps the database fenced and accepts only an exact retry with the
+same genesis anchor. State reads, scans, and attached writes remain unavailable
+until that retry repairs both anchor slots.
+
 A checkpoint advances the local retention floor. Older cursors return
 `Error::JournalPositionExpired`. This API provides local recovery records. It
 does not provide a shared or remote log.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ minor release plus the previous minor.
 
 | Version | Supported |
 |---------|-----------|
-| `0.9.0` | Yes (current) |
-| `< 0.9.0` | No |
+| `0.9.1` | Yes (current) |
+| `< 0.9.1` | No |
 
 ## Reporting a vulnerability
 

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/benches/regression.rs
+++ b/benches/regression.rs
@@ -4,13 +4,16 @@
 //! Holt-only target avoids compiling or initializing RocksDB, SQLite, and
 //! sled in the push-time CI path.
 
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use holt::{Tree, TreeConfig};
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use holt::{JournalAnchor, JournalEnvelope, Tree, TreeConfig, DB};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use tempfile::TempDir;
 
 const SEED: u64 = 0xC10A_D15E_A5ED;
 const KEY_COUNT: usize = 20_000;
+const JOURNAL_SAMPLE_COMMIT_CAP: u64 = 4_096;
 
 fn gen_kv_dataset() -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut out = Vec::with_capacity(KEY_COUNT);
@@ -72,6 +75,28 @@ fn make_tree() -> (Tree, TempDir) {
     cfg.checkpoint.enabled = false;
     let tree = Tree::open(cfg).expect("holt open");
     (tree, dir)
+}
+
+fn make_db() -> (DB, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let mut cfg = TreeConfig::new(dir.path());
+    cfg.durability = holt::Durability::Wal { sync: false };
+    cfg.buffer_pool_size = 32;
+    cfg.checkpoint.enabled = false;
+    let db = DB::open(cfg).expect("holt DB open");
+    db.create_tree("data").expect("create benchmark tree");
+    db.checkpoint().expect("checkpoint benchmark setup");
+    (db, dir)
+}
+
+fn journal_anchor(sequence: u64) -> JournalAnchor {
+    let mut digest = [0u8; 32];
+    digest[..8].copy_from_slice(&sequence.to_le_bytes());
+    JournalAnchor::new(sequence, digest)
+}
+
+fn extrapolate_sample(elapsed: Duration, requested: u64, measured: u64) -> Duration {
+    elapsed.mul_f64(requested as f64 / measured as f64)
 }
 
 fn preload(tree: &Tree, pairs: &[(Vec<u8>, Vec<u8>)]) {
@@ -149,5 +174,67 @@ fn bench_workload(c: &mut Criterion, name: &str, pairs: &[(Vec<u8>, Vec<u8>)]) {
     }
 }
 
-criterion_group!(benches, bench_persistent);
+fn bench_db_journal_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("db_journal_async");
+    group.throughput(Throughput::Elements(1));
+
+    {
+        let (db, _dir) = make_db();
+        let mut sequence = 0u64;
+        group.bench_function("ordinary", |b| {
+            b.iter_custom(|requested| {
+                let measured = requested.clamp(1, JOURNAL_SAMPLE_COMMIT_CAP);
+                let start = Instant::now();
+                for _ in 0..measured {
+                    sequence = sequence.wrapping_add(1);
+                    let value = sequence.to_le_bytes();
+                    db.atomic(|batch| batch.put("data", b"key", &value))
+                        .expect("ordinary DB atomic");
+                }
+                let elapsed = start.elapsed();
+                // Bound retained WAL bytes without charging checkpoint I/O to
+                // the commit measurement returned to Criterion.
+                db.checkpoint().expect("ordinary benchmark checkpoint");
+                extrapolate_sample(elapsed, requested, measured)
+            });
+        });
+    }
+
+    for payload_len in [128usize, 4 * 1024] {
+        let (db, _dir) = make_db();
+        let genesis = journal_anchor(0);
+        db.initialize_journal_stream(genesis)
+            .expect("initialize benchmark stream");
+        let mut previous = genesis;
+        group.bench_with_input(
+            BenchmarkId::new("attached", payload_len),
+            &payload_len,
+            |b, &payload_len| {
+                b.iter_custom(|requested| {
+                    let measured = requested.clamp(1, JOURNAL_SAMPLE_COMMIT_CAP);
+                    let start = Instant::now();
+                    for _ in 0..measured {
+                        let current = journal_anchor(previous.sequence() + 1);
+                        let mut payload = vec![0xA5; payload_len];
+                        payload[..8].copy_from_slice(&current.sequence().to_le_bytes());
+                        let value = current.sequence().to_le_bytes();
+                        let envelope = JournalEnvelope::new(previous, current, payload)
+                            .expect("valid benchmark envelope");
+                        db.atomic_with_journal_envelope(envelope, |batch| {
+                            batch.put("data", b"key", &value);
+                        })
+                        .expect("attached DB atomic");
+                        previous = current;
+                    }
+                    let elapsed = start.elapsed();
+                    db.checkpoint().expect("attached benchmark checkpoint");
+                    extrapolate_sample(elapsed, requested, measured)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_persistent, bench_db_journal_paths);
 criterion_main!(benches);

--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -489,7 +489,9 @@ impl DB {
     /// the stream only for that DB's process lifetime. In both profiles the DB
     /// must be writable and cleanly checkpointed before first initialization.
     /// An exact retry with the same anchor succeeds; a different anchor fails
-    /// closed.
+    /// closed. A file I/O error can leave initialization incomplete. In that
+    /// state Holt rejects ordinary writes, attached writes, state reads, and
+    /// scans until an exact retry durably repairs the anchor mirror.
     pub fn initialize_journal_stream(&self, genesis: JournalAnchor) -> Result<()> {
         self.ensure_writable()?;
         let _maintenance = self.maintenance_gate.enter_exclusive();
@@ -2413,6 +2415,182 @@ mod tests {
             .unwrap());
         assert_eq!(data.get(b"new-key").unwrap(), Some(b"new-value".to_vec()));
         assert_eq!(db.journal_state().unwrap().tail(), first);
+    }
+
+    #[test]
+    fn interrupted_stream_initialization_stays_fenced_until_exact_retry() {
+        for successful_anchor_writes in [0, 1] {
+            let dir = tempdir().unwrap();
+            let mut cfg = TreeConfig::new(dir.path());
+            cfg.checkpoint.enabled = false;
+            cfg.durability = super::super::config::Durability::Wal { sync: true };
+
+            let db = DB::open(cfg.clone()).unwrap();
+            let data = db.create_tree("data").unwrap();
+            db.checkpoint().unwrap();
+            let genesis = journal_anchor(0, 0x7a);
+            let first = journal_anchor(1, 0x7b);
+
+            crate::journal::writer::WalWriter::fail_anchor_generation_after_for_test(
+                successful_anchor_writes,
+            );
+            assert!(db.initialize_journal_stream(genesis).is_err());
+
+            assert!(matches!(
+                data.put(b"tree-outside-chain", b"visible"),
+                Err(Error::JournalStreamUnavailable { .. })
+            ));
+            assert!(data.get(b"tree-outside-chain").unwrap().is_none());
+            assert!(matches!(
+                db.atomic(|batch| batch.put("data", b"db-outside-chain", b"visible")),
+                Err(Error::Atomic {
+                    kind: AtomicErrorKind::DefinitelyNotApplied,
+                    source,
+                }) if matches!(source.as_ref(), Error::JournalStreamUnavailable { .. })
+            ));
+            assert!(data.get(b"db-outside-chain").unwrap().is_none());
+            assert!(matches!(
+                db.journal_state(),
+                Err(Error::JournalStreamUnavailable { .. })
+            ));
+            assert!(matches!(
+                db.journal_envelopes_after(genesis, 8, 4096),
+                Err(Error::JournalStreamUnavailable { .. })
+            ));
+
+            let envelope = JournalEnvelope::new(genesis, first, b"attached".to_vec()).unwrap();
+            assert!(matches!(
+                db.atomic_with_journal_envelope(envelope.clone(), |batch| {
+                    batch.put("data", b"attached", b"premature");
+                }),
+                Err(Error::Atomic {
+                    kind: AtomicErrorKind::DefinitelyNotApplied,
+                    source,
+                }) if matches!(source.as_ref(), Error::JournalStreamUnavailable { .. })
+            ));
+            assert!(data.get(b"attached").unwrap().is_none());
+
+            assert!(matches!(
+                db.initialize_journal_stream(journal_anchor(0, 0x7c)),
+                Err(Error::JournalAnchorMismatch { .. })
+            ));
+
+            // A checkpoint cannot clear an incomplete initialization fence.
+            db.checkpoint().unwrap();
+            assert!(matches!(
+                data.put(b"after-checkpoint", b"blocked"),
+                Err(Error::JournalStreamUnavailable { .. })
+            ));
+
+            // An exact retry repairs the missing generation and is the only
+            // transition that makes the attached stream ready in-process.
+            db.initialize_journal_stream(genesis).unwrap();
+            assert_eq!(
+                db.journal_state().unwrap(),
+                JournalState::new(genesis, genesis)
+            );
+            assert!(db
+                .atomic_with_journal_envelope(envelope, |batch| {
+                    batch.put("data", b"attached", b"ready");
+                })
+                .unwrap());
+            drop(data);
+            drop(db);
+
+            let reopened = DB::open(cfg).unwrap();
+            assert_eq!(reopened.journal_state().unwrap().checkpoint(), genesis);
+            let reopened_data = reopened.open_tree("data").unwrap();
+            assert!(reopened_data.get(b"tree-outside-chain").unwrap().is_none());
+            assert!(reopened_data.get(b"db-outside-chain").unwrap().is_none());
+            assert_eq!(
+                reopened_data.get(b"attached").unwrap(),
+                Some(b"ready".to_vec())
+            );
+        }
+    }
+
+    #[test]
+    fn interrupted_stream_reopen_uses_only_durable_anchor_slots() {
+        for successful_anchor_writes in [0, 1] {
+            let dir = tempdir().unwrap();
+            let mut cfg = TreeConfig::new(dir.path());
+            cfg.checkpoint.enabled = false;
+            let db = DB::open(cfg.clone()).unwrap();
+            db.create_tree("data").unwrap();
+            db.checkpoint().unwrap();
+            let genesis = journal_anchor(0, 0x7d);
+
+            crate::journal::writer::WalWriter::fail_anchor_generation_after_for_test(
+                successful_anchor_writes,
+            );
+            assert!(db.initialize_journal_stream(genesis).is_err());
+            drop(db);
+
+            let reopened = DB::open(cfg).unwrap();
+            if successful_anchor_writes == 0 {
+                assert!(matches!(
+                    reopened.journal_state(),
+                    Err(Error::JournalStreamUnavailable { .. })
+                ));
+                assert!(reopened
+                    .atomic(|batch| batch.put("data", b"ordinary", b"allowed"))
+                    .unwrap());
+            } else {
+                assert_eq!(
+                    reopened.journal_state().unwrap(),
+                    JournalState::new(genesis, genesis)
+                );
+                assert!(matches!(
+                    reopened.atomic(|batch| batch.put("data", b"ordinary", b"blocked")),
+                    Err(Error::Atomic {
+                        kind: AtomicErrorKind::DefinitelyNotApplied,
+                        source,
+                    }) if matches!(source.as_ref(), Error::JournalStreamUnavailable { .. })
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn reopen_rejects_an_ordinary_record_after_an_initialized_anchor() {
+        let dir = tempdir().unwrap();
+        let mut cfg = TreeConfig::new(dir.path());
+        cfg.checkpoint.enabled = false;
+        cfg.durability = super::super::config::Durability::Wal { sync: true };
+        let wal_path = cfg.wal_path().unwrap();
+
+        let db = DB::open(cfg.clone()).unwrap();
+        db.create_tree("data").unwrap();
+        db.checkpoint().unwrap();
+        db.initialize_journal_stream(journal_anchor(0, 0x7e))
+            .unwrap();
+        drop(db);
+
+        let mut writer = crate::journal::writer::WalWriter::open_existing(&wal_path).unwrap();
+        writer
+            .append(
+                &crate::journal::wal_op::WalOp::Insert {
+                    tree_id: FIRST_USER_TREE_ID,
+                    key: b"outside-chain".to_vec(),
+                    value: b"invalid".to_vec(),
+                },
+                100,
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        let before = std::fs::read(&wal_path).unwrap();
+
+        for reopen_cfg in [cfg.clone(), cfg.read_only()] {
+            assert!(matches!(
+                DB::open(reopen_cfg),
+                Err(Error::ReplaySanityFailed {
+                    context: "initialized attached WAL contains an ordinary record",
+                    ..
+                })
+            ));
+            assert_eq!(std::fs::read(&wal_path).unwrap(), before);
+        }
     }
 
     #[test]

--- a/src/api/db.rs
+++ b/src/api/db.rs
@@ -26,7 +26,7 @@ use super::tree::{
 use super::view::View;
 use crate::concurrency::{CommitGate, Gate};
 use crate::engine::RangeEntry;
-use crate::journal::codec::BatchEncoder;
+use crate::journal::codec::{encode_attached_batch_record, BatchEncoder};
 use crate::journal::Journal;
 use crate::layout::BlobGuid;
 use crate::store::blob_store::BlobStore;
@@ -1375,7 +1375,7 @@ impl DB {
                     .begin_attached(envelope.previous(), record_len)
                     .map_err(atomic_definitely_not_applied)?;
                 self.apply_batch_groups_with_attached_journal(
-                    &groups, base_seq, append, &envelope, record_len,
+                    &groups, base_seq, append, envelope, record_len,
                 )
                 .map_err(atomic_outcome_unknown)?
             };
@@ -1483,20 +1483,26 @@ impl DB {
         groups: &[DBBatchGroup],
         base_seq: u64,
         append: crate::journal::JournalAppendGuard<'_>,
-        envelope: &JournalEnvelope,
+        envelope: JournalEnvelope,
         record_len: usize,
     ) -> Result<Option<crate::journal::JournalAck>> {
-        let mut record = append.record_buffer(record_len);
-        let mut enc = BatchEncoder::begin_with_envelope(&mut record, base_seq, 0, envelope);
-        let mut group_base = base_seq;
-        for group in groups {
-            group
-                .tree
-                .apply_batch_walker_inline(&group.ops, group_base, Some(&mut enc))?;
-            group_base += count_group_wal_ops(group);
-        }
-        let _n = enc.finish();
-        append.submit(record, envelope, self.cfg.durability.wal_sync())
+        let record = encode_attached_batch_record(
+            append.record_buffer(record_len),
+            base_seq,
+            0,
+            envelope,
+            |encoder| {
+                let mut group_base = base_seq;
+                for group in groups {
+                    group
+                        .tree
+                        .apply_batch_walker_inline(&group.ops, group_base, Some(encoder))?;
+                    group_base += count_group_wal_ops(group);
+                }
+                Ok(())
+            },
+        )?;
+        append.submit(record, self.cfg.durability.wal_sync())
     }
 
     fn apply_batch_groups_in_memory(&self, groups: &[DBBatchGroup], base_seq: u64) -> Result<()> {

--- a/src/api/journal.rs
+++ b/src/api/journal.rs
@@ -5,6 +5,7 @@
 //! the same checksummed WAL record as the batch that mutates the database.
 
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
 use super::errors::{Error, Result};
@@ -268,6 +269,7 @@ impl JournalEnvelope {
 /// semantics as the file-backed stream. It deliberately provides no reopen or
 /// crash durability: dropping the memory DB drops both its data and envelopes.
 pub(crate) struct VolatileJournal {
+    ordinary_fenced: AtomicBool,
     state: Mutex<VolatileJournalState>,
 }
 
@@ -285,6 +287,7 @@ pub(crate) struct VolatileJournalAppendGuard<'a> {
 impl VolatileJournal {
     pub(crate) fn new() -> Self {
         Self {
+            ordinary_fenced: AtomicBool::new(false),
             state: Mutex::new(VolatileJournalState::default()),
         }
     }
@@ -298,6 +301,7 @@ impl VolatileJournal {
                 expected: existing.sequence(),
             }),
             None => {
+                self.ordinary_fenced.store(true, Ordering::Release);
                 state.checkpoint = Some(genesis);
                 state.tail = Some(genesis);
                 Ok(())
@@ -311,7 +315,7 @@ impl VolatileJournal {
     }
 
     pub(crate) fn ensure_ordinary_writes_allowed(&self) -> Result<()> {
-        if self.state.lock().unwrap().checkpoint.is_some() {
+        if self.ordinary_fenced.load(Ordering::Acquire) {
             Err(Error::JournalStreamUnavailable {
                 reason: "ordinary writes are disabled after attached stream initialization",
             })

--- a/src/journal/codec.rs
+++ b/src/journal/codec.rs
@@ -497,6 +497,49 @@ pub struct BatchEncoder<'buf> {
     finished: bool,
 }
 
+/// Fully encoded attached batch whose envelope identity cannot diverge from
+/// the bytes submitted to the journal.
+pub(crate) struct EncodedAttachedRecord {
+    bytes: Vec<u8>,
+    envelope: JournalEnvelope,
+}
+
+impl EncodedAttachedRecord {
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<u8>, JournalEnvelope) {
+        (self.bytes, self.envelope)
+    }
+}
+
+/// Encode and seal one attached DB batch.
+///
+/// The owned envelope is both the source of the encoded envelope bytes and
+/// the tail transition consumed by the append coordinator. Callers cannot
+/// pair a record with different recovery metadata after encoding.
+pub(crate) fn encode_attached_batch_record<F>(
+    mut bytes: Vec<u8>,
+    seq: u64,
+    tree_id: u64,
+    envelope: JournalEnvelope,
+    encode_ops: F,
+) -> Result<EncodedAttachedRecord>
+where
+    F: FnOnce(&mut BatchEncoder<'_>) -> Result<()>,
+{
+    if !bytes.is_empty() {
+        return Err(Error::Internal(
+            "attached record buffer must be empty before encoding",
+        ));
+    }
+    let mut encoder = BatchEncoder::begin_with_envelope(&mut bytes, seq, tree_id, &envelope);
+    encode_ops(&mut encoder)?;
+    encoder.finish();
+    Ok(EncodedAttachedRecord { bytes, envelope })
+}
+
 impl<'buf> BatchEncoder<'buf> {
     /// Open a new `Batch` record on `out`. The header + body prefix
     /// (tree_id, zero-placeholder count) are written immediately;
@@ -1066,6 +1109,7 @@ fn sanity(context: &'static str) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use std::fmt::Write;
 
     fn sample_envelope() -> JournalEnvelope {
@@ -1421,6 +1465,112 @@ mod tests {
                 ));
             }
             other => panic!("expected attached DB batch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sealed_attached_record_matches_generic_encoder_and_decoder() {
+        let envelope = sample_envelope();
+        let expected = WalOp::DbBatchWithEnvelope {
+            envelope: envelope.clone(),
+            ops: vec![
+                WalOp::Insert {
+                    tree_id: 7,
+                    key: b"new".to_vec(),
+                    value: b"value".to_vec(),
+                },
+                WalOp::Erase {
+                    tree_id: 7,
+                    key: b"old".to_vec(),
+                },
+                WalOp::RenameObject {
+                    tree_id: 7,
+                    src_key: b"from".to_vec(),
+                    dst_key: b"to".to_vec(),
+                    force: true,
+                },
+            ],
+        };
+        let sealed =
+            encode_attached_batch_record(Vec::new(), 1_000, 0, envelope.clone(), |encoder| {
+                encoder.push_insert(7, b"new", b"value");
+                encoder.push_erase(7, b"old");
+                encoder.push_rename_object(7, b"from", b"to", true);
+                Ok(())
+            })
+            .unwrap();
+        let (bytes, carried_envelope) = sealed.into_parts();
+        assert_eq!(carried_envelope, envelope);
+
+        let mut generic = Vec::new();
+        encode_record(&expected, 1_000, &mut generic);
+        assert_eq!(bytes, generic);
+
+        let decoded = decode_record(&bytes).unwrap();
+        assert_eq!(decoded.seq, 1_000);
+        assert_eq!(decoded.bytes_consumed, bytes.len());
+        assert_eq!(format!("{:?}", decoded.op), format!("{expected:?}"));
+    }
+
+    proptest! {
+        #[test]
+        fn sealed_attached_record_property_roundtrips(
+            sequence in 0u64..u64::MAX,
+            tree_id in any::<u64>(),
+            payload in prop::collection::vec(any::<u8>(), 1..1024),
+            key in prop::collection::vec(any::<u8>(), 0..64),
+            value in prop::collection::vec(any::<u8>(), 0..128),
+            erased in prop::collection::vec(any::<u8>(), 0..64),
+            src in prop::collection::vec(any::<u8>(), 0..64),
+            dst in prop::collection::vec(any::<u8>(), 0..64),
+            force in any::<bool>(),
+        ) {
+            let previous = JournalAnchor::new(sequence, [0x33; JOURNAL_DIGEST_BYTES]);
+            let current = JournalAnchor::new(sequence + 1, [0x44; JOURNAL_DIGEST_BYTES]);
+            let envelope = JournalEnvelope::new(previous, current, payload).unwrap();
+            let expected = WalOp::DbBatchWithEnvelope {
+                envelope: envelope.clone(),
+                ops: vec![
+                    WalOp::Insert {
+                        tree_id,
+                        key: key.clone(),
+                        value: value.clone(),
+                    },
+                    WalOp::Erase {
+                        tree_id,
+                        key: erased.clone(),
+                    },
+                    WalOp::RenameObject {
+                        tree_id,
+                        src_key: src.clone(),
+                        dst_key: dst.clone(),
+                        force,
+                    },
+                ],
+            };
+            let sealed = encode_attached_batch_record(
+                Vec::new(),
+                sequence,
+                0,
+                envelope.clone(),
+                |encoder| {
+                    encoder.push_insert(tree_id, &key, &value);
+                    encoder.push_erase(tree_id, &erased);
+                    encoder.push_rename_object(tree_id, &src, &dst, force);
+                    Ok(())
+                },
+            )
+            .unwrap();
+            let (bytes, carried_envelope) = sealed.into_parts();
+            prop_assert_eq!(carried_envelope, envelope);
+
+            let decoded = decode_record(&bytes).unwrap();
+            prop_assert_eq!(decoded.seq, sequence);
+            prop_assert_eq!(decoded.bytes_consumed, bytes.len());
+            prop_assert_eq!(format!("{:?}", decoded.op), format!("{expected:?}"));
+            let footer = bytes.len() - RECORD_FOOTER_SIZE;
+            let stored_crc = u32::from_le_bytes(bytes[footer..].try_into().unwrap());
+            prop_assert_eq!(stored_crc, crc32(&bytes[..footer]));
         }
     }
 

--- a/src/journal/group_commit.rs
+++ b/src/journal/group_commit.rs
@@ -31,7 +31,7 @@
 //! checkpoint barrier), exactly like legacy group commit.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -114,12 +114,18 @@ struct Shared {
     control_tx: Sender<Control>,
     record_pool: Mutex<Vec<Vec<u8>>>,
     path: PathBuf,
+    /// Monotonic fence for ordinary records. Initialization sets this before
+    /// either anchor slot can become durable and never clears it in-process.
+    ordinary_fenced: AtomicBool,
     tail: Mutex<TailState>,
 }
 
 struct TailState {
     checkpoint: Option<JournalAnchor>,
     tail: Option<JournalAnchor>,
+    /// Genesis selected by an initialization attempt whose two-slot durable
+    /// write has not yet completed. Only an exact retry may resume it.
+    initializing: Option<JournalAnchor>,
     scan_resume: Option<AttachedEnvelopeResume>,
 }
 
@@ -325,9 +331,11 @@ impl Journal {
             control_tx,
             record_pool: Mutex::new(Vec::new()),
             path: path.to_path_buf(),
+            ordinary_fenced: AtomicBool::new(attached.is_some()),
             tail: Mutex::new(TailState {
                 checkpoint: attached.map(JournalState::checkpoint),
                 tail: attached.map(JournalState::tail),
+                initializing: None,
                 scan_resume: None,
             }),
         });
@@ -352,7 +360,7 @@ impl Journal {
     }
 
     pub(crate) fn ensure_ordinary_writes_allowed(&self) -> Result<()> {
-        if self.shared.tail.lock().unwrap().checkpoint.is_some() {
+        if self.shared.ordinary_fenced.load(Ordering::Acquire) {
             Err(Error::JournalStreamUnavailable {
                 reason: "ordinary WAL records are disabled after attached stream initialization",
             })
@@ -437,15 +445,32 @@ impl Journal {
             }
             None => {}
         }
-        if self.needs_checkpoint() {
-            return Err(Error::JournalStreamUnavailable {
-                reason: "WAL must be checkpoint-clean before stream initialization",
-            });
+        match tail.initializing {
+            Some(existing) if existing != genesis => {
+                return Err(Error::JournalAnchorMismatch {
+                    requested: genesis.sequence(),
+                    expected: existing.sequence(),
+                });
+            }
+            Some(_) => {}
+            None => {
+                if self.needs_checkpoint() {
+                    return Err(Error::JournalStreamUnavailable {
+                        reason: "WAL must be checkpoint-clean before stream initialization",
+                    });
+                }
+                tail.initializing = Some(genesis);
+                // Publish the fail-closed fence before the first slot write.
+                // The maintenance gate excludes an ordinary writer that has
+                // already passed its own Acquire load.
+                self.shared.ordinary_fenced.store(true, Ordering::Release);
+            }
         }
         let mut writer = self.shared.writer.lock().unwrap();
         writer.persist_checkpoint_anchor(genesis)?;
         tail.checkpoint = Some(genesis);
         tail.tail = Some(genesis);
+        tail.initializing = None;
         tail.scan_resume = None;
         Ok(())
     }
@@ -489,6 +514,11 @@ impl Journal {
         // attached tail before flushing so no attached writer can publish a
         // new record between the durability barrier and the file scan.
         let mut tail = self.shared.tail.lock().unwrap();
+        if tail.checkpoint.is_none() || tail.initializing.is_some() {
+            return Err(Error::JournalStreamUnavailable {
+                reason: "stream initialization has not completed",
+            });
+        }
         self.flush_up_to(self.queued_work())?;
         match scan_attached_envelope_page_from(
             &self.shared.path,

--- a/src/journal/group_commit.rs
+++ b/src/journal/group_commit.rs
@@ -40,15 +40,14 @@ use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
 
 use crate::api::errors::{Error, Result};
 use crate::api::journal::{
-    JournalAnchor, JournalEnvelope, JournalEnvelopePage, JournalState, MAX_JOURNAL_RECORD_BYTES,
+    JournalAnchor, JournalEnvelopePage, JournalState, MAX_JOURNAL_RECORD_BYTES,
 };
 
-use super::codec::decode_record;
+use super::codec::EncodedAttachedRecord;
 use super::reader::{
     scan_attached_envelope_page_from, validate_attached_journal, AttachedEnvelopeResume,
 };
 use super::ring::{ReserveTicket, WalRing};
-use super::wal_op::WalOp;
 use super::writer::WalWriter;
 
 /// Production journal counters surfaced through `Tree::stats`.
@@ -298,6 +297,7 @@ pub(crate) struct Journal {
 pub(crate) struct JournalAppendGuard<'a> {
     journal: &'a Journal,
     tail: MutexGuard<'a, TailState>,
+    preflight_record_len: usize,
 }
 
 impl Journal {
@@ -501,6 +501,7 @@ impl Journal {
         Ok(JournalAppendGuard {
             journal: self,
             tail,
+            preflight_record_len: record_len,
         })
     }
 
@@ -600,22 +601,15 @@ impl JournalAppendGuard<'_> {
 
     pub(crate) fn submit(
         mut self,
-        record: Vec<u8>,
-        envelope: &JournalEnvelope,
+        record: EncodedAttachedRecord,
         sync: bool,
     ) -> Result<Option<JournalAck>> {
-        let decoded = decode_record(&record)?;
-        let WalOp::DbBatchWithEnvelope {
-            envelope: encoded, ..
-        } = decoded.op
-        else {
-            return Err(Error::Internal("attached submit requires WAL tag 13"));
-        };
-        if &encoded != envelope {
+        if record.len() > self.preflight_record_len {
             return Err(Error::Internal(
-                "attached submit envelope differs from encoded WAL record",
+                "attached record exceeded its preflight length",
             ));
         }
+        let (bytes, envelope) = record.into_parts();
         let expected = self.tail.tail.expect("begin_attached initialized tail");
         if envelope.previous() != expected {
             return Err(Error::JournalAnchorMismatch {
@@ -623,7 +617,7 @@ impl JournalAppendGuard<'_> {
                 expected: expected.sequence(),
             });
         }
-        let ack = self.journal.publish(record, sync)?;
+        let ack = self.journal.publish(bytes, sync)?;
         self.tail.tail = Some(envelope.current());
         Ok(ack)
     }
@@ -686,7 +680,12 @@ fn do_truncate(shared: &Shared) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::journal::codec::FILE_HEADER_SIZE;
+    use crate::journal::codec::{encode_attached_batch_record, FILE_HEADER_SIZE};
+    use crate::JournalEnvelope;
+
+    fn test_anchor(sequence: u64, byte: u8) -> JournalAnchor {
+        JournalAnchor::new(sequence, [byte; 32])
+    }
 
     // The 6 legacy contract tests, retargeted at the ring-backed Journal.
 
@@ -784,6 +783,66 @@ mod tests {
         journal.submit(vec![1, 2, 3, 4], false).unwrap();
         journal.flush_up_to(journal.queued_work()).unwrap();
         assert_eq!(journal.stats().appends, 1);
+    }
+
+    #[test]
+    fn sealed_attached_submit_checks_preflight_bound_and_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = Journal::open_or_create(&dir.path().join("journal.wal"), 0).unwrap();
+        let genesis = test_anchor(0, 0x10);
+        journal.initialize_anchor(genesis).unwrap();
+
+        let make_record = |envelope: JournalEnvelope| {
+            encode_attached_batch_record(Vec::new(), 1, 0, envelope, |encoder| {
+                encoder.push_insert(7, b"key", b"value");
+                Ok(())
+            })
+            .unwrap()
+        };
+
+        let first = test_anchor(1, 0x11);
+        let record = make_record(JournalEnvelope::new(genesis, first, b"first".to_vec()).unwrap());
+        let record_len = record.len();
+        let appends_before = journal.stats().appends;
+        assert!(matches!(
+            journal
+                .begin_attached(genesis, record_len - 1)
+                .unwrap()
+                .submit(record, false),
+            Err(Error::Internal(
+                "attached record exceeded its preflight length"
+            ))
+        ));
+        assert_eq!(journal.stats().appends, appends_before);
+        assert_eq!(journal.state().unwrap().tail(), genesis);
+
+        let wrong_previous = test_anchor(0, 0x12);
+        let record =
+            make_record(JournalEnvelope::new(wrong_previous, first, b"wrong".to_vec()).unwrap());
+        let record_len = record.len();
+        assert!(matches!(
+            journal
+                .begin_attached(genesis, record_len)
+                .unwrap()
+                .submit(record, false),
+            Err(Error::JournalAnchorMismatch {
+                requested: 0,
+                expected: 0,
+            })
+        ));
+        assert_eq!(journal.stats().appends, appends_before);
+        assert_eq!(journal.state().unwrap().tail(), genesis);
+
+        let record =
+            make_record(JournalEnvelope::new(genesis, first, b"accepted".to_vec()).unwrap());
+        let record_len = record.len();
+        journal
+            .begin_attached(genesis, record_len)
+            .unwrap()
+            .submit(record, false)
+            .unwrap();
+        assert_eq!(journal.stats().appends, appends_before + 1);
+        assert_eq!(journal.state().unwrap().tail(), first);
     }
 
     #[test]

--- a/src/journal/reader.rs
+++ b/src/journal/reader.rs
@@ -93,7 +93,7 @@ where
 /// state. A header-only format-3 file remains eligible for the writer's
 /// in-place format-4 header upgrade.
 pub(crate) fn preflight_writable_wal(path: &Path) -> Result<()> {
-    let records = StreamingRecords::open(path)?;
+    let mut records = StreamingRecords::open(path)?;
     if records.header.version == LEGACY_FORMAT_VERSION
         && records.file_len != LEGACY_FILE_HEADER_SIZE as u64
     {
@@ -101,6 +101,9 @@ pub(crate) fn preflight_writable_wal(path: &Path) -> Result<()> {
             context: "nonempty WAL format 3 is replay-only; checkpoint it with a format-3 Holt binary before v4 writes",
             record_offset: 0,
         });
+    }
+    if records.header.checkpoint_anchor.is_some() {
+        while records.next_record()?.is_some() {}
     }
     Ok(())
 }
@@ -136,6 +139,7 @@ where
                         record_offset: offset as u64,
                     });
                 }
+                validate_record_mode(&header, &r.op, offset as u64)?;
 
                 // Flatten both batch variants transparently: the callback sees
                 // the inner primitive ops with derived seqs (`base + i`). The
@@ -584,6 +588,7 @@ impl StreamingRecords {
         self.reader.read_exact(&mut bytes[RECORD_HEADER_SIZE..])?;
         let decoded =
             decode_record(&bytes).map_err(|error| patch_offset(error, record_offset as usize))?;
+        validate_record_mode(&self.header, &decoded.op, record_offset)?;
         #[cfg(test)]
         STREAMING_RECORDS_DECODED.with(|count| count.set(count.get() + 1));
         self.offset = self
@@ -595,6 +600,16 @@ impl StreamingRecords {
             offset: record_offset,
         }))
     }
+}
+
+fn validate_record_mode(header: &FileHeader, op: &WalOp, record_offset: u64) -> Result<()> {
+    if header.checkpoint_anchor.is_some() && !matches!(op, WalOp::DbBatchWithEnvelope { .. }) {
+        return Err(Error::ReplaySanityFailed {
+            context: "initialized attached WAL contains an ordinary record",
+            record_offset,
+        });
+    }
+    Ok(())
 }
 
 fn is_torn_tail(context: &'static str) -> bool {
@@ -630,6 +645,9 @@ mod attached_streaming_tests {
     };
     use crate::journal::writer::WalWriter;
 
+    const ORDINARY_RECORD_IN_ATTACHED_WAL: &str =
+        "initialized attached WAL contains an ordinary record";
+
     fn anchor(sequence: u64) -> JournalAnchor {
         let mut digest = [0u8; 32];
         digest[..8].copy_from_slice(&sequence.to_le_bytes());
@@ -661,6 +679,176 @@ mod attached_streaming_tests {
         }
         writer.flush().unwrap();
         (dir, path, offsets)
+    }
+
+    fn write_initialized_ordinary_record(op: &WalOp) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("journal.wal");
+        let mut writer = WalWriter::create(&path, 0).unwrap();
+        writer.append(op, 1).unwrap();
+        writer.flush().unwrap();
+        writer.persist_checkpoint_anchor(anchor(0)).unwrap();
+        drop(writer);
+        (dir, path)
+    }
+
+    fn assert_ordinary_record_rejected<T>(result: Result<T>, record_offset: u64) {
+        match result {
+            Err(Error::ReplaySanityFailed {
+                context: ORDINARY_RECORD_IN_ATTACHED_WAL,
+                record_offset: actual,
+            }) if actual == record_offset => {}
+            Err(error) => panic!("expected ordinary-record rejection, got {error:?}"),
+            Ok(_) => panic!("expected ordinary-record rejection"),
+        }
+    }
+
+    #[test]
+    fn initialized_wal_rejects_insert_before_each_reader_accepts_it() {
+        let insert = WalOp::Insert {
+            tree_id: 0,
+            key: b"key".to_vec(),
+            value: b"value".to_vec(),
+        };
+        let (_dir, path) = write_initialized_ordinary_record(&insert);
+        let bytes = fs::read(&path).unwrap();
+        let record_offset = FILE_HEADER_SIZE as u64;
+
+        let raw_callbacks = std::cell::Cell::new(0usize);
+        let mut raw_callback = |_: &WalOp, _: u64, _: u64| {
+            raw_callbacks.set(raw_callbacks.get() + 1);
+            Ok(())
+        };
+        assert_ordinary_record_rejected(replay_bytes(&bytes, &mut raw_callback), record_offset);
+        assert_eq!(raw_callbacks.get(), 0);
+
+        let file_callbacks = std::cell::Cell::new(0usize);
+        assert_ordinary_record_rejected(
+            replay(&path, |_, _, _| {
+                file_callbacks.set(file_callbacks.get() + 1);
+                Ok(())
+            }),
+            record_offset,
+        );
+        assert_eq!(file_callbacks.get(), 0);
+
+        assert_ordinary_record_rejected(validate_attached_journal(&path), record_offset);
+        assert_ordinary_record_rejected(
+            scan_attached_envelope_page(&path, anchor(0), 1, usize::MAX),
+            record_offset,
+        );
+        assert_ordinary_record_rejected(
+            scan_attached_envelope_page_from(&path, anchor(0), 1, usize::MAX, None),
+            record_offset,
+        );
+        assert_ordinary_record_rejected(scan_attached_envelopes(&path), record_offset);
+        assert_ordinary_record_rejected(preflight_writable_wal(&path), record_offset);
+    }
+
+    #[test]
+    fn initialized_wal_rejects_an_ordinary_batch_before_flattening() {
+        let batch = WalOp::Batch {
+            ops: vec![WalOp::Insert {
+                tree_id: 0,
+                key: b"key".to_vec(),
+                value: b"value".to_vec(),
+            }],
+        };
+        let (_dir, path) = write_initialized_ordinary_record(&batch);
+        let bytes = fs::read(&path).unwrap();
+        let callbacks = std::cell::Cell::new(0usize);
+        let mut callback = |_: &WalOp, _: u64, _: u64| {
+            callbacks.set(callbacks.get() + 1);
+            Ok(())
+        };
+
+        assert_ordinary_record_rejected(
+            replay_bytes(&bytes, &mut callback),
+            FILE_HEADER_SIZE as u64,
+        );
+        assert_eq!(callbacks.get(), 0);
+        assert_ordinary_record_rejected(preflight_writable_wal(&path), FILE_HEADER_SIZE as u64);
+    }
+
+    #[test]
+    fn uninitialized_wal_keeps_ordinary_records_valid() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("journal.wal");
+        let mut writer = WalWriter::create(&path, 0).unwrap();
+        writer
+            .append(
+                &WalOp::Insert {
+                    tree_id: 0,
+                    key: b"first".to_vec(),
+                    value: b"value".to_vec(),
+                },
+                1,
+            )
+            .unwrap();
+        writer
+            .append(
+                &WalOp::Batch {
+                    ops: vec![WalOp::Insert {
+                        tree_id: 0,
+                        key: b"second".to_vec(),
+                        value: b"value".to_vec(),
+                    }],
+                },
+                2,
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+
+        preflight_writable_wal(&path).unwrap();
+        let mut callbacks = 0usize;
+        let (_, stats) = replay(&path, |_, _, _| {
+            callbacks += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(callbacks, 2);
+        assert_eq!(stats.records_seen, 2);
+        assert_eq!(validate_attached_journal(&path).unwrap(), None);
+        assert!(matches!(
+            scan_attached_envelope_page(&path, anchor(0), 1, usize::MAX),
+            Err(Error::JournalStreamUnavailable {
+                reason: "stream has not been initialized",
+            })
+        ));
+        let scan = scan_attached_envelopes(&path).unwrap();
+        assert_eq!(scan.checkpoint, None);
+        assert_eq!(scan.tail, None);
+        assert!(scan.envelopes.is_empty());
+    }
+
+    #[test]
+    fn initialized_wal_keeps_attached_records_valid() {
+        let (_dir, path, _offsets) = write_envelopes(1, 16);
+
+        preflight_writable_wal(&path).unwrap();
+        let state = validate_attached_journal(&path).unwrap().unwrap();
+        assert_eq!(state.checkpoint(), anchor(0));
+        assert_eq!(state.tail(), anchor(1));
+
+        let mut callbacks = 0usize;
+        let (_, stats) = replay(&path, |_, _, _| {
+            callbacks += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(callbacks, 0);
+        assert_eq!(stats.records_seen, 1);
+
+        let page = scan_attached_envelope_page(&path, anchor(0), 1, usize::MAX).unwrap();
+        assert_eq!(page.envelopes().len(), 1);
+        assert_eq!(page.next(), anchor(1));
+        assert!(!page.has_more());
+
+        let scan = scan_attached_envelopes(&path).unwrap();
+        assert_eq!(scan.checkpoint, Some(anchor(0)));
+        assert_eq!(scan.tail, Some(anchor(1)));
+        assert_eq!(scan.envelopes.len(), 1);
     }
 
     #[test]

--- a/tools/soak/Cargo.lock
+++ b/tools/soak/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "holt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",


### PR DESCRIPTION
## What changed

Holt 0.9.0 could persist the first journal anchor slot, fail while writing the second slot, and then accept ordinary writes. A later reopen treated the stream as initialized even though those mutations had no recovery envelope.

This change fences ordinary writes before the first anchor slot can become durable. An interrupted initialization remains incomplete and accepts only an exact retry with the same genesis anchor. State reads, scans, and attached writes fail until the retry repairs both slots. Open, replay, and recovery scans reject an ordinary logical record after an initialized attached-stream anchor.

Attached submission now carries encoder-sealed bytes and its owned envelope into group commit. The commit path no longer decodes and copies the record before queueing it. Replay and recovery scans still decode records and verify CRCs. The branch also adds a permanent journal-path benchmark and prepares version 0.9.1.

## Test plan

- `cargo fmt --all -- --check`
- `cargo build --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-features --lib --tests --examples --locked`
- `cargo test --workspace --all-features --doc --locked`
- workspace, benchmark, and soak-tool clippy checks with warnings denied
- rustdoc with warnings denied
- 512-case codec and workspace property tests
- four public examples and short `normal` / `db-normal` soak runs
- `cargo publish --dry-run --locked`

Regression tests cover failures before zero or one durable anchor slots, same-genesis repair, different-genesis rejection, and a checkpoint during incomplete initialization. They also cover mixed `Insert` and `Batch` records across open, replay, streaming validation, and recovery scans. Codec tests compare sealed records with the generic encoder and exercise varied payloads and operations.

The local host lacks rustup/nightly, `cargo-deny`, `cargo-llvm-cov`, and the Linux io_uring environment. GitHub Actions remains responsible for those platform, fuzz, coverage, and dependency-policy gates.

## Compatibility and recovery boundary

Holt 0.9.1 keeps the format-4 WAL, public journal API, record bytes, CRC replay checks, and checkpoint protocol. Existing 0.9.0 stores need no format migration.

If Holt 0.9.0 returned an initialization error and then accepted ordinary writes, 0.9.1 rejects mixed records that remain in the WAL. If 0.9.0 checkpointed those writes, the WAL suffix is gone. Holt cannot detect or reconstruct that recovery gap. Rebuild such a store from authoritative application state before using the attached stream.

## Performance evidence

A controlled same-host A/B found no measurable ordinary-write regression from the atomic fence. Median latency changed by -1.26% for puts and -0.12% for the mixed workload. Both confidence intervals crossed zero.

Removing the submission-time decode reduced median `sync: false` attached-commit latency by 12.81% with 128-byte payloads and 27.50% with 4 KiB payloads. Median `sync: true` latency changed by -0.17%, where forced sync dominates.

A fresh run of the permanent async benchmark measured ordinary commits at 758.92 to 827.72 ns. Attached commits measured 838.19 to 855.25 ns at 128 bytes and 1.8607 to 1.9227 us at 4 KiB.

## Related

Follow-up to #51. This maintainer-directed Holt 0.9.1 hotfix has no linked issue.
