### PR TITLE
Prepare Holt 0.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-08-18
+
 ### Added
 
 - Added `Tree::longest_prefix_record` and
@@ -21,6 +23,15 @@ fine-grained per-commit history is in `git log`.
 
 - Added an atomic zero-debt check for deferred WAL state so read-only
   longest-prefix lookups avoid the write-delta mutex in steady state.
+- Updated the Linux `io-uring` dependency to 0.7.14 and the Node binding's
+  N-API dependency to 3.12.1.
+
+### Upgrade notes
+
+- Holt 0.9.2 uses the same data and format-4 WAL layouts as 0.9.1. Existing
+  stores do not need a format migration.
+- The longest-prefix operation is available through the Rust API. C and Node
+  bindings remain unchanged.
 
 ## [0.9.1] — 2026-08-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holt"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.82"
 autobenches = false

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ a minor release, but minor releases may still break source compatibility
 before 1.0. Pin exact versions for production evaluation:
 
 ```toml
-holt = "=0.9.1"
+holt = "=0.9.2"
 ```
 
 The engine is covered by unit, integration, property, fuzz, soak, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ minor release plus the previous minor.
 
 | Version | Supported |
 |---------|-----------|
-| `0.9.1` | Yes (current) |
-| `< 0.9.1` | No |
+| `0.9.2` | Yes (current) |
+| `< 0.9.2` | No |
 
 ## Reporting a vulnerability
 

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/tools/soak/Cargo.lock
+++ b/tools/soak/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "holt"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",


### PR DESCRIPTION
## Summary

- bump the Rust `holt` crate to 0.9.2
- move the longest-prefix lookup changes into the 0.9.2 CHANGELOG section
- update README, security support policy, and root/bench/soak lockfiles
- keep the independently versioned Node package at 0.1.0

## Compatibility

Holt 0.9.2 uses the same data layout and format-4 WAL as 0.9.1. No store migration is required. The new longest-prefix operation is Rust-only in this release; C and Node bindings are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --lib --tests --examples --locked -- --skip permission_denied_store_directory_is_rejected_on_open`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- bench and soak lockfiles regenerated against Holt 0.9.2

The skipped permission test relies on chmod denying root and is not meaningful in the current root container.
