### PR TITLE
backport(0.8): manifest dual-writer defense for v0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ fine-grained per-commit history is in `git log`.
 
 ## [Unreleased]
 
+## [0.8.6] — 2026-09-01
+
+### Fixed
+
+- `FileBlobStore` now defends the manifest against a second live writer.
+  Writes verify the opening process id (the directory lock is shared across
+  `fork`) and that `store.lock` on disk is still the locked inode; manifest
+  replay fails closed at the first `Set` that lands on a slot held by a
+  different live guid, naming the concurrent-writer cause instead of
+  surfacing later as an opaque duplicate-slot error. Vacuum relocation now
+  restores its pre-relocation state when the snapshot persist fails. No
+  on-disk format change.
+
 ## [0.8.5] — 2026-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holt"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holt"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 rust-version = "1.82"
 autobenches = false

--- a/src/store/blob_store/file/mod.rs
+++ b/src/store/blob_store/file/mod.rs
@@ -185,6 +185,17 @@ const VALUE_SEGMENT_SLOT_BYTES: usize = PAGE_SIZE as usize;
 
 /// NVMe-backed, O_DIRECT, single-packed-file blob store.
 ///
+#[cfg(test)]
+#[derive(Default)]
+struct FlushGapHook(Mutex<Option<Box<dyn FnOnce() + Send>>>);
+
+#[cfg(test)]
+impl std::fmt::Debug for FlushGapHook {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("FlushGapHook")
+    }
+}
+
 /// Construct via [`FileBlobStore::open`]. Thread-safe; the
 /// underlying file handle is shared and `pread`/`pwrite` are
 /// atomic at the syscall boundary.
@@ -198,6 +209,11 @@ pub struct FileBlobStore {
     /// across `fork`, so writes verify the pid to keep a forked child
     /// from becoming a second live manifest writer.
     owner_pid: u32,
+    /// Test-only pause point between the writer-identity check and the
+    /// manifest append, the window a lock-replacement race must not be
+    /// able to exploit.
+    #[cfg(test)]
+    flush_gap_hook: FlushGapHook,
     access: FileAccess,
     data_file: File,
     read_index_file: File,
@@ -254,6 +270,12 @@ struct Manifest {
     /// holes as ranges so a sparse high-water manifest does not
     /// expand into one `u64` per free slot.
     reusable_slots: ReusableSlots,
+    /// Exclusive, kernel-locked append handle to `manifest.log`, held for
+    /// the manifest's whole lifetime by writable opens (`None` read-only).
+    /// Every append and truncation goes through this descriptor, so a
+    /// second live writer can never interleave batches into the same
+    /// inode: it fails to lock at open instead.
+    log_file: Option<File>,
     /// Slots superseded by a shadow rewrite or removed by `delete_blob`, but
     /// whose replacement/delete is not yet durable in the manifest. They
     /// become reusable only after `flush` persists the corresponding delta;
@@ -262,8 +284,6 @@ struct Manifest {
     pending_free_slots: Vec<u64>,
     /// Path to the manifest file (for tmp+rename writes).
     path: PathBuf,
-    /// Path to the append-only manifest delta log.
-    log_path: PathBuf,
     /// Bytes currently in `manifest.log`, used to decide when a
     /// full snapshot compaction is worth paying for.
     log_bytes: u64,
@@ -351,6 +371,37 @@ fn acquire_dir_lock(data_dir: &Path, access: FileAccess, timeout: Duration) -> R
                             "blob store at {} has an incompatible live access mode \
                              (waited {timeout:?})",
                             data_dir.display()
+                        ),
+                    )));
+                }
+                thread::sleep(DIR_LOCK_RETRY_INTERVAL);
+            }
+            _ => return Err(Error::BlobStoreIo(err)),
+        }
+    }
+}
+
+/// Take a non-blocking exclusive `flock` on an already-open handle, waiting
+/// up to `timeout` so a reopen racing a previous instance's drop serializes
+/// instead of failing (the same handover contract as `acquire_dir_lock`).
+fn lock_file_exclusive(file: &File, path: &Path, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = io::Error::last_os_error();
+        match err.kind() {
+            io::ErrorKind::Interrupted => {}
+            io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(Error::BlobStoreIo(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        format!(
+                            "{} is held by a live writer (waited {timeout:?}; \
+                             was store.lock removed or replaced?)",
+                            path.display()
                         ),
                     )));
                 }
