### PR TITLE
Add optimistic longest-prefix record lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+### Added
+
+- Added `Tree::longest_prefix_record` and
+  `View::longest_prefix_record`. One optimistic ART traversal returns the
+  longest live ancestor key together with its value and record version. This
+  release slice exposes the operation through the Rust API; C and Node
+  bindings are unchanged.
+
+### Changed
+
+- Added an atomic zero-debt check for deferred WAL state so read-only
+  longest-prefix lookups avoid the write-delta mutex in steady state.
+
 ## [0.9.1] — 2026-08-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ assert!(ok);
 
 let deleted = tree.delete_if_version(b"bucket/a.jpg", record.version)?;
 assert!(!deleted); // version changed above
+
+tree.put(b"bucket", b"bucket-meta")?;
+tree.put(b"bucket/a", b"prefix-meta")?;
+let prefix = tree
+    .longest_prefix_record(b"bucket/a/images/01.jpg")?
+    .unwrap();
+assert_eq!(prefix.key, b"bucket/a");
+assert_eq!(prefix.value, b"prefix-meta");
 ```
 
 Prefix listing:

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -46,3 +46,13 @@ path = "stress.rs"
 name = "concurrent"
 harness = false
 path = "concurrent.rs"
+
+[[bench]]
+name = "longest_prefix"
+harness = false
+path = "longest_prefix.rs"
+
+[[bench]]
+name = "longest_prefix_concurrent"
+harness = false
+path = "longest_prefix_concurrent.rs"

--- a/benches/LONGEST_PREFIX_RESULTS.md
+++ b/benches/LONGEST_PREFIX_RESULTS.md
@@ -1,0 +1,46 @@
+# Longest-Prefix Results
+
+Recorded on 2026-08-18 with:
+
+- Holt based on `v0.9.1`;
+- Rust 1.97.1;
+- Intel Xeon Platinum 8457C, 2 sockets, 90 physical cores;
+- release profile, in-memory tree;
+- OrbitKV-shaped keys with 33 bytes per prefix chunk;
+- 64 distractor paths per case.
+
+The baseline performs exact `get_record` calls from the deepest chunk boundary
+to the shallowest. Native uses one `longest_prefix_record` ART traversal.
+
+## Single Thread
+
+Criterion `--quick` median estimates:
+
+| Chunks | Scenario | Native | Exact fallback | Speedup |
+|---:|---|---:|---:|---:|
+| 4 | deep hit | 94.8 ns | 301 ns | 3.18x |
+| 16 | half hit | 99.8 ns | 5.48 us | 54.9x |
+| 64 | shallow hit | 93.0 ns | 95.5 us | 1,027x |
+| 64 | miss | 46.8 ns | 2.36 us | 50.5x |
+| 256 | deep hit | 428 ns | 11.8 us | 27.6x |
+| 256 | shallow hit | 162 ns | 1.47 ms | 9,071x |
+| 256 | miss | 121 ns | 38.8 us | 322x |
+
+The 256-chunk tier asserts that the benchmark tree contains at least two Holt
+blobs, so those rows include cross-blob traversal.
+
+## Concurrent
+
+The concurrent harness uses a 64-chunk shallow hit and 100,000 operations per
+thread. It is pinned with `taskset` to eight physical cores on NUMA node 0:
+
+| Threads | Native ops/s | Exact fallback ops/s | Speedup |
+|---:|---:|---:|---:|
+| 1 | 14,167,854 | 10,864 | 1,304x |
+| 2 | 26,010,681 | 21,419 | 1,214x |
+| 4 | 55,808,087 | 43,019 | 1,297x |
+| 8 | 107,395,294 | 79,579 | 1,350x |
+
+These are metadata lookup microbenchmarks, not end-to-end inference results.
+They exclude Capsule payload I/O, SGLang export/hydration, GPU transfer, and
+attention execution.

--- a/benches/README.md
+++ b/benches/README.md
@@ -84,6 +84,16 @@ cargo bench --manifest-path benches/Cargo.toml --bench main -- _create_delete
 cargo bench --manifest-path benches/Cargo.toml --bench main -- _rename
 cargo bench --manifest-path benches/Cargo.toml --bench main -- _metadata_mix
 
+# Longest-prefix lookup versus deepest-to-shallowest exact lookup.
+cargo bench --manifest-path benches/Cargo.toml \
+  --no-default-features --bench longest_prefix -- --quick --noplot
+
+# Multi-threaded OrbitKV-shaped longest-prefix lookup.
+HOLT_LPM_OPS_PER_THREAD=100000 \
+taskset -c 0,2,4,6,8,10,12,14 \
+cargo bench --manifest-path benches/Cargo.toml \
+  --no-default-features --bench longest_prefix_concurrent
+
 # Large-tree stress harness: fixed 20M preload, million-scale ops.
 # Run this explicitly; it is intentionally not part of Criterion.
 HOLT_STRESS_N=20000000 \

--- a/benches/longest_prefix.rs
+++ b/benches/longest_prefix.rs
@@ -1,0 +1,190 @@
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{
+    BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
+use holt::{PrefixRecord, Tree, TreeConfig, View};
+
+const CHUNK_BYTES: usize = 33;
+const VALUE: &[u8] = b"orbitkv-capsule-manifest";
+
+struct Case {
+    tree: Tree,
+    view: View,
+    query_chunks: usize,
+    query: Vec<u8>,
+    candidates: Vec<Vec<u8>>,
+    expected: Option<Vec<u8>>,
+}
+
+fn capsule_key(chunk_count: usize, salt: u8) -> Vec<u8> {
+    let mut key = b"orbitkv/capsule/v1\0tenant/model/plan".to_vec();
+    key.reserve(chunk_count * CHUNK_BYTES);
+    for chunk in 0..chunk_count {
+        key.push(1);
+        for byte in 0..32 {
+            key.push(
+                salt.wrapping_add(
+                    u8::try_from((chunk * 37 + byte * 13) % 251)
+                        .expect("modulo result fits in u8"),
+                ),
+            );
+        }
+    }
+    key
+}
+
+fn build_case(query_chunks: usize, match_chunks: Option<usize>) -> Case {
+    let tree = Tree::open(TreeConfig::memory()).expect("open benchmark tree");
+    let query = capsule_key(query_chunks, 7);
+    let candidates = (1..=query_chunks)
+        .rev()
+        .map(|chunks| capsule_key(chunks, 7))
+        .collect::<Vec<_>>();
+    let expected = match_chunks.map(|chunks| capsule_key(chunks, 7));
+    if let Some(key) = &expected {
+        tree.put(key, VALUE).expect("publish matching capsule");
+    }
+
+    for salt in 32..96 {
+        tree.put(&capsule_key(query_chunks, salt), VALUE)
+            .expect("publish distractor capsule");
+    }
+    let view = tree.snapshot(b"").expect("capture benchmark view").view().clone();
+    Case {
+        tree,
+        view,
+        query_chunks,
+        query,
+        candidates,
+        expected,
+    }
+}
+
+fn fallback_tree(tree: &Tree, candidates: &[Vec<u8>]) -> Option<PrefixRecord> {
+    candidates.iter().find_map(|key| {
+        tree.get_record(key)
+            .expect("fallback point lookup")
+            .map(|record| PrefixRecord {
+                key: key.clone(),
+                value: record.value,
+                version: record.version,
+            })
+    })
+}
+
+fn fallback_view(view: &View, candidates: &[Vec<u8>]) -> Option<PrefixRecord> {
+    candidates.iter().find_map(|key| {
+        view.get_record(key)
+            .expect("fallback point lookup")
+            .map(|record| PrefixRecord {
+                key: key.clone(),
+                value: record.value,
+                version: record.version,
+            })
+    })
+}
+
+fn assert_case(case: &Case) {
+    if case.query_chunks == 256 {
+        assert!(
+            case.tree
+                .stats()
+                .expect("inspect benchmark tree")
+                .blob_count
+                >= 2,
+            "the 256-chunk tier must exercise cross-blob lookup"
+        );
+    }
+    let native = case
+        .tree
+        .longest_prefix_record(&case.query)
+        .expect("native tree lookup");
+    let fallback = fallback_tree(&case.tree, &case.candidates);
+    assert_eq!(native, fallback);
+    assert_eq!(
+        native.as_ref().map(|record| &record.key),
+        case.expected.as_ref()
+    );
+
+    let native_view = case
+        .view
+        .longest_prefix_record(&case.query)
+        .expect("native view lookup");
+    let fallback_view = fallback_view(&case.view, &case.candidates);
+    assert_eq!(native_view, fallback_view);
+}
+
+fn benchmark_longest_prefix(c: &mut Criterion) {
+    for query_chunks in [4, 16, 64, 256] {
+        for (scenario, match_chunks) in [
+            ("deep_hit", Some(query_chunks)),
+            ("half_hit", Some((query_chunks / 2).max(1))),
+            ("shallow_hit", Some(1)),
+            ("miss", None),
+        ] {
+            let case = build_case(query_chunks, match_chunks);
+            assert_case(&case);
+            let mut group = c.benchmark_group(format!("lpm/{scenario}"));
+            group.measurement_time(Duration::from_secs(3));
+            group.sample_size(50);
+            group.throughput(Throughput::Elements(1));
+
+            group.bench_with_input(
+                BenchmarkId::new("tree_native", query_chunks),
+                &case,
+                |b, case| {
+                    b.iter(|| {
+                        black_box(
+                            case.tree
+                                .longest_prefix_record(black_box(&case.query))
+                                .expect("native tree lookup"),
+                        )
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("tree_fallback", query_chunks),
+                &case,
+                |b, case| {
+                    b.iter(|| {
+                        black_box(fallback_tree(
+                            black_box(&case.tree),
+                            black_box(&case.candidates),
+                        ))
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("view_native", query_chunks),
+                &case,
+                |b, case| {
+                    b.iter(|| {
+                        black_box(
+                            case.view
+                                .longest_prefix_record(black_box(&case.query))
+                                .expect("native view lookup"),
+                        )
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("view_fallback", query_chunks),
+                &case,
+                |b, case| {
+                    b.iter(|| {
+                        black_box(fallback_view(
+                            black_box(&case.view),
+                            black_box(&case.candidates),
+                        ))
+                    });
+                },
+            );
+            group.finish();
+        }
+    }
+}
+
+criterion_group!(benches, benchmark_longest_prefix);
+criterion_main!(benches);

--- a/benches/longest_prefix_concurrent.rs
+++ b/benches/longest_prefix_concurrent.rs
@@ -1,0 +1,125 @@
+use std::hint::black_box;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use holt::{Tree, TreeConfig};
+
+const CHUNK_BYTES: usize = 33;
+const VALUE: &[u8] = b"orbitkv-capsule-manifest";
+
+fn capsule_key(chunk_count: usize) -> Vec<u8> {
+    let mut key = b"orbitkv/capsule/v1\0tenant/model/plan".to_vec();
+    key.reserve(chunk_count * CHUNK_BYTES);
+    for chunk in 0..chunk_count {
+        key.push(1);
+        for byte in 0..32 {
+            key.push(
+                u8::try_from((chunk * 37 + byte * 13) % 251)
+                    .expect("modulo result fits in u8"),
+            );
+        }
+    }
+    key
+}
+
+fn fallback(tree: &Tree, candidates: &[Vec<u8>]) {
+    let record = candidates.iter().find_map(|key| {
+        tree.get_record(key)
+            .expect("fallback point lookup")
+            .map(|record| (key, record))
+    });
+    black_box(record);
+}
+
+fn measure(
+    tree: &Tree,
+    query: &[u8],
+    candidates: &[Vec<u8>],
+    threads: usize,
+    native: bool,
+    operations_per_thread: usize,
+) -> f64 {
+    let barrier = Arc::new(Barrier::new(threads + 1));
+    let handles = (0..threads)
+        .map(|_| {
+            let tree = tree.clone();
+            let query = query.to_vec();
+            let candidates = candidates.to_vec();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..operations_per_thread {
+                    if native {
+                        black_box(
+                            tree.longest_prefix_record(black_box(&query))
+                                .expect("native lookup"),
+                        );
+                    } else {
+                        fallback(&tree, black_box(&candidates));
+                    }
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    barrier.wait();
+    let start = Instant::now();
+    for handle in handles {
+        handle.join().expect("benchmark worker");
+    }
+    let elapsed = start.elapsed();
+    let total = threads * operations_per_thread;
+    total as f64 / elapsed.as_secs_f64()
+}
+
+fn main() {
+    let query_chunks = 64;
+    let tree = Tree::open(TreeConfig::memory()).expect("open benchmark tree");
+    let query = capsule_key(query_chunks);
+    tree.put(&capsule_key(1), VALUE)
+        .expect("publish shallow capsule");
+    let candidates = (1..=query_chunks)
+        .rev()
+        .map(capsule_key)
+        .collect::<Vec<_>>();
+
+    for _ in 0..10_000 {
+        black_box(
+            tree.longest_prefix_record(&query)
+                .expect("native warmup lookup"),
+        );
+    }
+
+    let operations_per_thread = std::env::var("HOLT_LPM_OPS_PER_THREAD")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(50_000);
+    println!(
+        "shape=orbitkv chunks={query_chunks} scenario=shallow_hit ops_per_thread={operations_per_thread}"
+    );
+    println!("threads,native_ops_s,fallback_ops_s,speedup");
+    for threads in [1, 2, 4, 8] {
+        let native = measure(
+            &tree,
+            &query,
+            &candidates,
+            threads,
+            true,
+            operations_per_thread,
+        );
+        thread::sleep(Duration::from_millis(100));
+        let fallback = measure(
+            &tree,
+            &query,
+            &candidates,
+            threads,
+            false,
+            operations_per_thread,
+        );
+        println!(
+            "{threads},{native:.0},{fallback:.0},{:.2}",
+            native / fallback
+        );
+    }
+}

--- a/src/api/atomic.rs
+++ b/src/api/atomic.rs
@@ -22,6 +22,17 @@ pub struct Record {
     pub version: RecordVersion,
 }
 
+/// Longest-prefix lookup result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrefixRecord {
+    /// Longest live user key that prefixes the query.
+    pub key: Vec<u8>,
+    /// Value stored under `key`.
+    pub value: Vec<u8>,
+    /// Current compare-and-set token for the matching record.
+    pub version: RecordVersion,
+}
+
 /// Opaque per-record version returned by
 /// [`Tree::get_version`](super::tree::Tree::get_version).
 ///

--- a/src/api/tree.rs
+++ b/src/api/tree.rs
@@ -47,7 +47,7 @@ use crate::store::{
 
 const AUTO_GC_BATCH_SIZE: usize = 256;
 
-use super::atomic::{AtomicBatch, BatchOp, Record, RecordVersion};
+use super::atomic::{AtomicBatch, BatchOp, PrefixRecord, Record, RecordVersion};
 
 const ONLINE_COMPACT_BLOB_BUDGET: usize = 256;
 const ONLINE_MERGE_PARENT_BUDGET: usize = 256;
@@ -806,6 +806,37 @@ impl Tree {
     pub fn get_record(&self, key: &[u8]) -> Result<Option<Record>> {
         self.ensure_live()?;
         self.lookup_record_unlocked(key)
+    }
+
+    /// Return the longest live key that is a byte prefix of `query`.
+    ///
+    /// The key, value, and conditional-write version are returned from one
+    /// linearized tree state. Deferred WAL writes are merged before the ART
+    /// path walk. Concurrent blob mutations are detected by optimistic
+    /// version validation and restart from the root; readers do not fence one
+    /// another.
+    ///
+    /// This differs from [`Self::scan`]: the matched record may be any
+    /// ancestor key of `query`, and the ART is traversed once rather than
+    /// issuing one exact lookup for every candidate prefix length.
+    pub fn longest_prefix_record(&self, query: &[u8]) -> Result<Option<PrefixRecord>> {
+        loop {
+            self.ensure_live()?;
+            if self.store.has_any_write_delta() {
+                self.flush_write_delta_for_tree()?;
+            }
+            let hit = engine::longest_prefix_multi(&self.store, &self.root_pin, query, true)?;
+            if self.store.has_any_write_delta()
+                && self.store.write_delta_count_for_tree(self.tree_id) != 0
+            {
+                continue;
+            }
+            return Ok(hit.map(|hit| PrefixRecord {
+                key: hit.key,
+                value: hit.value,
+                version: RecordVersion::new(hit.seq),
+            }));
+        }
     }
 
     /// Return the current version token for `key`.

--- a/src/api/view.rs
+++ b/src/api/view.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use super::atomic::{Record, RecordVersion};
+use super::atomic::{PrefixRecord, Record, RecordVersion};
 use super::errors::{Error, Result};
 use super::tree::{count_scan_limit, prefix_count_from_seen};
 use crate::concurrency::Gate;
@@ -80,6 +80,22 @@ impl View {
     pub fn get_record(&self, key: &[u8]) -> Result<Option<Record>> {
         self.ensure_in_scope(key)?;
         self.lookup_record(key)
+    }
+
+    /// Return the longest captured key that is a byte prefix of `query`.
+    ///
+    /// The match is restricted to this view's scope and comes from the same
+    /// immutable snapshot as every other view read.
+    pub fn longest_prefix_record(&self, query: &[u8]) -> Result<Option<PrefixRecord>> {
+        self.ensure_in_scope(query)?;
+        engine::longest_prefix_multi(&self.store, &self.root_pin, query, false).map(|hit| {
+            hit.filter(|hit| hit.key.starts_with(&self.scope))
+                .map(|hit| PrefixRecord {
+                    key: hit.key,
+                    value: hit.value,
+                    version: RecordVersion::new(hit.seq),
+                })
+        })
     }
 
     /// Return the captured version token for `key`.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -36,5 +36,5 @@ pub use walker::{
 };
 pub(crate) use walker::{
     collect_blob_children_from_frame, fresh_blob_guid, insert_multi_batch_conditional,
-    lookup_multi_with_snapshot, InsertBatchItem, PrefixListCache, SearchKey,
+    longest_prefix_multi, lookup_multi_with_snapshot, InsertBatchItem, PrefixListCache, SearchKey,
 };

--- a/src/engine/walker/lookup.rs
+++ b/src/engine/walker/lookup.rs
@@ -24,7 +24,7 @@ use crate::store::{
 use super::cast;
 use super::readers::{child_offset, resolve_typed, root_child_offset};
 use super::route::{pin_route_parent, validate_route_edge};
-use super::types::{BlobNodeCrossing, LookupHit, LookupResult};
+use super::types::{BlobNodeCrossing, LongestPrefixHit, LookupHit, LookupResult};
 use super::SearchKey;
 
 /// Look up `key` in the tree whose root is the encoded offset
@@ -123,6 +123,428 @@ where
     F: FnMut(LookupHit<'_>) -> R,
 {
     lookup_multi_with_gc_policy(bm, root_pin, route_cache, key, &mut consume, false)
+}
+
+/// Return the longest live user key that prefixes `query`.
+///
+/// Unlike exact lookup, this path intentionally pins every crossed blob
+/// because a negative exact-read-index answer cannot prove that no shorter
+/// terminator child matched earlier in the query path. Every visited blob
+/// version is validated before publishing the result; concurrent mutation
+/// restarts the walk from the root.
+pub(crate) fn longest_prefix_multi(
+    bm: &BufferManager,
+    root_pin: &Arc<CachedBlob>,
+    query: &[u8],
+    restart_on_gc: bool,
+) -> Result<Option<LongestPrefixHit>> {
+    'restart: loop {
+        let mut child_pin = None;
+        let mut depth = 0;
+        let mut state = LongestPrefixState {
+            bm,
+            key: SearchKey::user(query),
+            best: None,
+            root_version: None,
+            visited: Vec::new(),
+            unstable: false,
+            gc_epoch: restart_on_gc.then(|| bm.gc_read_epoch()),
+        };
+        loop {
+            let pin = child_pin.as_ref().unwrap_or(root_pin);
+            let version = pin.content_version();
+            let guard = pin.read_optimistic();
+            let frame = BlobFrameRef::wrap(guard.as_slice());
+            let root_slot = frame.header().root_slot;
+            let step = root_child_offset(root_slot, "longest_prefix: root child")
+                .and_then(|root| longest_prefix_at(frame, root, depth, &mut state));
+            if state.unstable || !guard.validate() || !pin.validate_content_version(version) {
+                bm.note_optimistic_restart();
+                continue 'restart;
+            }
+            let step = step?;
+            drop(guard);
+            if let Some(pin) = child_pin.take() {
+                state.visited.push((pin, version));
+            } else {
+                state.root_version = Some(version);
+            }
+            match step {
+                LongestPrefixStep::Done => {
+                    if state
+                        .root_version
+                        .is_some_and(|root_version| root_pin.validate_content_version(root_version))
+                        && state.visited.iter().all(|(visited_pin, visited_version)| {
+                            visited_pin.validate_content_version(*visited_version)
+                        })
+                    {
+                        return Ok(state.best);
+                    }
+                    bm.note_optimistic_restart();
+                    continue 'restart;
+                }
+                LongestPrefixStep::Crossing(crossing) => {
+                    let Some(pin) = pin_longest_prefix_child(&mut state, crossing.child_guid)?
+                    else {
+                        bm.note_optimistic_restart();
+                        continue 'restart;
+                    };
+                    child_pin = Some(pin);
+                    depth = crossing.child_depth;
+                }
+            }
+        }
+    }
+}
+
+struct LongestPrefixState<'bm, 'key> {
+    bm: &'bm BufferManager,
+    key: SearchKey<'key>,
+    best: Option<LongestPrefixHit>,
+    root_version: Option<u64>,
+    visited: Vec<(Arc<CachedBlob>, u64)>,
+    unstable: bool,
+    gc_epoch: Option<u64>,
+}
+
+enum LongestPrefixStep {
+    Done,
+    Crossing(BlobNodeCrossing),
+}
+
+fn longest_prefix_at(
+    frame: BlobFrameRef<'_>,
+    mut off: u32,
+    mut depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<LongestPrefixStep> {
+    loop {
+        let (ntype, body) = resolve_typed(frame, off)?;
+        match ntype {
+            NodeType::Invalid => {
+                return Err(Error::node_corrupt(
+                    "walker::longest_prefix: hit NodeType::Invalid",
+                ));
+            }
+            NodeType::EmptyRoot => return Ok(LongestPrefixStep::Done),
+            NodeType::Leaf => {
+                update_longest_prefix_leaf(body, state)?;
+                return Ok(LongestPrefixStep::Done);
+            }
+            NodeType::Prefix => {
+                let Some((next, next_depth)) =
+                    longest_prefix_through_prefix(body, state.key, depth)?
+                else {
+                    return Ok(LongestPrefixStep::Done);
+                };
+                off = next;
+                depth = next_depth;
+            }
+            NodeType::Node4 => {
+                let Some(next) = longest_prefix_through_node4(frame, body, depth, state)? else {
+                    return Ok(LongestPrefixStep::Done);
+                };
+                off = next;
+                depth += 1;
+            }
+            NodeType::Node16 => {
+                let Some(next) = longest_prefix_through_node16(frame, body, depth, state)? else {
+                    return Ok(LongestPrefixStep::Done);
+                };
+                off = next;
+                depth += 1;
+            }
+            NodeType::Node48 => {
+                let Some(next) = longest_prefix_through_node48(frame, body, depth, state)? else {
+                    return Ok(LongestPrefixStep::Done);
+                };
+                off = next;
+                depth += 1;
+            }
+            NodeType::Node256 => {
+                let Some(next) = longest_prefix_through_node256(frame, body, depth, state)? else {
+                    return Ok(LongestPrefixStep::Done);
+                };
+                off = next;
+                depth += 1;
+            }
+            NodeType::Blob => {
+                let blob = cast::<BlobNode>(body);
+                let prefix_len = usize::from(blob.prefix_len);
+                if prefix_len > BLOB_MAX_INLINE
+                    || !state.key.range_eq(depth, &blob.bytes[..prefix_len])
+                {
+                    return Ok(LongestPrefixStep::Done);
+                }
+                return Ok(LongestPrefixStep::Crossing(BlobNodeCrossing {
+                    child_guid: blob.child_blob_guid,
+                    child_depth: depth + prefix_len,
+                }));
+            }
+        }
+    }
+}
+
+fn longest_prefix_through_prefix(
+    body: &[u8],
+    key: SearchKey<'_>,
+    depth: usize,
+) -> Result<Option<(u32, usize)>> {
+    let prefix = cast::<Prefix>(body);
+    let prefix_len = usize::from(prefix.prefix_len);
+    if prefix_len > prefix.bytes.len() {
+        return Err(Error::node_corrupt(
+            "longest_prefix: prefix_len exceeds inline buffer",
+        ));
+    }
+    Ok(key
+        .range_eq(depth, &prefix.bytes[..prefix_len])
+        .then(|| (child_offset(prefix.child as u16), depth + prefix_len)))
+}
+
+fn longest_prefix_through_node4(
+    frame: BlobFrameRef<'_>,
+    body: &[u8],
+    depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<Option<u32>> {
+    let node = cast::<Node4>(body);
+    let count = usize::from(node.count).min(4);
+    update_inner_terminator_candidate(
+        frame,
+        node.keys[..count].iter().zip(&node.children),
+        depth,
+        state,
+    )?;
+    let Some(byte) = query_byte_at(state.key, depth) else {
+        return Ok(None);
+    };
+    Ok(node.keys[..count]
+        .iter()
+        .position(|candidate| *candidate == byte)
+        .map(|index| child_offset(node.children[index])))
+}
+
+fn longest_prefix_through_node16(
+    frame: BlobFrameRef<'_>,
+    body: &[u8],
+    depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<Option<u32>> {
+    let node = cast::<Node16>(body);
+    let count = usize::from(node.count).min(16);
+    update_inner_terminator_candidate(
+        frame,
+        node.keys[..count].iter().zip(&node.children),
+        depth,
+        state,
+    )?;
+    Ok(query_byte_at(state.key, depth)
+        .and_then(|byte| simd::node16_find_byte(&node.keys, node.count, byte))
+        .map(|index| child_offset(node.children[usize::from(index)])))
+}
+
+fn longest_prefix_through_node48(
+    frame: BlobFrameRef<'_>,
+    body: &[u8],
+    depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<Option<u32>> {
+    let node = cast::<Node48>(body);
+    update_indexed_terminator_candidate(frame, node.index[0], &node.children, depth, state)?;
+    let Some(index) = query_byte_at(state.key, depth).map(|byte| node.index[usize::from(byte)])
+    else {
+        return Ok(None);
+    };
+    if index == 0 {
+        return Ok(None);
+    }
+    let child_index = usize::from(index - 1);
+    if child_index >= node.children.len() {
+        return Err(Error::node_corrupt(
+            "longest_prefix: node48 index out of range",
+        ));
+    }
+    Ok(Some(child_offset(node.children[child_index])))
+}
+
+fn longest_prefix_through_node256(
+    frame: BlobFrameRef<'_>,
+    body: &[u8],
+    depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<Option<u32>> {
+    let node = cast::<Node256>(body);
+    if node.children[0] != 0 {
+        update_terminator_candidate_at(frame, child_offset(node.children[0]), depth, state)?;
+    }
+    Ok(query_byte_at(state.key, depth).and_then(|byte| {
+        let child = node.children[usize::from(byte)];
+        (child != 0).then(|| child_offset(child))
+    }))
+}
+
+fn query_byte_at(key: SearchKey<'_>, depth: usize) -> Option<u8> {
+    key.user_bytes().and_then(|bytes| bytes.get(depth)).copied()
+}
+
+fn update_inner_terminator_candidate<'a>(
+    frame: BlobFrameRef<'_>,
+    children: impl Iterator<Item = (&'a u8, &'a u16)>,
+    depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<()> {
+    if let Some((_, child)) = children.into_iter().find(|(byte, _)| **byte == 0) {
+        update_terminator_candidate_at(frame, child_offset(*child), depth, state)?;
+    }
+    Ok(())
+}
+
+fn update_indexed_terminator_candidate(
+    frame: BlobFrameRef<'_>,
+    index: u8,
+    children: &[u16],
+    depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<()> {
+    if index == 0 {
+        return Ok(());
+    }
+    let child_index = usize::from(index - 1);
+    if child_index >= children.len() {
+        return Err(Error::node_corrupt(
+            "longest_prefix: node48 terminator index out of range",
+        ));
+    }
+    update_terminator_candidate_at(frame, child_offset(children[child_index]), depth, state)
+}
+
+fn update_terminator_candidate_at(
+    frame: BlobFrameRef<'_>,
+    off: u32,
+    depth: usize,
+    state: &mut LongestPrefixState<'_, '_>,
+) -> Result<()> {
+    let key = state.key;
+    let Some(query) = key.user_bytes() else {
+        return Err(Error::Internal("longest_prefix requires a user search key"));
+    };
+    if depth > query.len() {
+        return Ok(());
+    }
+    let candidate = SearchKey::user(&query[..depth]);
+    let hit = match descend(frame, off, candidate, depth + 1)? {
+        LookupResult::Found(hit) => Some(LongestPrefixHit {
+            key: query[..depth].to_vec(),
+            value: hit.value.to_vec(),
+            seq: hit.seq,
+        }),
+        LookupResult::NotFound => None,
+        LookupResult::Crossing(crossing) => {
+            exact_lookup_from_crossing(state, candidate, crossing, &query[..depth])?
+        }
+    };
+    if let Some(hit) = hit {
+        if state
+            .best
+            .as_ref()
+            .is_none_or(|current| current.key.len() < hit.key.len())
+        {
+            state.best = Some(hit);
+        }
+    }
+    Ok(())
+}
+
+fn exact_lookup_from_crossing(
+    state: &mut LongestPrefixState<'_, '_>,
+    key: SearchKey<'_>,
+    mut crossing: BlobNodeCrossing,
+    user_key: &[u8],
+) -> Result<Option<LongestPrefixHit>> {
+    loop {
+        let Some(pin) = pin_longest_prefix_child(state, crossing.child_guid)? else {
+            return Ok(None);
+        };
+        let version = pin.content_version();
+        let guard = pin.read_optimistic();
+        let frame = BlobFrameRef::wrap(guard.as_slice());
+        let result = lookup_at(frame, frame.header().root_slot, key, crossing.child_depth);
+        if !guard.validate() || !pin.validate_content_version(version) {
+            state.unstable = true;
+            return Ok(None);
+        }
+        let result = result?;
+        drop(guard);
+        state.visited.push((Arc::clone(&pin), version));
+        match result {
+            LookupResult::Found(hit) => {
+                return Ok(Some(LongestPrefixHit {
+                    key: user_key.to_vec(),
+                    value: hit.value.to_vec(),
+                    seq: hit.seq,
+                }));
+            }
+            LookupResult::NotFound => return Ok(None),
+            LookupResult::Crossing(next) => crossing = next,
+        }
+    }
+}
+
+fn pin_longest_prefix_child(
+    state: &mut LongestPrefixState<'_, '_>,
+    child_guid: BlobGuid,
+) -> Result<Option<Arc<CachedBlob>>> {
+    match state.bm.pin(child_guid) {
+        Ok(pin) => Ok(Some(pin)),
+        Err(error)
+            if is_blob_store_not_found(&error)
+                && missing_child_is_retryable(state.bm, child_guid, state.gc_epoch) =>
+        {
+            state.unstable = true;
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn update_longest_prefix_leaf(body: &[u8], state: &mut LongestPrefixState<'_, '_>) -> Result<()> {
+    let leaf = *cast::<Leaf>(&body[..size_of::<Leaf>()]);
+    if leaf.tombstone != 0 {
+        return Ok(());
+    }
+    let key_len = usize::from(leaf.key_len);
+    let value_len = usize::from(leaf.value_len);
+    let key_end = size_of::<Leaf>()
+        .checked_add(key_len)
+        .ok_or(Error::node_corrupt("longest_prefix: key length overflow"))?;
+    let value_end = key_end
+        .checked_add(value_len)
+        .ok_or(Error::node_corrupt("longest_prefix: value length overflow"))?;
+    if value_end > body.len() {
+        return Err(Error::node_corrupt(
+            "longest_prefix: leaf key/value out of range",
+        ));
+    }
+    let stored_key = &body[size_of::<Leaf>()..key_end];
+    let user_key = stored_key.strip_suffix(&[0]).unwrap_or(stored_key);
+    let Some(query_bytes) = state.key.user_bytes() else {
+        return Err(Error::Internal("longest_prefix requires a user search key"));
+    };
+    if !query_bytes.starts_with(user_key)
+        || state
+            .best
+            .as_ref()
+            .is_some_and(|candidate| candidate.key.len() >= user_key.len())
+    {
+        return Ok(());
+    }
+    state.best = Some(LongestPrefixHit {
+        key: user_key.to_vec(),
+        value: body[key_end..value_end].to_vec(),
+        seq: leaf.seq,
+    });
+    Ok(())
 }
 
 fn lookup_multi_with_gc_policy<R, F>(

--- a/src/engine/walker/mod.rs
+++ b/src/engine/walker/mod.rs
@@ -66,7 +66,7 @@ pub use insert::{insert_multi, insert_multi_conditional};
 pub(crate) use insert::{insert_multi_batch_conditional, InsertBatchItem};
 pub(crate) use key::SearchKey;
 pub use lookup::lookup_multi_with;
-pub(crate) use lookup::lookup_multi_with_snapshot;
+pub(crate) use lookup::{longest_prefix_multi, lookup_multi_with_snapshot};
 pub use merge::try_merge_children;
 pub use migrate::{blob_needs_compaction, blob_would_route, compact_blob};
 pub(crate) use range::PrefixListCache;

--- a/src/engine/walker/types.rs
+++ b/src/engine/walker/types.rs
@@ -29,6 +29,17 @@ pub struct LookupHit<'a> {
     pub seq: u64,
 }
 
+/// Owned longest-prefix match returned across blob pins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LongestPrefixHit {
+    /// User key bytes without the ART terminator.
+    pub(crate) key: Vec<u8>,
+    /// Value bytes copied from the matching leaf.
+    pub(crate) value: Vec<u8>,
+    /// Leaf sequence attached to the matching record.
+    pub(crate) seq: u64,
+}
+
 /// Where a single-blob walker descent stopped at a BlobNode.
 #[derive(Debug, Clone, Copy)]
 pub struct BlobNodeCrossing {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ pub use api::stats::{
 };
 
 // Single-record atomic batches.
-pub use api::atomic::{AtomicBatch, Record, RecordVersion};
+pub use api::atomic::{AtomicBatch, PrefixRecord, Record, RecordVersion};
 
 // Background checkpointer policy. The `Checkpointer` handle itself
 // is crate-internal; users tune or disable it via this config.

--- a/src/store/buffer_manager/mod.rs
+++ b/src/store/buffer_manager/mod.rs
@@ -2294,6 +2294,10 @@ impl BufferManager {
         self.write_delta.len()
     }
 
+    pub(crate) fn has_any_write_delta(&self) -> bool {
+        self.write_delta.has_any()
+    }
+
     pub(crate) fn write_delta_count_for_tree(&self, tree_id: u64) -> usize {
         self.write_delta.tree_len(tree_id)
     }

--- a/src/store/buffer_manager/write_delta.rs
+++ b/src/store/buffer_manager/write_delta.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 use crate::layout::BlobGuid;
@@ -26,6 +27,7 @@ pub(crate) struct DeltaOp {
 #[derive(Default)]
 pub(crate) struct WriteDelta {
     inner: Mutex<DeltaMaps>,
+    has_any: AtomicBool,
 }
 
 #[derive(Default)]
@@ -56,7 +58,9 @@ impl WriteDelta {
                 creates_key,
             },
         };
-        self.inner.lock().unwrap().insert_pending(op);
+        let mut guard = self.inner.lock().unwrap();
+        guard.insert_pending(op);
+        self.has_any.store(true, Ordering::Release);
     }
 
     pub(crate) fn stage_delete(&self, tree_id: u64, root_guid: BlobGuid, key: &[u8], seq: u64) {
@@ -66,7 +70,9 @@ impl WriteDelta {
             key: key.to_vec(),
             entry: DeltaEntry::Delete { seq },
         };
-        self.inner.lock().unwrap().insert_pending(op);
+        let mut guard = self.inner.lock().unwrap();
+        guard.insert_pending(op);
+        self.has_any.store(true, Ordering::Release);
     }
 
     pub(crate) fn get(&self, tree_id: u64, key: &[u8]) -> Option<DeltaEntry> {
@@ -75,6 +81,10 @@ impl WriteDelta {
 
     pub(crate) fn len(&self) -> usize {
         self.inner.lock().unwrap().len()
+    }
+
+    pub(crate) fn has_any(&self) -> bool {
+        self.has_any.load(Ordering::Acquire)
     }
 
     pub(crate) fn tree_len(&self, tree_id: u64) -> usize {
@@ -117,6 +127,9 @@ impl WriteDelta {
         for op in ops {
             guard.remove_flushing(op);
         }
+        if guard.len() == 0 {
+            self.has_any.store(false, Ordering::Release);
+        }
     }
 
     pub(crate) fn abort_flush(&self, ops: Vec<DeltaOp>) {
@@ -128,6 +141,7 @@ impl WriteDelta {
             guard.remove_flushing(&op);
             guard.insert_pending(op);
         }
+        self.has_any.store(true, Ordering::Release);
     }
 }
 
@@ -361,6 +375,24 @@ mod tests {
         assert_eq!(delta.tree_key_set_len(7), 1);
         delta.finish_flush(&ops);
         assert_eq!(delta.tree_key_set_len(7), 0);
+    }
+
+    #[test]
+    fn zero_debt_flag_tracks_finish_and_abort() {
+        let delta = WriteDelta::default();
+        assert!(!delta.has_any());
+
+        delta.stage_put(7, [1; 16], b"a", b"v", 1, false);
+        assert!(delta.has_any());
+        let ops = delta.begin_flush_tree(7);
+        assert!(delta.has_any(), "flushing debt is still visible");
+        delta.finish_flush(&ops);
+        assert!(!delta.has_any());
+
+        delta.stage_delete(7, [1; 16], b"a", 2);
+        let ops = delta.begin_flush_tree(7);
+        delta.abort_flush(ops);
+        assert!(delta.has_any(), "aborted debt returns to pending");
     }
 
     #[test]

--- a/tests/tree_smoke.rs
+++ b/tests/tree_smoke.rs
@@ -424,6 +424,188 @@ fn get_record_returns_value_and_version_together() {
 }
 
 #[test]
+fn longest_prefix_record_returns_deepest_key_and_version() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+    tree.put(b"", b"root").unwrap();
+    tree.put(b"tenant", b"tenant").unwrap();
+    tree.put(b"tenant/model", b"model").unwrap();
+    tree.put(b"tenant/model/prefix", b"capsule").unwrap();
+    tree.put(b"tenant/other", b"other").unwrap();
+
+    let matched = tree
+        .longest_prefix_record(b"tenant/model/prefix/suffix")
+        .unwrap()
+        .unwrap();
+    assert_eq!(matched.key, b"tenant/model/prefix");
+    assert_eq!(matched.value, b"capsule");
+    assert_eq!(
+        matched.version,
+        tree.get_record(&matched.key).unwrap().unwrap().version
+    );
+
+    let shorter = tree
+        .longest_prefix_record(b"tenant/model/missing")
+        .unwrap()
+        .unwrap();
+    assert_eq!(shorter.key, b"tenant/model");
+    assert_eq!(shorter.value, b"model");
+
+    let root = tree.longest_prefix_record(b"absent").unwrap().unwrap();
+    assert!(root.key.is_empty());
+    assert_eq!(root.value, b"root");
+}
+
+#[test]
+fn longest_prefix_record_handles_binary_keys() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+    tree.put(&[1], b"one").unwrap();
+    tree.put(&[1, 2], b"one-two").unwrap();
+    tree.put(&[1, 2, 255], b"one-two-ff").unwrap();
+
+    let matched = tree
+        .longest_prefix_record(&[1, 2, 255, 3])
+        .unwrap()
+        .unwrap();
+    assert_eq!(matched.key, [1, 2, 255]);
+    assert_eq!(matched.value, b"one-two-ff");
+}
+
+#[test]
+fn longest_prefix_record_observes_updates_and_deletes() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+    tree.put(b"a", b"a").unwrap();
+    tree.put(b"a/b", b"old").unwrap();
+    tree.put(b"a/b", b"new").unwrap();
+
+    let updated = tree.longest_prefix_record(b"a/b/c").unwrap().unwrap();
+    assert_eq!(updated.key, b"a/b");
+    assert_eq!(updated.value, b"new");
+
+    assert!(tree.delete(b"a/b").unwrap());
+    let fallback = tree.longest_prefix_record(b"a/b/c").unwrap().unwrap();
+    assert_eq!(fallback.key, b"a");
+    assert_eq!(fallback.value, b"a");
+}
+
+#[test]
+fn view_longest_prefix_record_is_snapshot_stable_and_scope_safe() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+    tree.put(b"tenant", b"outside-scope").unwrap();
+    tree.put(b"tenant/a", b"captured").unwrap();
+    let snapshot = tree.snapshot(b"tenant/").unwrap();
+
+    tree.put(b"tenant/a", b"live-update").unwrap();
+    tree.put(b"tenant/a/deeper", b"live-deeper").unwrap();
+
+    let captured = snapshot
+        .longest_prefix_record(b"tenant/a/deeper/suffix")
+        .unwrap()
+        .unwrap();
+    assert_eq!(captured.key, b"tenant/a");
+    assert_eq!(captured.value, b"captured");
+
+    assert!(
+        snapshot
+            .longest_prefix_record(b"tenant/missing")
+            .unwrap()
+            .is_none(),
+        "the scoped view must not return the ancestor key outside its scope"
+    );
+}
+
+#[test]
+fn longest_prefix_record_matches_naive_oracle() {
+    let tree = Tree::open(TreeConfig::memory()).unwrap();
+    let mut keys = Vec::new();
+    for first in 1..=8u8 {
+        for depth in 1..=6usize {
+            let key = (0..depth)
+                .map(|index| {
+                    first.wrapping_add(
+                        u8::try_from(index * 17).expect("bounded test index fits in u8"),
+                    )
+                })
+                .collect::<Vec<_>>();
+            tree.put(&key, &key).unwrap();
+            keys.push(key);
+        }
+    }
+
+    for first in 0..=9u8 {
+        for suffix in 0..64u8 {
+            let query = vec![
+                first,
+                first.wrapping_add(17),
+                first.wrapping_add(34),
+                suffix,
+                0xfe,
+            ];
+            let expected = keys
+                .iter()
+                .filter(|key| query.starts_with(key))
+                .max_by_key(|key| key.len());
+            let actual = tree.longest_prefix_record(&query).unwrap();
+            assert_eq!(
+                actual.as_ref().map(|record| &record.key),
+                expected,
+                "query={query:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn concurrent_longest_prefix_readers_observe_complete_versions() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+
+    let tree = Arc::new(Tree::open(TreeConfig::memory()).unwrap());
+    tree.put(b"prefix", b"base").unwrap();
+    tree.put(b"prefix/deep", b"version-a").unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let writer_tree = Arc::clone(&tree);
+    let writer_stop = Arc::clone(&stop);
+    let writer = thread::spawn(move || {
+        for iteration in 0..2_000 {
+            let value = if iteration % 2 == 0 {
+                b"version-a".as_slice()
+            } else {
+                b"version-b".as_slice()
+            };
+            writer_tree.put(b"prefix/deep", value).unwrap();
+        }
+        writer_stop.store(true, Ordering::Release);
+    });
+
+    let readers = (0..4)
+        .map(|_| {
+            let tree = Arc::clone(&tree);
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || {
+                while !stop.load(Ordering::Acquire) {
+                    let record = tree
+                        .longest_prefix_record(b"prefix/deep/suffix")
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(record.key, b"prefix/deep");
+                    assert!(
+                        record.value == b"version-a" || record.value == b"version-b",
+                        "reader observed an invalid value: {:?}",
+                        record.value
+                    );
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    writer.join().unwrap();
+    for reader in readers {
+        reader.join().unwrap();
+    }
+}
+
+#[test]
 fn conditional_delete_uses_record_versions() {
     let tree = Tree::open(TreeConfig::memory()).unwrap();
     tree.put(b"k", b"v1").unwrap();
@@ -776,6 +958,30 @@ fn auto_spillover_creates_child_blob_when_root_blob_fills() {
         "expected auto-spillover to allocate at least 1 child blob, got {} total blob(s)",
         blobs.len(),
     );
+}
+
+#[test]
+fn longest_prefix_record_crosses_spilled_blobs() {
+    let store: Arc<dyn BlobStore> = Arc::new(MemoryBlobStore::new());
+    let tree = TreeBuilder::new("ignored")
+        .open_with_blob_store(store)
+        .unwrap();
+    let value = vec![0xAB; 200];
+    for i in 0..5000u32 {
+        tree.put(format!("prefix/{i:08}").as_bytes(), &value)
+            .unwrap();
+    }
+    assert!(
+        tree.stats().unwrap().blob_count >= 2,
+        "test precondition: workload must spill across blobs"
+    );
+
+    let matched = tree
+        .longest_prefix_record(b"prefix/00004999/suffix")
+        .unwrap()
+        .unwrap();
+    assert_eq!(matched.key, b"prefix/00004999");
+    assert_eq!(matched.value, value);
 }
 
 #[test]

--- a/tests/wal_tree_integration.rs
+++ b/tests/wal_tree_integration.rs
@@ -714,6 +714,26 @@ fn batched_mode_with_checkpoint_persists_everything() {
 }
 
 #[test]
+fn longest_prefix_record_merges_deferred_wal_state_before_lookup() {
+    let dir = tempdir().unwrap();
+    let cfg = durable_cfg(dir.path());
+    let tree = Tree::open(cfg).unwrap();
+    tree.put(b"capsule", b"base").unwrap();
+    tree.put(b"capsule/deep", b"latest").unwrap();
+
+    let matched = tree
+        .longest_prefix_record(b"capsule/deep/suffix")
+        .unwrap()
+        .unwrap();
+    assert_eq!(matched.key, b"capsule/deep");
+    assert_eq!(matched.value, b"latest");
+    assert_eq!(
+        matched.version,
+        tree.get_record(b"capsule/deep").unwrap().unwrap().version
+    );
+}
+
+#[test]
 fn next_seq_resumes_past_replayed_records() {
     let dir = tempdir().unwrap();
     let cfg = durable_cfg(dir.path());


### PR DESCRIPTION
## Summary

- add `Tree::longest_prefix_record` and `View::longest_prefix_record`
- return the matched key, value, and `RecordVersion` through `PrefixRecord`
- walk the ART once while retaining the deepest terminator-leaf match
- preserve live-tree semantics across deferred WAL state, concurrent blob mutation, GC, cross-blob traversal, and scoped snapshots
- add OrbitKV-shaped latency and concurrent-throughput benchmarks

## Concurrency and correctness

The live-tree path uses optimistic per-blob version validation and restarts from the root on conflict. It does not take a tree-wide read lock. Cross-blob pins are revalidated before publishing a result, and live reads retry when GC or structural maintenance retires a child.

Deferred WAL state is merged before lookup. A zero-debt atomic fast path avoids the write-delta mutex for steady-state read-only workloads. `View` uses the same traversal over its immutable snapshot and filters matches outside the captured scope.

Coverage includes:

- exact, shallow, and missing-prefix results
- record-version agreement
- binary keys under Holt's existing terminator encoding
- update/delete fallback
- scoped snapshot isolation
- randomized naive-oracle comparison
- concurrent readers with an updating writer
- cross-blob lookup
- deferred WAL visibility
- write-delta pending/flushing/finish/abort lifecycle

## Performance

Recorded on an Intel Xeon Platinum 8457C with Rust 1.97.1, release profile, in-memory Holt, and OrbitKV-shaped 33-byte prefix chunks.

Selected single-thread Criterion results:

| Shape | Native | Deep-to-shallow exact fallback | Speedup |
|---|---:|---:|---:|
| 4 chunks, deep hit | 94.8 ns | 301 ns | 3.18x |
| 16 chunks, half hit | 99.8 ns | 5.48 us | 54.9x |
| 64 chunks, shallow hit | 93.0 ns | 95.5 us | 1,027x |
| 64 chunks, miss | 46.8 ns | 2.36 us | 50.5x |
| 256 chunks, shallow hit | 162 ns | 1.47 ms | 9,071x |

The 256-chunk tier asserts that the tree spans at least two Holt blobs.

Pinned to eight physical cores on one NUMA node, a 64-chunk shallow hit scales from 14.2M ops/s at one thread to 107.4M ops/s at eight threads. Full commands, environment, and results are in `benches/LONGEST_PREFIX_RESULTS.md`.

These are metadata lookup microbenchmarks, not end-to-end inference results.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets -- --skip permission_denied_store_directory_is_rejected_on_open`
- `cargo clippy --workspace --all-targets -- -D warnings`
- benchmark crate clippy and release build

The skipped permission test relies on chmod denying access and does not hold when the suite runs as root. A normal unfiltered run had no other failure.

## Scope

This PR exposes the operation through the Rust API. C and Node bindings are unchanged.