@@ -503,6 +554,8 @@ impl FileBlobStore {
             data_dir,
             dir_lock,
             owner_pid: std::process::id(),
+            #[cfg(test)]
+            flush_gap_hook: FlushGapHook::default(),
             access,
             data_file,
             read_index_file,
@@ -572,6 +625,8 @@ impl FileBlobStore {
             data_dir,
             dir_lock,
             owner_pid: std::process::id(),
+            #[cfg(test)]
+            flush_gap_hook: FlushGapHook::default(),
             access,
             data_file,
             read_index_file,
@@ -975,6 +1030,21 @@ impl FileBlobStore {
         Ok(())
     }
 
+    #[cfg(test)]
+    fn install_flush_gap_test_hook(&self, hook: impl FnOnce() + Send + 'static) {
+        let mut slot = self.flush_gap_hook.0.lock().unwrap();
+        assert!(slot.is_none(), "flush gap hook already installed");
+        *slot = Some(Box::new(hook));
+    }
+
+    #[cfg(test)]
+    fn run_flush_gap_test_hook(&self) {
+        let hook = self.flush_gap_hook.0.lock().unwrap().take();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
     fn flush_locked(&self) -> Result<()> {
         self.verify_exclusive_writer()?;
         // Order matters: data must be on disk before the manifest
@@ -985,6 +1055,9 @@ impl FileBlobStore {
             self.sync_data_file()?;
             self.mark_data_synced(epoch);
         }
+
+        #[cfg(test)]
+        self.run_flush_gap_test_hook();
 
         let mut publish_free_slots = false;
         if self.manifest_dirty.swap(false, Ordering::AcqRel) {
@@ -1820,6 +1893,30 @@ struct SlotMove {
 
 impl Manifest {
     fn load_or_create(path: &Path, log_path: &Path, repair_torn_tail: bool) -> Result<Self> {
+        // A writable manifest owns ONE exclusive, kernel-locked append handle
+        // to `manifest.log` for its whole lifetime, acquired before replay.
+        // Exclusivity over the appended inode is thereby HELD, not checked:
+        // a second writer admitted through a replaced `store.lock` cannot
+        // braid batches into this log because it cannot lock this inode, and
+        // there is no check-to-append window to race.
+        let log_file = if repair_torn_tail {
+            let log_existed = log_path.exists();
+            let file = OpenOptions::new()
+                .read(true)
+                .append(true)
+                .create(true)
+                .open(log_path)?;
+            lock_file_exclusive(&file, log_path, DIR_LOCK_ACQUIRE_TIMEOUT)?;
+            if !log_existed {
+                if let Some(parent) = log_path.parent() {
+                    sync_dir(parent)?;
+                }
+            }
+            Some(file)
+        } else {
+            None
+        };
+
         let (mut entries, mut next_slot) = match File::open(path) {
             Ok(mut f) => Self::parse_snapshot(&mut f)?,
             Err(e) if e.kind() == io::ErrorKind::NotFound => (HashMap::new(), 0),
@@ -1827,8 +1924,11 @@ impl Manifest {
         };
 
         let replay = Self::replay_log(log_path, &mut entries, &mut next_slot)?;
-        if repair_torn_tail && replay.valid_bytes < replay.file_bytes {
-            truncate_manifest_log(log_path, replay.valid_bytes)?;
+        if replay.valid_bytes < replay.file_bytes {
+            if let Some(file) = &log_file {
+                file.set_len(replay.valid_bytes)?;
+                file.sync_data()?;
+            }
         }
         let used_slots: Vec<_> = entries.values().map(|entry| entry.slot).collect();
         let reusable_slots = ReusableSlots::reconstruct(next_slot, &used_slots)?;
@@ -1839,7 +1939,7 @@ impl Manifest {
             reusable_slots,
             pending_free_slots: Vec::new(),
             path: path.to_path_buf(),
-            log_path: log_path.to_path_buf(),
+            log_file,
             log_bytes: replay.valid_bytes,
             pending_log: Vec::new(),
         })
@@ -1993,21 +2093,18 @@ impl Manifest {
             return Ok(());
         }
 
-        let log_created = !self.log_path.exists();
-        let mut f = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.log_path)?;
+        let Some(mut f) = self.log_file.as_ref() else {
+            return Err(Error::BlobStoreIo(io::Error::other(
+                "read-only manifest cannot persist deltas",
+            )));
+        };
         let mut buf = Vec::with_capacity(self.pending_log.len() * 40);
         for delta in &self.pending_log {
             encode_manifest_delta(*delta, &mut buf)?;
         }
         f.write_all(&buf)?;
         f.sync_data()?;
-        drop(f);
-        if log_created {
-            sync_dir(data_dir)?;
-        }
+        let _ = data_dir;
 
         self.log_bytes = self.log_bytes.saturating_add(buf.len() as u64);
         if self.should_compact_log() {
@@ -2060,22 +2157,15 @@ impl Manifest {
     }
 
     fn truncate_log(&mut self) -> Result<()> {
-        match OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(&self.log_path)
-        {
-            Ok(f) => {
-                f.sync_data()?;
-                self.log_bytes = 0;
-                Ok(())
-            }
-            Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                self.log_bytes = 0;
-                Ok(())
-            }
-            Err(e) => Err(Error::BlobStoreIo(e)),
-        }
+        let Some(f) = self.log_file.as_ref() else {
+            return Err(Error::BlobStoreIo(io::Error::other(
+                "read-only manifest cannot truncate its log",
+            )));
+        };
+        f.set_len(0)?;
+        f.sync_data()?;
+        self.log_bytes = 0;
+        Ok(())
     }
 
     fn replay_log(
@@ -2230,13 +2320,6 @@ fn encode_manifest_delta(delta: ManifestDelta, out: &mut Vec<u8>) -> Result<()> 
 fn sync_dir(path: &Path) -> Result<()> {
     let dir = File::open(path)?;
     dir.sync_all()?;
-    Ok(())
-}
-
-fn truncate_manifest_log(path: &Path, valid_bytes: u64) -> Result<()> {
-    let f = OpenOptions::new().write(true).open(path)?;
-    f.set_len(valid_bytes)?;
-    f.sync_all()?;
     Ok(())
 }
 
@@ -2423,6 +2506,52 @@ mod tests {
         assert_eq!(
             round_up_slots(DATA_PREALLOC_LARGE_AT_SLOTS + 1),
             DATA_PREALLOC_LARGE_AT_SLOTS + DATA_PREALLOC_LARGE_CHUNK_SLOTS,
+        );
+    }
+
+    #[test]
+    fn lock_replacement_race_cannot_yield_two_successful_writers() {
+        // The acceptance-found blocker: replace store.lock inside writer 1's
+        // check-to-append window, admit a full writer-2 lifecycle, and both
+        // writers report success while the braided log makes the store
+        // permanently unreopenable. The contract this test pins: at most one
+        // writer's durable work is accepted, and the store stays reopenable.
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let Some(w1) = try_open(dir.path()) else {
+            return;
+        };
+        let g1 = [0xA1u8; 16];
+        let g2 = [0xB2u8; 16];
+        w1.write_blob(g1, &buf_with(1)).unwrap();
+
+        let second_writer_succeeded = Arc::new(AtomicBool::new(false));
+        let hook_flag = Arc::clone(&second_writer_succeeded);
+        let hook_dir = dir.path().to_path_buf();
+        w1.install_flush_gap_test_hook(move || {
+            // Writer 1 has already passed its identity check for this flush.
+            let _ = std::fs::remove_file(hook_dir.join(LOCK_FILENAME));
+            if let Ok(w2) = FileBlobStore::open(&hook_dir) {
+                if w2.write_blob(g2, &buf_with(2)).is_ok() && w2.flush().is_ok() {
+                    hook_flag.store(true, Ordering::SeqCst);
+                }
+            }
+        });
+
+        let w1_flush = w1.flush();
+        drop(w1);
+
+        assert!(
+            !(second_writer_succeeded.load(Ordering::SeqCst) && w1_flush.is_ok()),
+            "both writers returned success across a lock replacement"
+        );
+        let reopened = FileBlobStore::open(dir.path());
+        assert!(
+            reopened.is_ok(),
+            "store must stay reopenable after the race: {:?}",
+            reopened.err()
         );
     }
 

--- a/src/store/blob_store/file/mod.rs
+++ b/src/store/blob_store/file/mod.rs
@@ -193,7 +193,11 @@ pub struct FileBlobStore {
     data_dir: PathBuf,
     /// Shared read or exclusive write advisory lock on `data_dir`.
     /// The kernel releases the lock when this handle closes.
-    _dir_lock: File,
+    dir_lock: File,
+    /// Process that opened this instance. `flock` ownership is shared
+    /// across `fork`, so writes verify the pid to keep a forked child
+    /// from becoming a second live manifest writer.
+    owner_pid: u32,
     access: FileAccess,
     data_file: File,
     read_index_file: File,
@@ -280,7 +284,7 @@ struct ManifestEntry {
     slot: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct ReusableSlots {
     singles: Vec<u64>,
     ranges: Vec<FreeSlotRange>,
@@ -497,7 +501,8 @@ impl FileBlobStore {
 
         Ok(Self {
             data_dir,
-            _dir_lock: dir_lock,
+            dir_lock,
+            owner_pid: std::process::id(),
             access,
             data_file,
             read_index_file,
@@ -565,7 +570,8 @@ impl FileBlobStore {
 
         Ok(Self {
             data_dir,
-            _dir_lock: dir_lock,
+            dir_lock,
+            owner_pid: std::process::id(),
             access,
             data_file,
             read_index_file,
@@ -742,6 +748,7 @@ impl FileBlobStore {
         if writes.is_empty() {
             return Ok(Vec::new());
         }
+        self.verify_exclusive_writer()?;
         let entries = self.reserve_write_entries(writes.iter().map(|(guid, _)| *guid));
         if let Some(required_slots) = entries
             .iter()
@@ -927,7 +934,49 @@ impl FileBlobStore {
         Ok(())
     }
 
+    /// Refuse writes when this instance's exclusive claim to the store can
+    /// no longer be trusted: the process forked (the advisory lock is
+    /// shared across `fork`), or `store.lock` on disk is no longer the
+    /// inode this instance locked (the file was removed or replaced, so a
+    /// second opener may hold an exclusive lock on a different inode).
+    /// Either way a second live writer could interleave its delta batches
+    /// into `manifest.log`; replay cannot untangle two self-consistent
+    /// writers and eventually fails closed with a duplicate slot.
+    fn verify_exclusive_writer(&self) -> Result<()> {
+        if self.access.is_read_only() {
+            return Ok(());
+        }
+        let current_pid = std::process::id();
+        if current_pid != self.owner_pid {
+            return Err(Error::BlobStoreIo(io::Error::other(format!(
+                "blob store at {} was opened by process {} but written from \
+                 process {}; a forked child must open its own store handle",
+                self.data_dir.display(),
+                self.owner_pid,
+                current_pid,
+            ))));
+        }
+        use std::os::unix::fs::MetadataExt;
+        let held = self.dir_lock.metadata().map_err(Error::BlobStoreIo)?;
+        let lock_path = self.data_dir.join(LOCK_FILENAME);
+        let on_disk = std::fs::metadata(&lock_path).map_err(|error| {
+            Error::BlobStoreIo(io::Error::other(format!(
+                "store lock {} disappeared while held: {error}",
+                lock_path.display(),
+            )))
+        })?;
+        if held.dev() != on_disk.dev() || held.ino() != on_disk.ino() {
+            return Err(Error::BlobStoreIo(io::Error::other(format!(
+                "store lock {} was replaced while held; another writer may \
+                 own the store",
+                lock_path.display(),
+            ))));
+        }
+        Ok(())
+    }
+
     fn flush_locked(&self) -> Result<()> {
+        self.verify_exclusive_writer()?;
         // Order matters: data must be on disk before the manifest
         // promotes any new slot. Otherwise a crash could leave the
         // manifest pointing at a slot whose data is still in NVMe's
@@ -1592,6 +1641,7 @@ impl BlobStore for FileBlobStore {
 
     fn delete_blob(&self, guid: BlobGuid) -> Result<()> {
         self.ensure_writable()?;
+        self.verify_exclusive_writer()?;
         let _io = self.data_io_lock.lock().unwrap();
         let mut m = self.manifest.write().unwrap();
         if let Some(entry) = m.entries.remove(&guid) {
@@ -1689,13 +1739,35 @@ impl BlobStore for FileBlobStore {
 
         let (slots_trimmed, next_slot, free_ranges) = {
             let mut m = self.manifest.write().unwrap();
+            // Relocation rewrites live guid->slot mappings and frees the old
+            // slots in memory WITHOUT queueing deltas; only the snapshot
+            // below makes that durable. If the snapshot fails, the durable
+            // log still maps every moved guid to its old slot, so continuing
+            // with the relocated in-memory state would hand out slots the
+            // log believes are live (free-without-durable-delta). Restore
+            // the pre-relocation state on failure. A truncate_log failure
+            // after a durable snapshot remains a narrower known window
+            // (stale relocation-era records replayed over the new snapshot)
+            // tracked as follow-up work.
+            let relocation_backup = if plan.is_empty() {
+                None
+            } else {
+                Some((m.entries.clone(), m.next_slot, m.reusable_slots.clone()))
+            };
             let slots_trimmed = if plan.is_empty() {
                 m.trim_trailing_free_slots()
             } else {
                 m.apply_relocation_plan(&plan)?
             };
             if slots_trimmed != 0 || !plan.is_empty() {
-                m.persist_snapshot(&self.data_dir)?;
+                if let Err(error) = m.persist_snapshot(&self.data_dir) {
+                    if let Some((entries, next_slot, reusable_slots)) = relocation_backup {
+                        m.entries = entries;
+                        m.next_slot = next_slot;
+                        m.reusable_slots = reusable_slots;
+                    }
+                    return Err(error);
+                }
                 m.truncate_log()?;
                 m.pending_log.clear();
                 self.manifest_dirty.store(false, Ordering::Release);
@@ -2025,6 +2097,19 @@ impl Manifest {
         f.read_to_end(&mut buf)?;
         let mut offset = 0usize;
         let mut valid_offset = 0usize;
+        // Live slot ownership WITHIN this log's own record sequence. A
+        // single serialized writer appends the delta that frees a slot
+        // strictly before any record that reuses it, so inside one log a
+        // `Set` landing on a slot held by a DIFFERENT live guid can only
+        // come from a second concurrent writer braiding its batches into
+        // the file (a forked child, or an opener admitted through a
+        // replaced `store.lock` inode). Fail closed at the first
+        // conflicting record instead of serving cross-written state.
+        // Snapshot-seeded entries deliberately do NOT participate: a crash
+        // between snapshot compaction and log truncation legitimately
+        // leaves a stale log whose records disagree with the snapshot and
+        // replay over it idempotently.
+        let mut slot_owners: HashMap<u64, BlobGuid> = HashMap::new();
         while offset < buf.len() {
             let remaining = buf.len() - offset;
             if remaining < MANIFEST_LOG_HEADER_SIZE {
@@ -2065,7 +2150,22 @@ impl Manifest {
                     let mut guid = [0u8; 16];
                     guid.copy_from_slice(&body[..16]);
                     let slot = u64::from_le_bytes(body[16..24].try_into().unwrap());
-                    entries.insert(guid, ManifestEntry { slot });
+                    match slot_owners.get(&slot) {
+                        Some(holder) if *holder != guid => {
+                            return Err(Error::node_corrupt(
+                                "FileBlobStore::ManifestLog::slot conflict \
+                                 (a second concurrent writer is the only \
+                                 known producer of this record order)",
+                            ));
+                        }
+                        _ => {}
+                    }
+                    if let Some(previous) = entries.insert(guid, ManifestEntry { slot }) {
+                        if previous.slot != slot {
+                            slot_owners.remove(&previous.slot);
+                        }
+                    }
+                    slot_owners.insert(slot, guid);
                     *next_slot = (*next_slot).max(slot.saturating_add(1));
                 }
                 MANIFEST_LOG_TY_DELETE => {
@@ -2076,7 +2176,9 @@ impl Manifest {
                     }
                     let mut guid = [0u8; 16];
                     guid.copy_from_slice(body);
-                    entries.remove(&guid);
+                    if let Some(previous) = entries.remove(&guid) {
+                        slot_owners.remove(&previous.slot);
+                    }
                 }
                 _ => {
                     return Err(Error::node_corrupt(
@@ -2322,6 +2424,107 @@ mod tests {
             round_up_slots(DATA_PREALLOC_LARGE_AT_SLOTS + 1),
             DATA_PREALLOC_LARGE_AT_SLOTS + DATA_PREALLOC_LARGE_CHUNK_SLOTS,
         );
+    }
+
+    #[test]
+    fn writes_refuse_a_replaced_store_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let Some(b) = try_open(dir.path()) else {
+            return;
+        };
+        let guid = [0x11u8; 16];
+        b.write_blob(guid, &buf_with(1)).unwrap();
+        b.flush().unwrap();
+
+        // Replace the lock inode out from under the held flock: this is the
+        // door that admits a second exclusive writer.
+        let lock_path = dir.path().join(LOCK_FILENAME);
+        std::fs::remove_file(&lock_path).unwrap();
+        File::create(&lock_path).unwrap();
+
+        let error = b.write_blob(guid, &buf_with(2)).unwrap_err();
+        assert!(
+            error.to_string().contains("replaced"),
+            "unexpected error: {error}"
+        );
+        let error = b.flush().unwrap_err();
+        assert!(
+            error.to_string().contains("replaced"),
+            "unexpected flush error: {error}"
+        );
+    }
+
+    #[test]
+    fn writes_refuse_a_missing_store_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let Some(b) = try_open(dir.path()) else {
+            return;
+        };
+        std::fs::remove_file(dir.path().join(LOCK_FILENAME)).unwrap();
+        let error = b.write_blob([0x12u8; 16], &buf_with(1)).unwrap_err();
+        assert!(
+            error.to_string().contains("disappeared"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn writes_refuse_a_forked_process_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let Some(mut b) = try_open(dir.path()) else {
+            return;
+        };
+        // flock ownership survives fork; the pid recorded at open is how a
+        // forked child is told to open its own handle instead of writing.
+        b.owner_pid = b.owner_pid.wrapping_add(1);
+        let error = b.write_blob([0x13u8; 16], &buf_with(1)).unwrap_err();
+        assert!(
+            error.to_string().contains("forked"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn replay_fails_closed_on_a_braided_slot_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let Some(b) = try_open(dir.path()) else {
+                return;
+            };
+            b.write_blob([0xA1u8; 16], &buf_with(1)).unwrap();
+            b.flush().unwrap();
+        }
+
+        // A second concurrent writer that opened from the same prefix would
+        // believe slot 0 is free and append its own Set for a different
+        // guid. A single serialized writer can never produce this order:
+        // the record freeing slot 0 would have to come first.
+        let mut record = Vec::new();
+        encode_manifest_delta(
+            ManifestDelta::Set {
+                guid: [0xB2u8; 16],
+                slot: 0,
+            },
+            &mut record,
+        )
+        .unwrap();
+        {
+            use std::io::Write;
+            let mut log = OpenOptions::new()
+                .append(true)
+                .open(dir.path().join(MANIFEST_LOG_FILENAME))
+                .unwrap();
+            log.write_all(&record).unwrap();
+            log.sync_data().unwrap();
+        }
+
+        match FileBlobStore::open(dir.path()) {
+            Err(error) => assert!(
+                error.to_string().contains("slot conflict"),
+                "unexpected error: {error}"
+            ),
+            Ok(_) => panic!("braided manifest log must not open"),
+        }
     }
 
     /// Skip every test in this module when O_DIRECT isn't supported

--- a/tests/blob_store_invariant.rs
+++ b/tests/blob_store_invariant.rs
@@ -1,0 +1,786 @@
+//! Invariant reproducer for NoKV issue #493:
+//! "FileBlobStore::Manifest::duplicate slot" on reopen of a store whose
+//! manifest.log is physically intact.
+//!
+//! Independently parses manifest.log from disk (b"MLG1" + u32le body_len +
+//! u8 ty {1=Set: 16B guid + 8B le slot, 2=Delete: 16B guid} + u32le crc32
+//! over magic..body) and replays it the same way `Manifest::load_or_create`
+//! + `ReusableSlots::reconstruct` would, asserting:
+//! - (1) FINAL state: no two live guids map to the same slot (= the #493
+//!   corruption; reopen would fail).
+//! - (2) EVERY PREFIX ending on a record boundary: same property. Any
+//!   prefix P whose replay yields a duplicate-slot state is a SIGKILL
+//!   landmine: a kill right after P is durable makes the next open fail.
+
+use holt::{CheckpointConfig, Durability, Tree, TreeBuilder, TreeConfig, DB};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+// ---------- manifest.log parser / replayer ----------
+
+const MAGIC: [u8; 4] = *b"MLG1";
+const HEADER: usize = 4 + 4 + 1;
+const FOOTER: usize = 4;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct Guid([u8; 16]);
+
+impl std::fmt::Debug for Guid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for b in self.0 {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Rec {
+    Set { guid: Guid, slot: u64 },
+    Delete { guid: Guid },
+}
+
+#[derive(Debug)]
+struct Conflict {
+    record_idx: usize,
+    slot: u64,
+    incoming: Guid,
+    holder: Guid,
+    resolved_at: Option<usize>,
+}
+
+#[derive(Debug)]
+struct Report {
+    path: PathBuf,
+    records: Vec<Rec>,
+    prefix_conflicts: Vec<Conflict>,
+    final_dup_slots: Vec<u64>,
+    torn_tail_bytes: u64,
+    crc_error: bool,
+}
+
+impl Report {
+    fn is_clean(&self) -> bool {
+        self.prefix_conflicts.is_empty() && self.final_dup_slots.is_empty() && !self.crc_error
+    }
+
+    fn dump(&self) -> String {
+        let mut s = String::new();
+        let _ = writeln!(
+            s,
+            "manifest.log {} : {} records, torn_tail_bytes={}, crc_error={}",
+            self.path.display(),
+            self.records.len(),
+            self.torn_tail_bytes,
+            self.crc_error
+        );
+        for c in &self.prefix_conflicts {
+            let _ = writeln!(
+                s,
+                "  PREFIX CONFLICT at record #{}: Set {:?} -> slot {} while slot {} live-held by {:?} (resolved_at={:?})",
+                c.record_idx, c.incoming, c.slot, c.slot, c.holder, c.resolved_at
+            );
+        }
+        if !self.final_dup_slots.is_empty() {
+            let _ = writeln!(
+                s,
+                "  FINAL-STATE DUPLICATE SLOTS: {:?}",
+                self.final_dup_slots
+            );
+        }
+        let _ = writeln!(s, "  full record trail:");
+        for (i, r) in self.records.iter().enumerate() {
+            match r {
+                Rec::Set { guid, slot } => {
+                    let _ = writeln!(s, "    #{i:04} Set    {guid:?} -> slot {slot}");
+                }
+                Rec::Delete { guid } => {
+                    let _ = writeln!(s, "    #{i:04} Delete {guid:?}");
+                }
+            }
+        }
+        s
+    }
+}
+
+fn parse_records(buf: &[u8]) -> (Vec<Rec>, u64, bool) {
+    let mut records = Vec::new();
+    let mut offset = 0usize;
+    let mut crc_error = false;
+    while offset < buf.len() {
+        if buf.len() - offset < HEADER {
+            break; // torn header
+        }
+        let start = offset;
+        if buf[offset..offset + 4] != MAGIC {
+            crc_error = true;
+            break;
+        }
+        let body_len = u32::from_le_bytes(buf[offset + 4..offset + 8].try_into().unwrap()) as usize;
+        let ty = buf[offset + 8];
+        let record_len = HEADER + body_len + FOOTER;
+        if buf.len() - start < record_len {
+            break; // torn tail (possible mid-append read)
+        }
+        let body = &buf[start + HEADER..start + HEADER + body_len];
+        let expected_crc = u32::from_le_bytes(
+            buf[start + HEADER + body_len..start + record_len]
+                .try_into()
+                .unwrap(),
+        );
+        let actual_crc = crc32fast_hash(&buf[start..start + HEADER + body_len]);
+        if expected_crc != actual_crc {
+            // Could be a mid-append read of the very last record; treat as
+            // torn tail rather than corruption, but note it.
+            break;
+        }
+        match ty {
+            1 => {
+                if body.len() != 24 {
+                    crc_error = true;
+                    break;
+                }
+                let mut g = [0u8; 16];
+                g.copy_from_slice(&body[..16]);
+                let slot = u64::from_le_bytes(body[16..24].try_into().unwrap());
+                records.push(Rec::Set {
+                    guid: Guid(g),
+                    slot,
+                });
+            }
+            2 => {
+                if body.len() != 16 {
+                    crc_error = true;
+                    break;
+                }
+                let mut g = [0u8; 16];
+                g.copy_from_slice(body);
+                records.push(Rec::Delete { guid: Guid(g) });
+            }
+            _ => {
+                crc_error = true;
+                break;
+            }
+        }
+        offset = start + record_len;
+    }
+    (records, (buf.len() - offset) as u64, crc_error)
+}
+
+// Local crc32 (IEEE) so the checker is fully independent of holt internals.
+fn crc32fast_hash(data: &[u8]) -> u32 {
+    let mut table = [0u32; 256];
+    for (i, entry) in table.iter_mut().enumerate() {
+        let mut c = i as u32;
+        for _ in 0..8 {
+            c = if c & 1 != 0 {
+                0xEDB8_8320 ^ (c >> 1)
+            } else {
+                c >> 1
+            };
+        }
+        *entry = c;
+    }
+    let mut crc = 0xFFFF_FFFFu32;
+    for &b in data {
+        crc = table[((crc ^ u32::from(b)) & 0xFF) as usize] ^ (crc >> 8);
+    }
+    !crc
+}
+
+fn check_manifest_log(path: &Path) -> Report {
+    let buf = std::fs::read(path).unwrap_or_default();
+    let (records, torn_tail_bytes, crc_error) = parse_records(&buf);
+
+    let mut entries: HashMap<Guid, u64> = HashMap::new();
+    let mut slot_count: HashMap<u64, u32> = HashMap::new();
+    let mut slot_holder: HashMap<u64, Guid> = HashMap::new();
+    let mut prefix_conflicts: Vec<Conflict> = Vec::new();
+
+    for (i, rec) in records.iter().enumerate() {
+        match *rec {
+            Rec::Set { guid, slot } => {
+                if let Some(old_slot) = entries.insert(guid, slot) {
+                    let c = slot_count.entry(old_slot).or_default();
+                    *c = c.saturating_sub(1);
+                    if *c <= 1 {
+                        for conf in prefix_conflicts.iter_mut() {
+                            if conf.slot == old_slot && conf.resolved_at.is_none() {
+                                conf.resolved_at = Some(i);
+                            }
+                        }
+                    }
+                }
+                let c = slot_count.entry(slot).or_default();
+                *c += 1;
+                if *c > 1 {
+                    prefix_conflicts.push(Conflict {
+                        record_idx: i,
+                        slot,
+                        incoming: guid,
+                        holder: *slot_holder.get(&slot).unwrap_or(&guid),
+                        resolved_at: None,
+                    });
+                }
+                slot_holder.insert(slot, guid);
+            }
+            Rec::Delete { guid } => {
+                if let Some(old_slot) = entries.remove(&guid) {
+                    let c = slot_count.entry(old_slot).or_default();
+                    *c = c.saturating_sub(1);
+                    if *c <= 1 {
+                        for conf in prefix_conflicts.iter_mut() {
+                            if conf.slot == old_slot && conf.resolved_at.is_none() {
+                                conf.resolved_at = Some(i);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let final_dup_slots: Vec<u64> = slot_count
+        .iter()
+        .filter(|(_, &c)| c > 1)
+        .map(|(&s, _)| s)
+        .collect();
+
+    Report {
+        path: path.to_path_buf(),
+        records,
+        prefix_conflicts,
+        final_dup_slots,
+        torn_tail_bytes,
+        crc_error,
+    }
+}
+
+fn find_manifest_logs(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.file_name().map(|n| n == "manifest.log").unwrap_or(false) {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+/// Check every manifest.log under `root`; panic with a full dump on any
+/// violation. `allow_torn` tolerates a torn tail (mid-append concurrent read).
+fn assert_invariant(root: &Path, ctx: &str, allow_torn: bool) {
+    for log in find_manifest_logs(root) {
+        let report = check_manifest_log(&log);
+        if !allow_torn {
+            assert_eq!(
+                report.torn_tail_bytes,
+                0,
+                "[{ctx}] torn tail while quiescent:\n{}",
+                report.dump()
+            );
+        }
+        assert!(
+            report.is_clean(),
+            "[{ctx}] MANIFEST INVARIANT VIOLATION:\n{}",
+            report.dump()
+        );
+    }
+}
+
+fn total_records(root: &Path) -> usize {
+    find_manifest_logs(root)
+        .iter()
+        .map(|l| check_manifest_log(l).records.len())
+        .sum()
+}
+
+// ---------- workload config mirroring nokv-meta-holt ----------
+
+fn nokv_like_config(dir: &Path, background_checkpointer: bool) -> TreeConfig {
+    let mut cfg = TreeConfig::new(dir);
+    cfg.durability = Durability::Wal { sync: true };
+    cfg.checkpoint = CheckpointConfig {
+        enabled: background_checkpointer,
+        auto_vacuum: false,
+        ..CheckpointConfig::default()
+    };
+    cfg
+}
+
+fn key(i: u64) -> Vec<u8> {
+    format!("ns/bucket-{:02}/object-{:04}", i % 4, i).into_bytes()
+}
+
+fn value(seed: u64, len: usize) -> Vec<u8> {
+    let mut v = vec![0u8; len];
+    let mut x = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+    for b in v.iter_mut() {
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        *b = x as u8;
+    }
+    v
+}
+
+// ---------- shape (a): same-page rewrite churn, manual checkpoints ----------
+
+#[test]
+fn shape_a_rewrite_churn_few_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = nokv_like_config(dir.path(), false);
+    let tree = Tree::open(cfg).unwrap();
+
+    const OPS: u64 = 3000;
+    for i in 0..OPS {
+        let k = key(i % 8); // few keys => same-page rewrite churn
+        tree.put(&k, &value(i, 512 + (i % 7) as usize * 128))
+            .unwrap();
+        if i % 25 == 24 {
+            tree.checkpoint().unwrap();
+            assert_invariant(dir.path(), &format!("shape_a op {i}"), false);
+        }
+    }
+    tree.checkpoint().unwrap();
+    assert_invariant(dir.path(), "shape_a final", false);
+    drop(tree);
+    assert_invariant(dir.path(), "shape_a after drop", false);
+    let n = total_records(dir.path());
+    assert!(n >= 50, "vacuous run: only {n} manifest records written");
+    eprintln!("shape_a: {n} manifest records checked");
+}
+
+// ---------- shape (b): puts + deletes ----------
+
+#[test]
+fn shape_b_put_delete_churn() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = nokv_like_config(dir.path(), false);
+    let tree = Tree::open(cfg).unwrap();
+
+    const OPS: u64 = 3000;
+    for i in 0..OPS {
+        let k = if i % 10 < 6 {
+            key(i % 16)
+        } else {
+            key(100 + i % 600)
+        };
+        if i % 7 == 3 {
+            let _ = tree.delete(&k).unwrap();
+        } else {
+            tree.put(&k, &value(i, 256 + (i % 11) as usize * 200))
+                .unwrap();
+        }
+        if i % 23 == 22 {
+            tree.checkpoint().unwrap();
+            assert_invariant(dir.path(), &format!("shape_b op {i}"), false);
+        }
+        if i % 500 == 499 {
+            let _ = tree.gc().unwrap();
+            tree.checkpoint().unwrap();
+            assert_invariant(dir.path(), &format!("shape_b gc op {i}"), false);
+        }
+    }
+    tree.checkpoint().unwrap();
+    assert_invariant(dir.path(), "shape_b final", false);
+}
+
+// ---------- shape (c): reopen-heavy, cross-incarnation log append ----------
+
+#[test]
+fn shape_c_reopen_interleaved() {
+    let dir = tempfile::tempdir().unwrap();
+
+    const INCARNATIONS: u64 = 30;
+    const OPS_PER_INC: u64 = 120;
+    let mut op = 0u64;
+    for inc in 0..INCARNATIONS {
+        let cfg = nokv_like_config(dir.path(), false);
+        let tree = Tree::open(cfg).unwrap();
+        assert_invariant(dir.path(), &format!("shape_c inc {inc} after open"), false);
+
+        for j in 0..OPS_PER_INC {
+            let k = if op % 10 < 6 {
+                key(op % 6)
+            } else {
+                key(100 + op % 500)
+            };
+            if op % 13 == 5 {
+                let _ = tree.delete(&k).unwrap();
+            } else {
+                tree.put(&k, &value(op, 384 + (op % 5) as usize * 256))
+                    .unwrap();
+            }
+            op += 1;
+            // Checkpoint only for part of the incarnation, so the tail of
+            // each incarnation's work lives only in the WAL at drop time
+            // and gets replayed by the NEXT open (mid-recovery churn).
+            if j < OPS_PER_INC / 2 && j % 20 == 19 {
+                tree.checkpoint().unwrap();
+                assert_invariant(dir.path(), &format!("shape_c inc {inc} op {op}"), false);
+            }
+        }
+        // Drop WITHOUT an explicit final checkpoint: WAL carries the tail.
+        drop(tree);
+        assert_invariant(dir.path(), &format!("shape_c inc {inc} after drop"), false);
+    }
+}
+
+// ---------- shape (c2): reopen with background checkpointer racing ----------
+
+#[test]
+fn shape_c2_reopen_with_background_checkpointer() {
+    let dir = tempfile::tempdir().unwrap();
+
+    const INCARNATIONS: u64 = 20;
+    const OPS_PER_INC: u64 = 200;
+    let mut op = 0u64;
+    for inc in 0..INCARNATIONS {
+        let cfg = nokv_like_config(dir.path(), true);
+        let tree = Tree::open(cfg).unwrap();
+        for _ in 0..OPS_PER_INC {
+            let k = if op % 10 < 6 {
+                key(op % 6)
+            } else {
+                key(100 + op % 500)
+            };
+            if op % 17 == 9 {
+                let _ = tree.delete(&k).unwrap();
+            } else {
+                tree.put(&k, &value(op, 300 + (op % 9) as usize * 150))
+                    .unwrap();
+            }
+            op += 1;
+        }
+        drop(tree); // background checkpointer stops on drop
+        assert_invariant(dir.path(), &format!("shape_c2 inc {inc} after drop"), false);
+    }
+}
+
+// ---------- shape (d): concurrent writers, multiple trees, bg checkpointer ----------
+
+#[test]
+fn shape_d_concurrent_multi_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = nokv_like_config(dir.path(), true);
+    let db = DB::open(cfg).unwrap();
+
+    let trees: Vec<Tree> = (0..3)
+        .map(|t| db.open_or_create_tree(&format!("t{t}")).unwrap())
+        .collect();
+
+    std::thread::scope(|s| {
+        for (tid, tree) in trees.iter().enumerate() {
+            let tree = tree.clone();
+            s.spawn(move || {
+                for i in 0..4000u64 {
+                    let k = key(i % 8);
+                    if i % 19 == 7 {
+                        let _ = tree.delete(&k).unwrap();
+                    } else {
+                        tree.put(
+                            &k,
+                            &value(i.wrapping_mul(tid as u64 + 1), 256 + (i % 6) as usize * 128),
+                        )
+                        .unwrap();
+                    }
+                }
+            });
+        }
+        // Poll the on-disk log while writers + background checkpointer run.
+        s.spawn(|| {
+            for round in 0..40 {
+                std::thread::sleep(std::time::Duration::from_millis(150));
+                assert_invariant(dir.path(), &format!("shape_d live round {round}"), true);
+            }
+        });
+    });
+
+    db.checkpoint().unwrap();
+    assert_invariant(dir.path(), "shape_d final", false);
+    drop(trees);
+    drop(db);
+    assert_invariant(dir.path(), "shape_d after drop", false);
+}
+
+// ---------- shape (e): real SIGKILL harness (child process) ----------
+//
+// The field failure (#493) was written under SIGKILL: serving owner killed,
+// then several reopen attempts also killed mid-recovery. In-process `drop`
+// is graceful (Checkpointer::drop runs a final sync round), so this shape
+// re-executes the test binary as a writer child and SIGKILLs it at random
+// times, including very early kills that land inside open()/WAL-replay.
+
+#[test]
+fn child_writer_entry() {
+    let Ok(dir) = std::env::var("HOLT_INV_CHILD_DIR") else {
+        return; // not in child mode; nothing to do
+    };
+    let dir = PathBuf::from(dir);
+    let mut cfg = nokv_like_config(&dir, true);
+    // Aggressive checkpoint cadence so manifest appends happen inside the
+    // short kill windows (same code paths, higher frequency).
+    cfg.checkpoint.idle_interval = std::time::Duration::from_millis(15);
+    cfg.checkpoint.dirty_blob_threshold = 4;
+    let tree = Tree::open(cfg).unwrap();
+    let mut i: u64 = std::env::var("HOLT_INV_CHILD_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    loop {
+        // 70% hot 8-key churn (same-page rewrites), 30% wide 1200-key
+        // spread (multi-frame tree, multi-guid slot competition).
+        let k = if i % 10 < 7 {
+            key(i % 8)
+        } else {
+            key(100 + i % 1200)
+        };
+        if i % 13 == 5 {
+            let _ = tree.delete(&k).unwrap();
+        } else {
+            tree.put(&k, &value(i, 512 + (i % 5) as usize * 512))
+                .unwrap();
+        }
+        i = i.wrapping_add(1);
+    }
+}
+
+#[test]
+fn shape_e_sigkill_churn() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = std::env::current_exe().unwrap();
+
+    let mut rng: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut next = move || {
+        rng ^= rng << 13;
+        rng ^= rng >> 7;
+        rng ^= rng << 17;
+        rng
+    };
+
+    const INCARNATIONS: u32 = 40;
+    for inc in 0..INCARNATIONS {
+        let mut child = std::process::Command::new(&exe)
+            .arg("--exact")
+            .arg("child_writer_entry")
+            .arg("--nocapture")
+            .env("HOLT_INV_CHILD_DIR", dir.path())
+            .env("HOLT_INV_CHILD_SEED", format!("{}", next() % 1000))
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        // Every third incarnation: kill very fast, aiming at mid-recovery
+        // (open + WAL replay of the previous incarnation's tail).
+        let delay_ms = if inc % 3 == 2 {
+            5 + next() % 60
+        } else {
+            80 + next() % 700
+        };
+        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+        child.kill().unwrap(); // SIGKILL on unix
+        let _ = child.wait();
+
+        // Post-kill: a torn last append is legitimate (repair_torn_tail's
+        // job); duplicate-slot at any complete-record prefix is not.
+        assert_invariant(dir.path(), &format!("shape_e inc {inc} post-kill"), true);
+
+        // Half the time, run a graceful verification recovery ourselves —
+        // this is exactly what the field's failed reopen attempted.
+        if next() % 2 == 0 {
+            let cfg = nokv_like_config(dir.path(), false);
+            let tree = Tree::open(cfg).unwrap_or_else(|e| {
+                let logs = find_manifest_logs(dir.path());
+                let mut dumps = String::new();
+                for l in logs {
+                    dumps.push_str(&check_manifest_log(&l).dump());
+                }
+                panic!("shape_e inc {inc}: REOPEN FAILED (the #493 symptom): {e}\n{dumps}");
+            });
+            drop(tree);
+            assert_invariant(
+                dir.path(),
+                &format!("shape_e inc {inc} post-recovery"),
+                false,
+            );
+        }
+    }
+    let n = total_records(dir.path());
+    assert!(n >= 50, "vacuous run: only {n} manifest records survived");
+    eprintln!("shape_e: {n} manifest records checked after {INCARNATIONS} SIGKILLs");
+}
+
+// ---------- shape (f): WAL-heavy recovery kill storm ----------
+//
+// Child mode "burst": checkpointer DISABLED, writes a large burst so the
+// WAL carries everything, then spins. Kill it; then run many incarnations
+// of the normal child (checkpointer enabled) killed FAST, so most kills
+// land inside open()/WAL-replay/first-checkpoint — the field's
+// "SIGKILLed mid-recovery" scenario.
+
+#[test]
+fn child_burst_entry() {
+    let Ok(dir) = std::env::var("HOLT_INV_BURST_DIR") else {
+        return;
+    };
+    let dir = PathBuf::from(dir);
+    let cfg = nokv_like_config(&dir, false); // no checkpointer: WAL-only
+    let tree = Tree::open(cfg).unwrap();
+    for i in 0..2500u64 {
+        let k = if i % 10 < 3 {
+            key(i % 8)
+        } else {
+            key(100 + i % 1500)
+        };
+        if i % 13 == 5 {
+            let _ = tree.delete(&k).unwrap();
+        } else {
+            tree.put(&k, &value(i, 512 + (i % 5) as usize * 512))
+                .unwrap();
+        }
+    }
+    // Signal readiness, then spin so the parent's kill is a true SIGKILL
+    // on a live process with a fat WAL and no checkpoint.
+    std::fs::write(dir.join("burst-ready"), b"1").unwrap();
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn shape_f_recovery_kill_storm() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = std::env::current_exe().unwrap();
+
+    // Phase 1: burst writer, killed with everything in the WAL.
+    let mut child = std::process::Command::new(&exe)
+        .arg("--exact")
+        .arg("child_burst_entry")
+        .arg("--nocapture")
+        .env("HOLT_INV_BURST_DIR", dir.path())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    let ready = dir.path().join("burst-ready");
+    for _ in 0..600 {
+        if ready.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    assert!(ready.exists(), "burst child never became ready");
+    child.kill().unwrap();
+    let _ = child.wait();
+    assert_invariant(dir.path(), "shape_f post-burst-kill", true);
+
+    // Phase 2: recovery kill storm. Each incarnation must replay the WAL
+    // tail; fast kills land mid-recovery or mid-first-checkpoint.
+    let mut rng: u64 = 0xDEAD_BEEF_CAFE_F00D;
+    let mut next = move || {
+        rng ^= rng << 13;
+        rng ^= rng >> 7;
+        rng ^= rng << 17;
+        rng
+    };
+    for inc in 0..30u32 {
+        let mut child = std::process::Command::new(&exe)
+            .arg("--exact")
+            .arg("child_writer_entry")
+            .arg("--nocapture")
+            .env("HOLT_INV_CHILD_DIR", dir.path())
+            .env("HOLT_INV_CHILD_SEED", format!("{}", next() % 1000))
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        // Mix ultra-fast kills (mid WAL replay) with kills that give the
+        // 15ms-cadence checkpointer a few rounds on the replayed state.
+        let delay = if inc % 2 == 0 {
+            3 + next() % 40
+        } else {
+            40 + next() % 260
+        };
+        std::thread::sleep(std::time::Duration::from_millis(delay));
+        child.kill().unwrap();
+        let _ = child.wait();
+        assert_invariant(dir.path(), &format!("shape_f storm inc {inc}"), true);
+    }
+
+    // Final graceful recovery must succeed (an Err here = the #493 symptom).
+    let cfg = nokv_like_config(dir.path(), true);
+    let tree = Tree::open(cfg).unwrap_or_else(|e| {
+        let mut dumps = String::new();
+        for l in find_manifest_logs(dir.path()) {
+            dumps.push_str(&check_manifest_log(&l).dump());
+        }
+        panic!("shape_f: FINAL REOPEN FAILED (the #493 symptom): {e}\n{dumps}");
+    });
+    tree.checkpoint().unwrap();
+    drop(tree);
+    assert_invariant(dir.path(), "shape_f final", false);
+    let n = total_records(dir.path());
+    // A multi-frame tree flushes ~1 Set per 512KB frame; storm incarnations
+    // killed mid-WAL-replay add none. >=5 proves the tree is multi-frame.
+    assert!(n >= 5, "vacuous run: only {n} manifest records written");
+    eprintln!("shape_f: {n} manifest records checked after burst + 30 storm kills");
+}
+
+// ---------- negative control: flock must exclude a second writer ----------
+
+#[test]
+fn dual_writer_excluded_by_flock() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = std::env::current_exe().unwrap();
+    let mut child = std::process::Command::new(&exe)
+        .arg("--exact")
+        .arg("child_writer_entry")
+        .arg("--nocapture")
+        .env("HOLT_INV_CHILD_DIR", dir.path())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    // A second writable open in this process must NOT succeed while the
+    // child holds the flock (5s acquire timeout in holt).
+    let cfg = nokv_like_config(dir.path(), false);
+    let second = Tree::open(cfg);
+    assert!(
+        second.is_err(),
+        "SECOND WRITER OPENED CONCURRENTLY — flock exclusion failed; \
+         dual-writer manifest interleave is possible"
+    );
+    child.kill().unwrap();
+    let _ = child.wait();
+}
+
+// ---------- builder smoke: make sure the config path we exercise matches ----------
+
+#[test]
+fn builder_smoke_matches_nokv_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    let tree = TreeBuilder::new(dir.path())
+        .durability(Durability::Wal { sync: true })
+        .checkpoint(CheckpointConfig {
+            enabled: false,
+            auto_vacuum: false,
+            ..CheckpointConfig::default()
+        })
+        .open()
+        .unwrap();
+    tree.put(b"a/b", b"v").unwrap();
+    tree.checkpoint().unwrap();
+    assert_invariant(dir.path(), "builder smoke", false);
+}


### PR DESCRIPTION
Clean cherry-pick of #60 onto the 0.8 line (`release/0.8` = v0.8.5), so consumers pinned to `=0.8.5` can take the dual-writer defense as a drop-in `=0.8.6` without the WAL format 3→4 migration that a move to 0.9.x entails. See #60 for the full analysis and defense description.

Validation on this branch: blob-store module tests 38/38 and the new invariant suite 11/11 (including the real-SIGKILL shapes).

Intended flow after merge: tag and release v0.8.6 from `release/0.8`, then bump NoKV's exact pin.

---

**Round 2**: carries the acceptance-blocker fix from #60 (held manifest append lock replacing the check-then-act identity guard; see #60 for the analysis). 0.8-line validation after the cherry-pick: blob-store module tests 39/39, invariant suite 11/11.
